### PR TITLE
New Node and Edge UI Components

### DIFF
--- a/app/system/util/enum.js
+++ b/app/system/util/enum.js
@@ -15,4 +15,26 @@ ENUM.EDITORTYPE = {
   EDGE: 'edge'  // parameter sent with packet, listed here for coverage
 };
 
+// BUILT-IN FIELDS
+ENUM.BUILTIN_FIELDS_NODE = [
+  'id',
+  'label',
+  'provenance',
+  'degrees',
+  'created',
+  'updated',
+  'revision'
+];
+ENUM.BUILTIN_FIELDS_EDGE = [
+  'id',
+  'source',
+  'target',
+  'provenance',
+  'degrees',
+  'created',
+  'updated',
+  'revision'
+];
+
+
 module.exports = ENUM;

--- a/app/unisys/server-database.js
+++ b/app/unisys/server-database.js
@@ -759,6 +759,16 @@ DB.PKT_RequestUnlockNode = function (pkt) {
   return m_MakeLockError(`nodeID ${nodeID} was not locked so can't unlock`);
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+DB.PKT_IsNodeLocked = function (pkt) {
+  let { nodeID } = pkt.Data();
+  const uaddr = pkt.s_uaddr;
+  let errcode = m_IsInvalidNode(nodeID);
+  if (errcode) return errcode;
+  // check if node is already locked
+  const isLocked = m_locked_nodes.has(nodeID);
+  return { nodeID, locked: isLocked };
+};
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function m_IsInvalidNode(nodeID) {
   if (!nodeID) return m_MakeLockError(`undefined nodeID`);
   nodeID = Number.parseInt(nodeID, 10);

--- a/app/unisys/server-database.js
+++ b/app/unisys/server-database.js
@@ -764,7 +764,6 @@ DB.PKT_IsNodeLocked = function (pkt) {
   const uaddr = pkt.s_uaddr;
   let errcode = m_IsInvalidNode(nodeID);
   if (errcode) return errcode;
-  // check if node is already locked
   const isLocked = m_locked_nodes.has(nodeID);
   return { nodeID, locked: isLocked };
 };
@@ -813,6 +812,15 @@ DB.PKT_RequestUnlockEdge = function (pkt) {
   }
   // this is an error because nodeID wasn't in the lock table
   return m_MakeLockError(`edgeID ${edgeID} was not locked so can't unlock`);
+};
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+DB.PKT_IsEdgeLocked = function (pkt) {
+  let { edgeID } = pkt.Data();
+  const uaddr = pkt.s_uaddr;
+  let errcode = m_IsInvalidEdge(edgeID);
+  if (errcode) return errcode;
+  const isLocked = m_locked_edges.has(edgeID);
+  return { edgeID, locked: isLocked };
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function m_IsInvalidEdge(edgeID) {

--- a/app/unisys/server-database.js
+++ b/app/unisys/server-database.js
@@ -1265,7 +1265,8 @@ DB.RegenerateDefaultTemplate = () => {
 /**
  * Returns object with flags indicating whether the template is being edited,
  * data is being imported, or node or edge are being edited
- * @returns {templateBeingEdited:boolean, importActive:boolean, nodeOrEdgeBeingEdited:boolean}
+ * @returns {templateBeingEdited:boolean, importActive:boolean, nodeOrEdgeBeingEdited:boolean,
+ *           lockedNodes:array, lockedEdges:array }
  */
 DB.GetEditStatus = () => {
   // If there are any 'template' open editors, then templateBeingEdited is true
@@ -1277,7 +1278,11 @@ DB.GetEditStatus = () => {
     m_open_editors.length > 0 &&
     (m_open_editors.includes(EDITORTYPE.NODE) ||
       m_open_editors.includes(EDITORTYPE.EDGE));
-  return { templateBeingEdited, importActive, nodeOrEdgeBeingEdited };
+  return {
+    templateBeingEdited, importActive, nodeOrEdgeBeingEdited,
+    lockedNodes: [...m_locked_nodes.keys()],
+    lockedEdges: [...m_locked_edges.keys()]
+  };
 };
 /**
  * Register a template, import, node or edge as being actively edited.

--- a/app/unisys/server.js
+++ b/app/unisys/server.js
@@ -176,6 +176,11 @@ UNISYS.RegisterHandlers = () => {
     return UDB.PKT_RequestUnlockNode(pkt);
   });
 
+  UNET.HandleMessage('SRV_DBISNODELOCKED', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_IsNodeLocked(pkt);
+  });
+
   UNET.HandleMessage('SRV_DBLOCKEDGE', function (pkt) {
     if (DBG) console.log(PR, sprint_message(pkt));
     return UDB.PKT_RequestLockEdge(pkt);

--- a/app/unisys/server.js
+++ b/app/unisys/server.js
@@ -8,14 +8,14 @@ const DBG = false;
 
 ///	LOAD LIBRARIES ////////////////////////////////////////////////////////////
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const UNET      = require('./server-network');
-const UDB       = require('./server-database');
-const LOGGER    = require('./server-logger');
+const UNET = require('./server-network');
+const UDB = require('./server-database');
+const LOGGER = require('./server-logger');
 
 /// CONSTANTS /////////////////////////////////////////////////////////////////
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const PROMPTS    = require('../system/util/prompts');
-const PR         = PROMPTS.Pad('SRV');
+const PROMPTS = require('../system/util/prompts');
+const PR = PROMPTS.Pad('SRV');
 
 /// MODULE VARS ///////////////////////////////////////////////////////////////
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -28,207 +28,210 @@ var UNISYS = {};
 /*/ Initialize() is called by brunch-server.js to define the default UNISYS
     network values, so it can embed them in the index.ejs file for webapps
     override = { port }
-/*/ UNISYS.InitializeNetwork = override => {
-      UDB.InitializeDatabase(override);
-      return UNET.InitializeNetwork(override);
-    };
+/*/
+UNISYS.InitializeNetwork = override => {
+  UDB.InitializeDatabase(override);
+  return UNET.InitializeNetwork(override);
+};
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ RegisterHandlers() is called before network is started, so they're
     ready to run. These are server-implemented reserved messages.
-/*/ UNISYS.RegisterHandlers = () => {
+/*/
+UNISYS.RegisterHandlers = () => {
 
-      UNET.HandleMessage('SRV_REFLECT',function(pkt) {
-        pkt.Data().serverSays='REFLECTING';
-        pkt.Data().stack.push('SRV_01');
-        if (DBG) console.log(PR,sprint_message(pkt));
-        // return the original packet
-        return pkt;
-      });
+  UNET.HandleMessage('SRV_REFLECT', function (pkt) {
+    pkt.Data().serverSays = 'REFLECTING';
+    pkt.Data().stack.push('SRV_01');
+    if (DBG) console.log(PR, sprint_message(pkt));
+    // return the original packet
+    return pkt;
+  });
 
-      UNET.HandleMessage('SRV_REG_HANDLERS',function(pkt) {
-        if (DBG) console.log(PR,sprint_message(pkt));
-        // now need to store the handlers somehow.
-        let data = UNET.RegisterRemoteHandlers(pkt);
-        // or return a new data object that will replace pkt.data
-        return data;
-      });
+  UNET.HandleMessage('SRV_REG_HANDLERS', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    // now need to store the handlers somehow.
+    let data = UNET.RegisterRemoteHandlers(pkt);
+    // or return a new data object that will replace pkt.data
+    return data;
+  });
 
-      UNET.HandleMessage('SRV_DBGET',function(pkt) {
-        if (DBG) console.log(PR,sprint_message(pkt));
-        return UDB.PKT_GetDatabase(pkt);
-      });
+  UNET.HandleMessage('SRV_DBGET', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_GetDatabase(pkt);
+  });
 
-      UNET.HandleMessage('SRV_DBSET', function (pkt) {
-        if (DBG) console.log(PR,sprint_message(pkt));
-        return UDB.PKT_SetDatabase(pkt);
-      });
+  UNET.HandleMessage('SRV_DBSET', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_SetDatabase(pkt);
+  });
 
-      /// Add new node/edges to db after an import
-      UNET.HandleMessage('SRV_DBINSERT', function (pkt) {
-        if (DBG) console.log(PR,sprint_message(pkt));
-        return UDB.PKT_InsertDatabase(pkt);
-      });
+  /// Add new node/edges to db after an import
+  UNET.HandleMessage('SRV_DBINSERT', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_InsertDatabase(pkt);
+  });
 
-      /// Update or add new node/edges to db after an import
-      UNET.HandleMessage('SRV_DBMERGE', function (pkt) {
-        if (DBG) console.log(PR,sprint_message(pkt));
-        return UDB.PKT_MergeDatabase(pkt);
-      });
+  /// Update or add new node/edges to db after an import
+  UNET.HandleMessage('SRV_DBMERGE', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_MergeDatabase(pkt);
+  });
 
-      /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-      /// TEMPLATE / IMPORT / NODE / EDGE EDITOR LOCKING
-      /**
-       * Reports on whether template, import, or node/edge are being edited
-       * @return { templateBeingEdited: boolean, importActive: boolean, nodeOrEdgeBeingEdited: boolean }
-       */
-      UNET.HandleMessage('SRV_GET_EDIT_STATUS', pkt => { // server-database
-        if (DBG) console.log(PR, sprint_message(pkt));
-        const data = UDB.GetEditStatus(pkt);
-        return data;
-      });
-      /**
-       * Requested by Node / Edge Editor when user wants to edit node / edge
-       * @return { templateBeingEdited: boolean, importActive: boolean, nodeOrEdgeBeingEdited: boolean }
-       */
-      UNET.HandleMessage('SRV_REQ_EDIT_LOCK', pkt => { // server-database
-        if (DBG) console.log(PR, sprint_message(pkt));
-        const data = UDB.RequestEditLock(pkt);
-        // Broadcast Lock State
-        UNET.NetCall('EDIT_PERMISSIONS_UPDATE', data);
-        return data;
-      });
-      /**
-       * @return { templateBeingEdited: boolean, importActive: boolean, nodeOrEdgeBeingEdited: boolean }
-       */
-      UNET.HandleMessage('SRV_RELEASE_EDIT_LOCK', pkt => { // server-database
-        if (DBG) console.log(PR, sprint_message(pkt));
-        const data = UDB.ReleaseEditLock(pkt);
-        // Broadcast Lock State
-        UNET.NetCall('EDIT_PERMISSIONS_UPDATE', data);
-        return data;
-      });
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// TEMPLATE / IMPORT / NODE / EDGE EDITOR LOCKING
+  /**
+   * Reports on whether template, import, or node/edge are being edited
+   * @return { templateBeingEdited: boolean, importActive: boolean, nodeOrEdgeBeingEdited: boolean }
+   */
+  UNET.HandleMessage('SRV_GET_EDIT_STATUS', pkt => { // server-database
+    if (DBG) console.log(PR, sprint_message(pkt));
+    const data = UDB.GetEditStatus(pkt);
+    return data;
+  });
+  /**
+   * Requested by Node / Edge Editor when user wants to edit node / edge
+   * @return { templateBeingEdited: boolean, importActive: boolean, nodeOrEdgeBeingEdited: boolean }
+   */
+  UNET.HandleMessage('SRV_REQ_EDIT_LOCK', pkt => { // server-database
+    if (DBG) console.log(PR, sprint_message(pkt));
+    const data = UDB.RequestEditLock(pkt);
+    // Broadcast Lock State
+    UNET.NetCall('EDIT_PERMISSIONS_UPDATE', data);
+    return data;
+  });
+  /**
+   * @return { templateBeingEdited: boolean, importActive: boolean, nodeOrEdgeBeingEdited: boolean }
+   */
+  UNET.HandleMessage('SRV_RELEASE_EDIT_LOCK', pkt => { // server-database
+    if (DBG) console.log(PR, sprint_message(pkt));
+    const data = UDB.ReleaseEditLock(pkt);
+    // Broadcast Lock State
+    UNET.NetCall('EDIT_PERMISSIONS_UPDATE', data);
+    return data;
+  });
 
 
-      /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-      /// TEMPLATE EDITING
-      UNET.HandleMessage('SRV_TEMPLATE_REGENERATE_DEFAULT', pkt => { // server-database
-        if (DBG) console.log(PR, sprint_message(pkt));
-        return UDB.RegenerateDefaultTemplate();
-      });
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// TEMPLATE EDITING
+  UNET.HandleMessage('SRV_TEMPLATE_REGENERATE_DEFAULT', pkt => { // server-database
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.RegenerateDefaultTemplate();
+  });
 
-      UNET.HandleMessage('SRV_TEMPLATESAVE', pkt => { // server-database
-        if (DBG) console.log(PR, sprint_message(pkt));
-        UNET.NetCall('NET_TEMPLATE_UPDATE', pkt.data.template); // Broadcast template to other computers on the net
-        return UDB.WriteTemplateTOML(pkt);
-      });
+  UNET.HandleMessage('SRV_TEMPLATESAVE', pkt => { // server-database
+    if (DBG) console.log(PR, sprint_message(pkt));
+    UNET.NetCall('NET_TEMPLATE_UPDATE', pkt.data.template); // Broadcast template to other computers on the net
+    return UDB.WriteTemplateTOML(pkt);
+  });
 
-      UNET.HandleMessage('SRV_GET_TEMPLATETOML_FILENAME', () => {
-        return UDB.GetTemplateTOMLFileName();
-      })
+  UNET.HandleMessage('SRV_GET_TEMPLATETOML_FILENAME', () => {
+    return UDB.GetTemplateTOMLFileName();
+  })
 
-      /// Update all EXISTING nodes/edges after a Template edit
-      UNET.HandleMessage('SRV_DBUPDATE_ALL', function (pkt) {
-        if (DBG) console.log(PR, sprint_message(pkt));
-        return UDB.PKT_UpdateDatabase(pkt);
-      });
+  /// Update all EXISTING nodes/edges after a Template edit
+  UNET.HandleMessage('SRV_DBUPDATE_ALL', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_UpdateDatabase(pkt);
+  });
 
-      /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-      /// NODE/EDGE EDITING
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// NODE/EDGE EDITING
 
-      // receives a packet from a client
-      UNET.HandleMessage('SRV_DBUPDATE',function(pkt) {
-        if (DBG) console.log(PR, sprint_message(pkt));
-        let data = UDB.PKT_Update(pkt);
-        // add src attribute for client SOURCE_UPDATE to know
-        // this is a remote update
-        data.src = 'remote';
-        // fire update messages
-        if (data.node) UNET.NetSend('SOURCE_UPDATE',data);
-        if (data.edge) UNET.NetSend('EDGE_UPDATE', data);
-        if (data.nodeID!==undefined) UNET.NetSend('NODE_DELETE', data);
-        if (data.edgeID!==undefined) UNET.NetSend('EDGE_DELETE',data);
-        // return SRV_DBUPDATE value (required)
-        return { OK:true, info:'SRC_DBUPDATE' };
-      });
+  // receives a packet from a client
+  UNET.HandleMessage('SRV_DBUPDATE', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    let data = UDB.PKT_Update(pkt);
+    // add src attribute for client SOURCE_UPDATE to know
+    // this is a remote update
+    data.src = 'remote';
+    // fire update messages
+    if (data.node) UNET.NetSend('SOURCE_UPDATE', data);
+    if (data.edge) UNET.NetSend('EDGE_UPDATE', data);
+    if (data.nodeID !== undefined) UNET.NetSend('NODE_DELETE', data);
+    if (data.edgeID !== undefined) UNET.NetSend('EDGE_DELETE', data);
+    // return SRV_DBUPDATE value (required)
+    return { OK: true, info: 'SRC_DBUPDATE' };
+  });
 
-      UNET.HandleMessage('SRV_CALCULATE_MAXNODEID',function(pkt) {
-        if (DBG) console.log(PR,sprint_message(pkt));
-        return UDB.PKT_CalculateMaxNodeID(pkt);
-      });
-      UNET.HandleMessage('SRV_DBGETNODEID',function(pkt) {
-        if (DBG) console.log(PR,sprint_message(pkt));
-        return UDB.PKT_GetNewNodeID(pkt);
-      });
-      UNET.HandleMessage('SRV_DBGETNODEIDS',function(pkt) {
-        if (DBG) console.log(PR,sprint_message(pkt));
-        return UDB.PKT_GetNewNodeIDs(pkt);
-      });
+  UNET.HandleMessage('SRV_CALCULATE_MAXNODEID', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_CalculateMaxNodeID(pkt);
+  });
+  UNET.HandleMessage('SRV_DBGETNODEID', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_GetNewNodeID(pkt);
+  });
+  UNET.HandleMessage('SRV_DBGETNODEIDS', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_GetNewNodeIDs(pkt);
+  });
 
-      UNET.HandleMessage('SRV_DBLOCKNODE', function (pkt) {
-        if (DBG) console.log(PR, sprint_message(pkt));
-        return UDB.PKT_RequestLockNode(pkt);
-      });
+  UNET.HandleMessage('SRV_DBLOCKNODE', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_RequestLockNode(pkt);
+  });
 
-      UNET.HandleMessage('SRV_DBUNLOCKNODE',function(pkt) {
-        if (DBG) console.log(PR,sprint_message(pkt));
-        return UDB.PKT_RequestUnlockNode(pkt);
-      });
+  UNET.HandleMessage('SRV_DBUNLOCKNODE', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_RequestUnlockNode(pkt);
+  });
 
-      UNET.HandleMessage('SRV_DBLOCKEDGE', function (pkt) {
-        if (DBG) console.log(PR, sprint_message(pkt));
-        return UDB.PKT_RequestLockEdge(pkt);
-      });
+  UNET.HandleMessage('SRV_DBLOCKEDGE', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_RequestLockEdge(pkt);
+  });
 
-      UNET.HandleMessage('SRV_DBUNLOCKEDGE', function (pkt) {
-        if (DBG) console.log(PR, sprint_message(pkt));
-        return UDB.PKT_RequestUnlockEdge(pkt);
-      });
+  UNET.HandleMessage('SRV_DBUNLOCKEDGE', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_RequestUnlockEdge(pkt);
+  });
 
-      UNET.HandleMessage('SRV_DBUNLOCKALLNODES', function (pkt) {
-        if (DBG) console.log(PR, sprint_message(pkt));
-        return UDB.PKT_RequestUnlockAllNodes(pkt);
-      });
-      UNET.HandleMessage('SRV_DBUNLOCKALLEDGES', function (pkt) {
-        if (DBG) console.log(PR, sprint_message(pkt));
-        return UDB.PKT_RequestUnlockAllEdges(pkt);
-      });
-      UNET.HandleMessage('SRV_DBUNLOCKALL', function (pkt) {
-        if (DBG) console.log(PR, sprint_message(pkt));
-        const res = UDB.PKT_RequestUnlockAll(pkt);
-        // Broadcast Lock State
-        const data = UDB.GetEditStatus();
-        UNET.NetCall('EDIT_PERMISSIONS_UPDATE', data);
-        return res;
-      });
+  UNET.HandleMessage('SRV_DBUNLOCKALLNODES', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_RequestUnlockAllNodes(pkt);
+  });
+  UNET.HandleMessage('SRV_DBUNLOCKALLEDGES', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_RequestUnlockAllEdges(pkt);
+  });
+  UNET.HandleMessage('SRV_DBUNLOCKALL', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    const res = UDB.PKT_RequestUnlockAll(pkt);
+    // Broadcast Lock State
+    const data = UDB.GetEditStatus();
+    UNET.NetCall('EDIT_PERMISSIONS_UPDATE', data);
+    return res;
+  });
 
-      UNET.HandleMessage('SRV_CALCULATE_MAXEDGEID',function(pkt) {
-        if (DBG) console.log(PR,sprint_message(pkt));
-        return UDB.PKT_CalculateMaxEdgeID(pkt);
-      });
-      UNET.HandleMessage('SRV_DBGETEDGEID', function (pkt) {
-        if (DBG) console.log(PR,sprint_message(pkt));
-        return UDB.PKT_GetNewEdgeID(pkt);
-      });
-      UNET.HandleMessage('SRV_DBGETEDGEIDS', function (pkt) {
-        if (DBG) console.log(PR,sprint_message(pkt));
-        return UDB.PKT_GetNewEdgeIDs(pkt);
-      });
+  UNET.HandleMessage('SRV_CALCULATE_MAXEDGEID', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_CalculateMaxEdgeID(pkt);
+  });
+  UNET.HandleMessage('SRV_DBGETEDGEID', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_GetNewEdgeID(pkt);
+  });
+  UNET.HandleMessage('SRV_DBGETEDGEIDS', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_GetNewEdgeIDs(pkt);
+  });
 
-      UNET.HandleMessage('SRV_LOG_EVENT',function(pkt) {
-        if (DBG) console.log(PR,sprint_message(pkt));
-        return LOGGER.PKT_LogEvent(pkt);
-      });
+  UNET.HandleMessage('SRV_LOG_EVENT', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return LOGGER.PKT_LogEvent(pkt);
+  });
 
-      // utility function //
-      function sprint_message(pkt) {
-        return `got '${pkt.Message()}' data=${JSON.stringify(pkt.Data())}`;
-      }
-    };
+  // utility function //
+  function sprint_message(pkt) {
+    return `got '${pkt.Message()}' data=${JSON.stringify(pkt.Data())}`;
+  }
+};
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/	StartNetwork() is called by brunch-server after the Express webserver
-/*/	UNISYS.StartNetwork = () => {
-      UNET.StartNetwork();
-    };
+/*/
+UNISYS.StartNetwork = () => {
+  UNET.StartNetwork();
+};
 
 
 /// EXPORT MODULE DEFINITION //////////////////////////////////////////////////

--- a/app/unisys/server.js
+++ b/app/unisys/server.js
@@ -191,6 +191,11 @@ UNISYS.RegisterHandlers = () => {
     return UDB.PKT_RequestUnlockEdge(pkt);
   });
 
+  UNET.HandleMessage('SRV_DBISEDGELOCKED', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_IsEdgeLocked(pkt);
+  });
+
   UNET.HandleMessage('SRV_DBUNLOCKALLNODES', function (pkt) {
     if (DBG) console.log(PR, sprint_message(pkt));
     return UDB.PKT_RequestUnlockAllNodes(pkt);

--- a/app/view/netcreate/NetCreate.jsx
+++ b/app/view/netcreate/NetCreate.jsx
@@ -47,6 +47,7 @@ const { Route } = require('react-router-dom');
 const ReactStrap = require('reactstrap');
 const { Button } = ReactStrap;
 const NetGraph = require('./components/NetGraph');
+const NCSearch = require('./components/NCSearch');
 const NCNode = require('./components/NCNode');
 const NCGraph = require('./components/NCGraph');
 const Search = require('./components/Search');
@@ -204,8 +205,9 @@ class NetCreate extends UNISYS.Component {
             }}
           >
             <div style={{ display: 'flex', flexFlow: 'column nowrap' }}>
-              <Search />
+              <NCSearch />
               <NCNode />
+              {/* <Search /> */}
               {/* <NodeSelector /> */}
             </div>
           </div>

--- a/app/view/netcreate/NetCreate.jsx
+++ b/app/view/netcreate/NetCreate.jsx
@@ -47,6 +47,7 @@ const { Route } = require('react-router-dom');
 const ReactStrap = require('reactstrap');
 const { Button } = ReactStrap;
 const NetGraph = require('./components/NetGraph');
+const NCNode = require('./components/NCNode');
 const NCGraph = require('./components/NCGraph');
 const Search = require('./components/Search');
 const NodeSelector = require('./components/NodeSelector');
@@ -202,6 +203,7 @@ class NetCreate extends UNISYS.Component {
           >
             <div style={{ display: 'flex', flexFlow: 'column nowrap' }}>
               <Search />
+              <NCNode />
               <NodeSelector />
             </div>
           </div>

--- a/app/view/netcreate/NetCreate.jsx
+++ b/app/view/netcreate/NetCreate.jsx
@@ -206,7 +206,7 @@ class NetCreate extends UNISYS.Component {
             <div style={{ display: 'flex', flexFlow: 'column nowrap' }}>
               <Search />
               <NCNode />
-              <NodeSelector />
+              {/* <NodeSelector /> */}
             </div>
           </div>
           <div

--- a/app/view/netcreate/NetCreate.jsx
+++ b/app/view/netcreate/NetCreate.jsx
@@ -148,7 +148,8 @@ class NetCreate extends UNISYS.Component {
   /*/ Define the component structure of the web application
   /*/
   render() {
-    const { isLoggedIn, disconnectMsg, layoutNodesOpen, layoutFiltersOpen } = this.state;
+    const { isLoggedIn, disconnectMsg, layoutNodesOpen, layoutFiltersOpen } =
+      this.state;
 
     // show or hide graph
     // Use 'visibiliity' css NOT React's 'hidden' so size is properly
@@ -173,7 +174,8 @@ class NetCreate extends UNISYS.Component {
           }}
         >
           <div style={{ color: '#fff', width: '100%', textAlign: 'center' }}>
-            <b>{disconnectMsg}!</b> Your changes will not be saved! Please report &quot;
+            <b>{disconnectMsg}!</b> Your changes will not be saved! Please report
+            &quot;
             {disconnectMsg}&quot; to your administrator to restart the graph.
           </div>
         </div>
@@ -228,9 +230,9 @@ class NetCreate extends UNISYS.Component {
               }}
             >
               Please contact Professor Kalani Craig, Institute for Digital Arts &
-              Humanities at (812) 856-5721 (BH) or craigkl@indiana.edu with questions or
-              concerns and/or to request information contained on this website in an
-              accessible format.
+              Humanities at (812) 856-5721 (BH) or craigkl@indiana.edu with questions
+              or concerns and/or to request information contained on this website in
+              an accessible format.
             </div>
           </div>
           {layoutFiltersOpen ? (

--- a/app/view/netcreate/components/EdgeEditor.jsx
+++ b/app/view/netcreate/components/EdgeEditor.jsx
@@ -544,15 +544,14 @@ class EdgeEditor extends UNISYS.Component {
   /// UDATA STATE HANDLERS //////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /*/ When the user is creating a new node, they need to set a target node.
-    The target node is set via an AutoComplete field.
-    When a node is selected via the AutoComplete field, the SELECTION state is updated.
-    So EdgeEditor needs to listen to the SELECTION state in order to
-    know the target node has been selected.
-    SELECTION is also triggered when the network updates an edge.
+      The target node is set via an AutoComplete field.
+      When a node is selected via the AutoComplete field, the SELECTION state is updated.
+      So EdgeEditor needs to listen to the SELECTION state in order to
+      know the target node has been selected.
+      SELECTION is also triggered when the network updates an edge.
   /*/
   handleSelection(data) {
     if (DBG) console.log('EdgeEditor', this.props.edgeID, 'got SELECTION data', data);
-
     // If we're one of the edges that have been updated, and we're not currently being edited,
     // then update the data.
     // If we're not currently being edited, then if edges have been updated, update self

--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -404,7 +404,8 @@ class EdgeTable extends UNISYS.Component {
   /*/
   lookupNodeLabel(nodeId) {
     const node = this.state.nodes.find(n => n.id === nodeId);
-    if (node === undefined) throw new Error('EdgeTable: Could not find node', nodeId);
+    if (node === undefined) return '...';
+    // if (node === undefined) throw new Error('EdgeTable: Could not find node', nodeId);
     return node.label;
   }
 
@@ -683,14 +684,16 @@ class EdgeTable extends UNISYS.Component {
                     {isLocked ? 'View' : 'Edit'}
                   </Button>
                 </td>
-                <td hidden={!DBG}>{edge.source}</td>
+                {/* Cast to string for edge.target where target is undefined */}
+                <td hidden={!DBG}>{String(edge.source)}</td>
                 <td>
                   <a href="#" onClick={e => this.selectNode(edge.source, e)}>
                     {edge.sourceLabel}
                   </a>
                 </td>
                 <td hidden={edgeDefs.type.hidden}>{edge.type}</td>
-                <td hidden={!DBG}>{edge.target}</td>
+                {/* Cast to string for edge.target where target is undefined */}
+                <td hidden={!DBG}>{String(edge.target)}</td>
                 <td>
                   <a href="#" onClick={e => this.selectNode(edge.target, e)}>
                     {edge.targetLabel}

--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -420,9 +420,9 @@ class EdgeTable extends UNISYS.Component {
 
     if (DBG) console.log('EdgeTable: Edge id', edge.id, 'selected for editing');
 
-    // Load Source then Edge
+    // Load Source Node then Edge
     UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [edge.source] }).then(() => {
-      UDATA.LocalCall('EDGE_EDIT', { edgeID: edge.id });
+      UDATA.LocalCall('EDGE_SELECT_AND_EDIT', { edgeId: edge.id });
     });
   }
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -39,6 +39,7 @@ const isLocalHost =
 import FILTER from './filter/FilterEnums';
 const React = require('react');
 const ReactStrap = require('reactstrap');
+const { BUILTIN_FIELDS_EDGE } = require('system/util/enum');
 const { Button } = ReactStrap;
 const MarkdownNote = require('./MarkdownNote');
 
@@ -370,25 +371,10 @@ class EdgeTable extends UNISYS.Component {
         return this.sortBySourceLabel(edges);
       case 'target':
         return this.sortByTargetLabel(edges);
-      case 'Info':
-        return this.sortByKey(edges, 'info', type);
-      case 'Weight':
-        return this.sortByKey(edges, 'weight', type);
-      case 'provenance':
-        return this.sortByKey(edges, 'provenance', type);
-      case 'comments':
-        return this.sortByKey(edges, 'comments', type);
-      case 'Notes':
-        return this.sortByKey(edges, 'notes', type);
-      case 'Category':
-        return this.sortByKey(edges, 'category', type);
-      case 'Citations':
-        return this.sortByKey(edges, 'citation', type);
-      case 'Updated':
-        return this.sortByUpdated(edges);
-      case 'Relationship':
+      // case 'Updated':
+      //   return this.sortByUpdated(edges);
       default:
-        return this.sortByKey(edges, 'type', type);
+        return this.sortByKey(edges, sortkey, type);
     }
   }
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -508,14 +494,12 @@ class EdgeTable extends UNISYS.Component {
   /*/
   render() {
     let { edgeDefs, isLocked } = this.state;
-
     if (edgeDefs.category === undefined) {
       // for backwards compatability
       edgeDefs.category = {};
       edgeDefs.category.label = '';
       edgeDefs.category.hidden = true;
     }
-
     const { tableHeight } = this.props;
     const styles = `thead, tbody { font-size: 0.8em }
                       .table {
@@ -532,6 +516,9 @@ class EdgeTable extends UNISYS.Component {
                       xtbody { overflow: auto; }
                       .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }
                       `;
+    const attributes = Object.keys(edgeDefs).filter(
+      k => !BUILTIN_FIELDS_EDGE.includes(k)
+    );
     return (
       <div
         style={{
@@ -578,14 +565,14 @@ class EdgeTable extends UNISYS.Component {
                   {edgeDefs.source.displayLabel} {this.sortSymbol('source')}
                 </Button>
               </th>
-              <th hidden={edgeDefs.type.hidden} width="10%">
+              {/* <th hidden={edgeDefs.type.hidden} width="10%">
                 <Button
                   size="sm"
                   onClick={() => this.setSortKey('Relationship', edgeDefs.type.type)}
                 >
                   {edgeDefs.type.displayLabel} {this.sortSymbol('Relationship')}
                 </Button>
-              </th>
+              </th> */}
               <th hidden={!DBG}>Target ID</th>
               <th width="10%">
                 <Button
@@ -595,56 +582,17 @@ class EdgeTable extends UNISYS.Component {
                   {edgeDefs.target.displayLabel} {this.sortSymbol('target')}
                 </Button>
               </th>
-              <th width="8%" hidden={edgeDefs.category.hidden}>
-                <Button
-                  size="sm"
-                  onClick={() => this.setSortKey('Category', edgeDefs.category.type)}
-                >
-                  {edgeDefs.category.displayLabel} {this.sortSymbol('Category')}
-                </Button>
-              </th>
-              <th width="10%" hidden={edgeDefs.citation.hidden}>
-                <Button
-                  size="sm"
-                  onClick={() => this.setSortKey('Citations', edgeDefs.citation.type)}
-                >
-                  {edgeDefs.citation.displayLabel} {this.sortSymbol('Citations')}
-                </Button>
-              </th>
-              <th width="20%" hidden={edgeDefs.notes.hidden}>
-                <Button
-                  size="sm"
-                  onClick={() => this.setSortKey('Notes', edgeDefs.notes.type)}
-                >
-                  {edgeDefs.notes.displayLabel} {this.sortSymbol('Notes')}
-                </Button>
-              </th>
-              <th width="10%" hidden={edgeDefs.info.hidden}>
-                <Button
-                  size="sm"
-                  onClick={() => this.setSortKey('Info', edgeDefs.info.type)}
-                >
-                  {edgeDefs.info.displayLabel} {this.sortSymbol('Info')}
-                </Button>
-              </th>
-              <th width="4%" hidden={edgeDefs.weight.hidden}>
-                <Button
-                  size="sm"
-                  onClick={() => this.setSortKey('Weight', edgeDefs.weight.type)}
-                >
-                  {edgeDefs.weight.displayLabel} {this.sortSymbol('Weight')}
-                </Button>
-              </th>
-              <th width="7%" hidden={edgeDefs.provenance.hidden}>
-                <Button
-                  size="sm"
-                  onClick={() =>
-                    this.setSortKey('provenance', edgeDefs.provenance.type)
-                  }
-                >
-                  {edgeDefs.provenance.displayLabel} {this.sortSymbol('provenance')}
-                </Button>
-              </th>
+              {attributes.map(a => (
+                <th hidden={edgeDefs[a].hidden} key={a}>
+                  <Button
+                    size="sm"
+                    onClick={() => this.setSortKey(a, edgeDefs[a].type)}
+                  >
+                    {edgeDefs[a].displayLabel} {this.sortSymbol(a)}
+                  </Button>
+                </th>
+              ))}
+              {/*
               <th width="7%" hidden={!isLocalHost}>
                 <Button
                   size="sm"
@@ -661,6 +609,7 @@ class EdgeTable extends UNISYS.Component {
                   {edgeDefs.comments.displayLabel} {this.sortSymbol('comments')}
                 </Button>
               </th>
+              */}
             </tr>
           </thead>
           <tbody style={{ maxHeight: tableHeight, fontSize: '12px' }}>
@@ -691,7 +640,7 @@ class EdgeTable extends UNISYS.Component {
                     {edge.sourceLabel}
                   </a>
                 </td>
-                <td hidden={edgeDefs.type.hidden}>{edge.type}</td>
+                {/* <td hidden={edgeDefs.type.hidden}>{edge.type}</td> */}
                 {/* Cast to string for edge.target where target is undefined */}
                 <td hidden={!DBG}>{String(edge.target)}</td>
                 <td>
@@ -699,16 +648,12 @@ class EdgeTable extends UNISYS.Component {
                     {edge.targetLabel}
                   </a>
                 </td>
-                <td hidden={edgeDefs.category.hidden}>{edge.category}</td>
-                <td hidden={edgeDefs.citation.hidden}>{edge.citation}</td>
-                <td hidden={edgeDefs.notes.hidden}>
-                  {edge.notes ? <MarkdownNote text={edge.notes} /> : ''}
-                </td>
-                <td hidden={edgeDefs.info.hidden}>{edge.info}</td>
-                <td hidden={edgeDefs.weight.hidden}>{edge.weight}</td>
-                <td hidden={edgeDefs.provenance.hidden} style={{ fontSize: '9px' }}>
-                  {edge.provenance}
-                </td>
+                {attributes.map(a => (
+                  <td hidden={edgeDefs[a].hidden} key={`${edge.id}${a}`}>
+                    {edge[a]}
+                  </td>
+                ))}
+                {/*
                 <td hidden={!isLocalHost} style={{ fontSize: '9px' }}>
                   {this.displayUpdated(edge)}
                 </td>
@@ -718,6 +663,7 @@ class EdgeTable extends UNISYS.Component {
                 >
                   {edge.comments}
                 </td>
+                */}
               </tr>
             ))}
           </tbody>

--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -31,7 +31,8 @@ var DBG = false;
 
 const SETTINGS = require('settings');
 const isLocalHost =
-  SETTINGS.EJSProp('client').ip === '127.0.0.1' || location.href.includes('admin=true');
+  SETTINGS.EJSProp('client').ip === '127.0.0.1' ||
+  location.href.includes('admin=true');
 
 /// LIBRARIES /////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -143,7 +144,8 @@ class EdgeTable extends UNISYS.Component {
     var time = d.toTimeString().substr(0, 5);
     var dateTime = date + ' at ' + time;
     var titleString = 'v' + nodeEdge.meta.revision;
-    if (nodeEdge._nlog) titleString += ' by ' + nodeEdge._nlog[nodeEdge._nlog.length - 1];
+    if (nodeEdge._nlog)
+      titleString += ' by ' + nodeEdge._nlog[nodeEdge._nlog.length - 1];
     var tag = <span title={titleString}> {dateTime} </span>;
 
     return tag;
@@ -555,7 +557,10 @@ class EdgeTable extends UNISYS.Component {
           <thead>
             <tr>
               <th width="4%" hidden={!DBG}>
-                <Button size="sm" onClick={() => this.setSortKey('id', edgeDefs.id.type)}>
+                <Button
+                  size="sm"
+                  onClick={() => this.setSortKey('id', edgeDefs.id.type)}
+                >
                   ID {this.sortSymbol('id')}
                 </Button>
               </th>
@@ -632,7 +637,9 @@ class EdgeTable extends UNISYS.Component {
               <th width="7%" hidden={edgeDefs.provenance.hidden}>
                 <Button
                   size="sm"
-                  onClick={() => this.setSortKey('provenance', edgeDefs.provenance.type)}
+                  onClick={() =>
+                    this.setSortKey('provenance', edgeDefs.provenance.type)
+                  }
                 >
                   {edgeDefs.provenance.displayLabel} {this.sortSymbol('provenance')}
                 </Button>
@@ -667,7 +674,12 @@ class EdgeTable extends UNISYS.Component {
                 <td hidden={!DBG}>{edge.id}</td>
                 <td hidden={!DBG}>{edge.size}</td>
                 <td>
-                  <Button size="sm" outline value={edge.id} onClick={this.onButtonClick}>
+                  <Button
+                    size="sm"
+                    outline
+                    value={edge.id}
+                    onClick={this.onButtonClick}
+                  >
                     {isLocked ? 'View' : 'Edit'}
                   </Button>
                 </td>

--- a/app/view/netcreate/components/NCAutoSuggest.css
+++ b/app/view/netcreate/components/NCAutoSuggest.css
@@ -1,0 +1,29 @@
+.matchlist {
+  position: fixed;
+  color: #3339;
+  background-color: #fff;
+  margin: 1px 0 0 0;
+  padding: 3px 0;
+  font-size: 12px;
+  z-index: 15;
+}
+.matchlist div {
+  padding: 0 10px;
+}
+.matchlist div:hover {
+  background-color: #ddd;
+  cursor: pointer;
+}
+.matchlist div.highlighted {
+  background-color: #ccc;
+  cursor: pointer;
+}
+
+.helptop {
+  position: absolute;
+  bottom: 120%;
+  padding: 0 5px;
+  color: #666;
+  background-color: #ff0c;
+  font-size: 12px;
+}

--- a/app/view/netcreate/components/NCAutoSuggest.jsx
+++ b/app/view/netcreate/components/NCAutoSuggest.jsx
@@ -113,7 +113,6 @@ class NCAutoSuggest extends UNISYS.Component {
     let newHighlightedLine = higlightedLine;
     if (keystroke === 'Enter') {
       let selectedValue = value;
-      console.log('UIKeydown', higlightedLine, ' matches', matches);
       if (higlightedLine > -1) {
         // there is highlight, so select that
         selectedValue = matches[higlightedLine].label;
@@ -137,7 +136,6 @@ class NCAutoSuggest extends UNISYS.Component {
       const highlightedNode = matches[newHighlightedLine];
       UDATA.LocalCall('AUTOSUGGEST_HILITE_NODE', { nodeId: highlightedNode.id });
     }
-    console.log('newHighlitedLine', matches, newHighlightedLine);
   }
 
   render() {

--- a/app/view/netcreate/components/NCAutoSuggest.jsx
+++ b/app/view/netcreate/components/NCAutoSuggest.jsx
@@ -96,9 +96,8 @@ class NCAutoSuggest extends UNISYS.Component {
    * --  Hitting Esc will cancel the autosuggest, also hitting Tab will prevent selecting the next field
    * --  Hitting Enter will select the item
    * @param {Object} event
-   * @param {funciton} cb call back
    */
-  m_UIKeyDown(event, cb) {
+  m_UIKeyDown(event) {
     const { matches, higlightedLine } = this.state;
     const { statekey, value, onSelect } = this.props;
     const keystroke = event.key;

--- a/app/view/netcreate/components/NCAutoSuggest.jsx
+++ b/app/view/netcreate/components/NCAutoSuggest.jsx
@@ -1,0 +1,173 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+    Custom Auto Suggest for NetCreate
+
+    USE:
+
+      <NCAutoSuggest
+        statekey={key}
+        value={value}
+        onChange={this.handleInputUpdate}
+        onSelect={this.handleSelection}
+      />
+
+    This will look up matching nodes via FIND_MATCHING_NODES nc-logic request.
+
+    This is a simple HTML component that will allow users to enter arbitrary
+    text input.  Any partial node labels will display as a list of popup
+    menu options.
+
+    It can be used in a NCNode or NCEdge
+
+    Replaces the AutoComplete and AutoSuggest components.
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+const DBG = false;
+const PR = 'NCAutoSuggest';
+
+/// LIBRARIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const React = require('react');
+const UNISYS = require('unisys/client');
+
+let UDATA;
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// export a class object for consumption by brunch/require
+class NCAutoSuggest extends UNISYS.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      matches: [], // {id, label}
+      higlightedLine: -1,
+      isValidNode: true
+    };
+
+    this.m_UIUpdate = this.m_UIUpdate.bind(this);
+    this.m_UISelect = this.m_UISelect.bind(this);
+    this.m_UIKeyDown = this.m_UIKeyDown.bind(this);
+
+    /// Initialize UNISYS DATA LINK for REACT
+    UDATA = UNISYS.NewDataLink(this);
+  }
+
+  /**
+   * This processes the form data before passing it on to the parent handler.
+   * The callback function is generally an input state update method in
+   * NCNode or NCEdge
+   * @param {Object} event
+   */
+  m_UIUpdate(event) {
+    const { onChange } = this.props;
+    const key = event.target.id;
+    const value = event.target.value;
+    let isValidNode = false;
+    UDATA.LocalCall('FIND_MATCHING_NODES', { searchString: value }).then(data => {
+      const matches =
+        data.nodes && data.nodes.length > 0
+          ? data.nodes.map(d => {
+              if (d.label === value) isValidNode = true;
+              return { id: d.id, label: d.label };
+            })
+          : undefined;
+      this.setState({ matches, isValidNode });
+      if (typeof onChange === 'function') onChange(key, value);
+    });
+  }
+  /**
+   * User has clicked an item in the matchlist, selecting one of the autosuggest items
+   * @param {string} key Usually either `source` or `target`
+   * @param {string} value
+   */
+  m_UISelect(key, value) {
+    const { onSelect } = this.props;
+    const { matches } = this.state;
+    const matchedNode = matches ? matches.find(n => n.label === value) : undefined;
+    this.setState({ isValidNode: matchedNode, matches: [] }); // clear matches
+    if (typeof onSelect === 'function')
+      onSelect(key, value, matchedNode ? matchedNode.id : undefined); // callback function NCEdge.uiSourceTargetInputUpdate
+  }
+  /**
+   * Handle key strokes
+   * --  Hitting up/down arrow will select the higlight
+   * --  Hitting Esc will cancel the autosuggest, also hitting Tab will prevent selecting the next field
+   * --  Hitting Enter will select the item
+   * @param {Object} event
+   * @param {funciton} cb call back
+   */
+  m_UIKeyDown(event, cb) {
+    const { matches, higlightedLine } = this.state;
+    const { statekey, value, onSelect } = this.props;
+    const keystroke = event.key;
+    const lastLine = matches ? matches.length : -1;
+    let newHighlightedLine = higlightedLine;
+    if (keystroke === 'Enter') {
+      let selectedValue = value;
+      if (higlightedLine > -1) {
+        // there is highlight, so select that
+        selectedValue = matches[higlightedLine].label;
+      }
+      this.m_UISelect(statekey, selectedValue, onSelect); // user selects current highlight
+    }
+    if (keystroke === 'Escape' || keystroke === 'Tab') {
+      event.preventDefault(); // prevent tab key from going to the next field
+      event.stopPropagation();
+      this.setState({ higlightedLine: -1 }); // close autosuggest
+    }
+    if (keystroke === 'ArrowUp') newHighlightedLine--;
+    if (keystroke === 'ArrowDown') newHighlightedLine++;
+    if (
+      higlightedLine !== newHighlightedLine &&
+      newHighlightedLine > -1 &&
+      lastLine > 0
+    ) {
+      newHighlightedLine = Math.min(lastLine - 1, Math.max(0, newHighlightedLine));
+      this.setState({ higlightedLine: newHighlightedLine });
+      const highlightedNode = matches[newHighlightedLine];
+      UDATA.LocalCall('AUTOSUGGEST_HILITE_NODE', { nodeId: highlightedNode.id });
+    }
+  }
+
+  render() {
+    const { matches, higlightedLine, isValidNode } = this.state;
+    const { statekey, value, onSelect } = this.props;
+    const matchList =
+      matches && matches.length > 0
+        ? matches.map((n, i) => (
+            <div
+              key={n.label}
+              value={n.label}
+              className={higlightedLine === i ? 'highlighted' : ''}
+              onClick={() => this.m_UISelect(statekey, n.label)}
+            >
+              {n.label}
+            </div>
+          ))
+        : undefined;
+    return (
+      <div>
+        <div className="helptop">Click on a node, or type a node name</div>
+        <input
+          id={statekey}
+          key={`${statekey}input`}
+          value={value}
+          type="string"
+          className={!isValidNode ? 'invalid' : ''}
+          onChange={this.m_UIUpdate}
+          onKeyDown={this.m_UIKeyDown}
+          onFocus={e => e.target.select()}
+          autoComplete="off" // turn off Chrome's default autocomplete, which conflicts
+        />
+        <br />
+        {matchList && <div className="matchlist">{matchList}</div>}
+      </div>
+    );
+  }
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = NCAutoSuggest;

--- a/app/view/netcreate/components/NCAutoSuggest.jsx
+++ b/app/view/netcreate/components/NCAutoSuggest.jsx
@@ -11,6 +11,12 @@
         onSelect={this.handleSelection}
       />
 
+    PROPS
+
+      onChange(key, value) -- returns `key` and `value` for the input field
+      onSelect(key, valuem, id) -- returns `key` and `value` for the final submission
+                                   as well as the matching id
+
     This will look up matching nodes via FIND_MATCHING_NODES nc-logic request.
 
     This is a simple HTML component that will allow users to enter arbitrary
@@ -18,6 +24,8 @@
     menu options.
 
     It can be used in a NCNode or NCEdge
+
+    `statekey` provides a unique key for source/target selection
 
     Replaces the AutoComplete and AutoSuggest components.
 
@@ -86,7 +94,7 @@ class NCAutoSuggest extends UNISYS.Component {
     const { onSelect } = this.props;
     const { matches } = this.state;
     const matchedNode = matches ? matches.find(n => n.label === value) : undefined;
-    this.setState({ isValidNode: matchedNode, matches: [] }); // clear matches
+    this.setState({ isValidNode: matchedNode, matches: [], higlightedLine: -1 }); // clear matches
     if (typeof onSelect === 'function')
       onSelect(key, value, matchedNode ? matchedNode.id : undefined); // callback function NCEdge.uiSourceTargetInputUpdate
   }
@@ -105,11 +113,12 @@ class NCAutoSuggest extends UNISYS.Component {
     let newHighlightedLine = higlightedLine;
     if (keystroke === 'Enter') {
       let selectedValue = value;
+      console.log('UIKeydown', higlightedLine, ' matches', matches);
       if (higlightedLine > -1) {
         // there is highlight, so select that
         selectedValue = matches[higlightedLine].label;
       }
-      this.m_UISelect(statekey, selectedValue, onSelect); // user selects current highlight
+      this.m_UISelect(statekey, selectedValue); // user selects current highlight
     }
     if (keystroke === 'Escape' || keystroke === 'Tab') {
       event.preventDefault(); // prevent tab key from going to the next field
@@ -128,6 +137,7 @@ class NCAutoSuggest extends UNISYS.Component {
       const highlightedNode = matches[newHighlightedLine];
       UDATA.LocalCall('AUTOSUGGEST_HILITE_NODE', { nodeId: highlightedNode.id });
     }
+    console.log('newHighlitedLine', matches, newHighlightedLine);
   }
 
   render() {
@@ -137,7 +147,7 @@ class NCAutoSuggest extends UNISYS.Component {
       matches && matches.length > 0
         ? matches.map((n, i) => (
             <div
-              key={n.label}
+              key={`${n.label}${i}`}
               value={n.label}
               className={higlightedLine === i ? 'highlighted' : ''}
               onClick={() => this.m_UISelect(statekey, n.label)}

--- a/app/view/netcreate/components/NCAutoSuggest.jsx
+++ b/app/view/netcreate/components/NCAutoSuggest.jsx
@@ -148,7 +148,7 @@ class NCAutoSuggest extends UNISYS.Component {
           ))
         : undefined;
     return (
-      <div>
+      <div style={{ position: 'relative' }}>
         <div className="helptop">Click on a node, or type a node name</div>
         <input
           id={statekey}

--- a/app/view/netcreate/components/NCDialog.css
+++ b/app/view/netcreate/components/NCDialog.css
@@ -1,0 +1,37 @@
+.dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  z-index: 100;
+}
+
+.dialog .screen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #0006;
+  z-index: 101;
+}
+
+.dialog .dialogwindow {
+  position: relative;
+  background-color: white;
+  padding: 25px;
+  z-index: 110;
+}
+
+.dialog .dialogmessage {
+  margin-bottom: 25px;
+}
+.dialog .dialogcontrolbar {
+  display: flex;
+  justify-content: right;
+}

--- a/app/view/netcreate/components/NCDialog.jsx
+++ b/app/view/netcreate/components/NCDialog.jsx
@@ -1,0 +1,64 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+    Generic Dialog
+
+    USE:
+
+      <NCDialog
+        statekey={key}
+        value={value}
+        onChange={this.handleInputUpdate}
+        onSelect={this.handleSelection}
+      />
+
+    This will look up matching nodes via FIND_MATCHING_NODES nc-logic request.
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+const DBG = false;
+const PR = 'NCDialog';
+
+/// LIBRARIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const React = require('react');
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+class NCDialog extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const {
+      message = 'Are you sure?',
+      okmessage = 'OK',
+      cancelmessage = 'Cancel',
+      onOK,
+      onCancel
+    } = this.props;
+    const OKBtn = <button onClick={onOK}>{okmessage}</button>;
+    const CancelBtn = onCancel ? (
+      <button onClick={onCancel}>{cancelmessage}</button>
+    ) : (
+      ''
+    );
+    return (
+      <div className="dialog">
+        <div className="screen"></div>
+        <div className="dialogwindow">
+          <div className="dialogmessage">{message}</div>
+          <div className="dialogcontrolbar">
+            {CancelBtn}
+            {`\u00a0`}
+            {OKBtn}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = NCDialog;

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -555,7 +555,8 @@ class NCEdge extends UNISYS.Component {
    */
   SetSourceTarget(data) {
     const { uSelectSourceTarget } = this.state;
-    UDATA.LocalCall('SELECTMGR_SET_MODE', { mode: 'normal' });
+    // The source/target has been set already, so return to edge edit mode
+    UDATA.LocalCall('SELECTMGR_SET_MODE', { mode: 'edge_edit' });
     this.ThenSaveSourceTarget(uSelectSourceTarget, data.node);
   }
   /**
@@ -596,6 +597,7 @@ class NCEdge extends UNISYS.Component {
     Object.keys(attributes).forEach(k => (edge[k] = attributes[k]));
     this.AppCall('DB_UPDATE', { edge }).then(() => {
       this.UnlockEdge(() => {
+        UDATA.LocalCall('SELECTMGR_SET_MODE', { mode: 'normal' });
         this.setState({
           uViewMode: NCUI.VIEWMODE.VIEW,
           uIsLockedByDB: false,
@@ -660,6 +662,9 @@ class NCEdge extends UNISYS.Component {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// UI MANIPULATION METHODS
   ///
+  /**
+   * Save `previousState` so that we can undo/restore data if user cancels
+   */
   EnableEditMode() {
     const { uSelectedTab, sourceId, targetId, attributes, provenance } = this.state;
     const previousState = {
@@ -673,6 +678,7 @@ class NCEdge extends UNISYS.Component {
       uSelectedTab,
       previousState
     });
+    UDATA.LocalCall('SELECTMGR_SET_MODE', { mode: 'edge_edit' });
   }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -715,6 +721,7 @@ class NCEdge extends UNISYS.Component {
         uViewMode: NCUI.VIEWMODE.VIEW,
         uIsLockedByDB: false
       });
+      UDATA.LocalCall('SELECTMGR_SET_MODE', { mode: 'normal' });
       UDATA.NetCall('SRV_RELEASE_EDIT_LOCK', { editor: EDITORTYPE.EDGE });
     });
   }

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -585,6 +585,10 @@ class NCEdge extends UNISYS.Component {
       // 'target'
       state.targetId = node.id;
     }
+
+    // show secondary selection
+    UDATA.LocalCall('SELECTMGR_SELECT_SECONDARY', { node });
+
     this.setState(state, () => this.UpdateDerivedValues());
   }
 

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -1,0 +1,621 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+    Prototype Simple NetCreate Edge Editor
+
+    Built for Version 2.0 ITEST.
+
+    Provides a viewer and editor for the currently selected edge.
+
+    USAGE
+
+      <NCNEdge edge={edge}/>
+
+    This is designed to be embedded in an <NCNode> object.
+    There should only be one open NCEdge component at a time.
+
+    PERMISSIONS
+    Editting is restricted by:
+    * User must be logged in
+    * Template is not being edited
+    * Data is not being imported
+    * Someone else is not editing the edge (and has placed a lock on it)
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+const DBG = false;
+const PR = 'NCEdge';
+
+/// LIBRARIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const React = require('react');
+const UNISYS = require('unisys/client');
+const EDGEMGR = require('../edge-mgr'); // handles edge synthesis
+const { EDITORTYPE } = require('system/util/enum');
+const NCUI = require('../nc-ui');
+
+let UDATA;
+const BUILTIN_FIELDS = [
+  'id',
+  'source',
+  'target',
+  'provenance',
+  'degrees',
+  'created',
+  'updated',
+  'revision'
+];
+export const TABS = {
+  // Also used as labels
+  ATTRIBUTES: 'ATTRIBUTES',
+  PROVENANCE: 'PROVENANCE'
+};
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// export a class object for consumption by brunch/require
+class NCEdge extends UNISYS.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isLoggedIn: false,
+      animateHeight: 0
+    }; // initialized on componentDidMount and clearSelection
+
+    // STATE MANAGEMENT
+    this.resetState = this.resetState.bind(this);
+    this.updateSession = this.updateSession.bind(this);
+    this.isLoggedIn = this.isLoggedIn.bind(this);
+    this.setPermissions = this.setPermissions.bind(this);
+    this.updatePermissions = this.updatePermissions.bind(this);
+
+    // EVENT HANDLERS
+    this.checkUnload = this.checkUnload.bind(this);
+    this.doUnload = this.doUnload.bind(this);
+    this.clearSelection = this.clearSelection.bind(this);
+    this.updateSelection = this.updateSelection.bind(this);
+    this.reqLoadEdge = this.reqLoadEdge.bind(this);
+    // DATA LOADING
+    this.loadEdge = this.loadEdge.bind(this);
+    this.loadAttributes = this.loadAttributes.bind(this);
+    this.lockEdge = this.lockEdge.bind(this);
+    this.unlockEdge = this.unlockEdge.bind(this);
+    this.isEdgeLocked = this.isEdgeLocked.bind(this);
+    this.saveEdge = this.saveEdge.bind(this);
+    // HELPER METHODS
+    this.setBackgroundColor = this.setBackgroundColor.bind(this);
+    // UI HANDLERS
+    this.uiSelectTab = this.uiSelectTab.bind(this);
+    this.uiRequestEditEdge = this.uiRequestEditEdge.bind(this);
+    this.uiDeselectEdge = this.uiDeselectEdge.bind(this);
+    this.enableEditMode = this.enableEditMode.bind(this);
+    this.uiCancelEditMode = this.uiCancelEditMode.bind(this);
+    this.uiDisableEditMode = this.uiDisableEditMode.bind(this);
+    this.uiInputUpdate = this.uiInputUpdate.bind(this);
+    // RENDERERS -- Main
+    this.renderView = this.renderView.bind(this);
+    this.renderEdit = this.renderEdit.bind(this);
+
+    /// Initialize UNISYS DATA LINK for REACT
+    UDATA = UNISYS.NewDataLink(this);
+
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    /// REGISTER LISTENERS
+    UDATA.OnAppStateChange('SELECTION', this.updateSelection);
+    UDATA.HandleMessage('EDGE_OPEN', this.reqLoadEdge);
+    UDATA.HandleMessage('EDGE_DESELECT', this.clearSelection);
+    UDATA.HandleMessage('EDIT_PERMISSIONS_UPDATE', this.setPermissions);
+    // UDATA.HandleMessage('NODE_EDIT', this.uiRequestEditNode); // Node Table request
+  }
+
+  componentDidMount() {
+    this.resetState(); // Initialize State
+
+    const { edge } = this.props;
+    this.loadEdge(edge);
+
+    window.addEventListener('beforeunload', this.checkUnload);
+    window.addEventListener('unload', this.doUnload);
+  }
+  componentWillUnmount() {
+    UDATA.AppStateChangeOff('SELECTION', this.updateSelection);
+    UDATA.UnhandleMessage('EDGE_OPEN', this.reqLoadEdge);
+    UDATA.UnhandleMessage('EDGE_DESELECT', this.clearSelection);
+    UDATA.UnhandleMessage('EDIT_PERMISSIONS_UPDATE', this.setPermissions);
+    // UDATA.UnhandleMessage('NODE_EDIT', this.uiRequestEditNode);
+    window.removeEventListener('beforeunload', this.checkUnload);
+    window.removeEventListener('unload', this.doUnload);
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// STATE MANAGEMENT
+  ///
+  resetState() {
+    this.setState({
+      // SYSTEM STATE
+      // isLoggedIn: false, // don't clear session state!
+      // previousState: {},
+      // // UI State
+      editBtnDisable: false,
+      editBtnHide: false,
+      viewMode: NCUI.VIEWMODE.VIEW,
+      selectedTab: TABS.ATTRIBUTES,
+      // backgroundColor: 'transparent',
+      isLockedByDB: false, // shows db lock message next to Edit Node button
+      isLockedByTemplate: false,
+      isLockedByImport: false,
+      editLockMessage: '',
+      // EDGE DEFS
+      id: null,
+      source: null,
+      target: null,
+      sourceId: null,
+      targetId: null,
+      sourceNode: undefined,
+      targetNode: undefined,
+      attributes: [],
+      provenance: []
+      // created: undefined,
+      // updated: undefined,
+      // revision: 0
+    });
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// EVENT HANDLERS
+  ///
+  checkUnload(event) {
+    event.preventDefault();
+    if (this.state.viewMode === NCUI.VIEWMODE.EDIT) {
+      (event || window.event).returnValue = null;
+    } else {
+      Reflect.deleteProperty(event, 'returnValue');
+    }
+    return event;
+  }
+  doUnload(event) {
+    if (this.state.viewMode === NCUI.VIEWMODE.EDIT) {
+      UDATA.NetCall('SRV_DBUNLOCKEDGE', { edgeID: this.state.id });
+      UDATA.NetCall('SRV_RELEASE_EDIT_LOCK', { editor: EDITORTYPE.EDGE });
+    }
+  }
+  /**
+   * Handle change in SESSION data
+   * SESSION is called by SessionShell when the ID changes
+   * set system-wide. data: { classId, projId, hashedId, groupId, isValid }
+   * Called both by componentWillMount() and AppStateChange handler.
+   * The 'SESSION' state change is triggered in two places in SessionShell during
+   * its handleChange() when active typing is occuring, and also during
+   * SessionShell.componentWillMount()
+   */
+  updateSession(decoded) {
+    this.setState({ isLoggedIn: decoded.isValid }, () => this.updatePermissions());
+  }
+  /**
+   * Checks current SESSION state to see if user is logged in.
+   * Since NCEdge is dynamically created and closed, we can't rely on
+   * SESSION AppState updates messages.
+   * NOTE updates state.
+   * @returns {boolean} True if user is logged in
+   */
+  isLoggedIn() {
+    const SESSION = UDATA.AppState('SESSION');
+    const isLoggedIn = SESSION.isValid;
+    this.setState({ isLoggedIn });
+    return isLoggedIn;
+  }
+  setPermissions(data) {
+    const { id } = this.state;
+    const edgeIsLocked = data.lockedEdges.includes(id);
+    this.setState(
+      {
+        isLockedByDB: edgeIsLocked,
+        isLockedByTemplate: data.templateBeingEdited,
+        isLockedByImport: data.importActive
+      },
+      () => this.updatePermissions()
+    );
+  }
+  updatePermissions() {
+    const { isLockedByDB, isLockedByTemplate, isLockedByImport } = this.state;
+    const isLoggedIn = this.isLoggedIn();
+    const TEMPLATE = UDATA.AppState('TEMPLATE');
+    let editLockMessage = '';
+    let editBtnDisable = false;
+    let editBtnHide = true;
+    if (isLoggedIn) editBtnHide = false;
+    if (isLockedByDB) {
+      editBtnDisable = true;
+      editLockMessage += TEMPLATE.edgeIsLockedMessage;
+    }
+    if (isLockedByTemplate) {
+      editBtnDisable = true;
+      editLockMessage += TEMPLATE.templateIsLockedMessage;
+    }
+    if (isLockedByImport) {
+      editBtnDisable = true;
+      editLockMessage += TEMPLATE.importIsLockedMessage;
+    }
+    this.setState({ editBtnDisable, editBtnHide, editLockMessage });
+  }
+  clearSelection() {
+    this.resetState();
+  }
+  updateSelection(data) {
+    // const edge = data.edges[0]; // select the first node
+    // this.loadEdge(edge);
+  }
+  reqLoadEdge(data) {
+    // handler for UDATA call, interprets the net `data`
+    this.loadEdge(data.edge);
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// DATA LOADING
+  ///
+  loadEdge(edge) {
+    const { viewMode } = this.state;
+
+    // If we're editing, ignore the select!
+    if (viewMode === NCUI.VIEWMODE.EDIT) return;
+
+    // If no edge was selected, deselect
+    if (!edge) {
+      this.clearSelection();
+      return;
+    }
+
+    // Look up source/target nodes
+    const NCDATA = UDATA.AppState('NCDATA');
+    const sourceNode = NCDATA.nodes.find(n => n.id === edge.source);
+    const targetNode = NCDATA.nodes.find(n => n.id === edge.target);
+
+    // Load the edge
+    const attributes = this.loadAttributes(edge);
+    this.setState(
+      {
+        id: edge.id,
+        sourceId: edge.source,
+        targetId: edge.target,
+        attributes: attributes,
+        // provenance: edge.provenance,
+        sourceNode,
+        targetNode
+        // created: edge.created,
+        // updated: edge.updated,
+        // revision: edge.revision
+      },
+      () => {
+        this.setBackgroundColor();
+        // setTimeout(() => {
+        this.setState({ animateHeight: 'fullheight' }); // animate transition
+        // }, 500);
+        this.isEdgeLocked(edgeIsLocked => {
+          this.setState({ isLockedByDB: edgeIsLocked }, () =>
+            this.updatePermissions()
+          );
+        });
+      }
+    );
+  }
+  /**
+   * Loads up the `attributes` object defined by the TEMPLATE
+   * Will skip
+   *   * BUILTIN fields
+   *   * attributes that are `hidden` by the template
+   * REVIEW: Currently the parameters will show up in random object order.
+   * @param {Object} edge
+   * @returns {Object} { ...attr-key: attr-value }
+   */
+  loadAttributes(edge) {
+    const EDGEDEFS = UDATA.AppState('TEMPLATE').edgeDefs;
+    const attributes = {};
+    Object.keys(EDGEDEFS).forEach(k => {
+      if (BUILTIN_FIELDS.includes(k)) return; // skip built-in fields
+      const attr_def = EDGEDEFS[k];
+      if (attr_def.hidden) return; // skip hidden fields
+      attributes[k] = edge[k];
+    });
+    return attributes;
+  }
+
+  /**
+   * Tries to lock the edge for editing.
+   * If the lock fails, then it means the edge was already locked
+   * previously and we're not allowed to edit
+   * @param {function} cb callback function
+   * @returns {boolean} true if lock was successful
+   */
+  lockEdge(cb) {
+    const { id } = this.state;
+    let lockSuccess = false;
+    UDATA.NetCall('SRV_DBLOCKEDGE', { edgeID: id }).then(data => {
+      if (data.NOP) {
+        console.log(`SERVER SAYS: ${data.NOP} ${data.INFO}`);
+      } else if (data.locked) {
+        console.log(`SERVER SAYS: lock success! you can edit Edge ${data.edgeID}`);
+        console.log(`SERVER SAYS: unlock the edge after successful DBUPDATE`);
+        lockSuccess = true;
+        // When a edge is being edited, lock the Template from being edited
+        UDATA.NetCall('SRV_REQ_EDIT_LOCK', { editor: EDITORTYPE.EDGE });
+      }
+      if (typeof cb === 'function') cb(lockSuccess);
+    });
+  }
+  unlockEdge(cb) {
+    const { id } = this.state;
+    let unlockSuccess = false;
+    UDATA.NetCall('SRV_DBUNLOCKEDGE', { edgeID: id }).then(data => {
+      if (data.NOP) {
+        console.log(`SERVER SAYS: ${data.NOP} ${data.INFO}`);
+      } else if (data.unlocked) {
+        console.log(
+          `SERVER SAYS: unlock success! you have released Edge ${data.edgeID}`
+        );
+        unlockSuccess = true;
+        // Release Template lock
+        UDATA.NetCall('SRV_RELEASE_EDIT_LOCK', { editor: EDITORTYPE.EDGE });
+      }
+      if (typeof cb === 'function') cb(unlockSuccess);
+    });
+  }
+  isEdgeLocked(cb) {
+    const { id } = this.state;
+    let edgeIsLocked = false;
+    UDATA.NetCall('SRV_DBISEDGELOCKED', { edgeID: id }).then(data => {
+      if (data.NOP) {
+        console.log(`SERVER SAYS: ${data.NOP} ${data.INFO}`);
+      } else if (data.locked) {
+        console.log(
+          `SERVER SAYS: Edge is locked! You cannot edit Edge ${data.edgeID}`
+        );
+        edgeIsLocked = true;
+      }
+      if (typeof cb === 'function') cb(edgeIsLocked);
+    });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// DATA SAVING
+  ///
+  saveEdge() {
+    const { id, sourceId, targetId, attributes, provenance } = this.state;
+
+    const edge = { id, sourceId, targetId, provenance };
+    Object.keys(attributes).forEach(k => (edge[k] = attributes[k]));
+
+    this.AppCall('DB_UPDATE', { edge }).then(() => {
+      this.unlockEdge(() => {
+        this.setState({
+          viewMode: NCUI.VIEWMODE.VIEW,
+          isLockedByDB: false
+        });
+      });
+    });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// HELPER METHODS
+  ///
+  /**
+   * Sets the background color of the node editor via `backgroundColor` state.
+   * Currently the background color is determined by the template edge type
+   * color mapping.  This will eventually be replaced with a color manager.
+   */
+  setBackgroundColor() {
+    const { attributes } = this.state;
+    const type = attributes ? attributes.type : ''; // "" matches undefined
+    const COLORMAP = UDATA.AppState('COLORMAP');
+    this.setState({ backgroundColor: COLORMAP.edgeColorMap[type] });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// UI EVENT HANDLERS
+  ///
+  uiSelectTab(event) {
+    this.setState({ selectedTab: event.target.value });
+  }
+
+  /**
+   * If `lockEdge` is not successful, then that means the edge was
+   * already locked, so we can't edit.
+   */
+  uiRequestEditEdge(event) {
+    event.stopPropagation();
+    this.lockEdge(lockSuccess => {
+      this.setState({ isLockedByDB: !lockSuccess }, () => {
+        if (lockSuccess) this.enableEditMode();
+      });
+    });
+  }
+
+  uiDeselectEdge() {
+    UDATA.LocalCall('EDGE_DESELECT');
+  }
+
+  enableEditMode() {
+    const { selectedTab, sourceId, targetId, attributes, provenance } = this.state;
+    const previousState = {
+      sourceId,
+      targetId,
+      attributes: Object.assign({}, attributes)
+      // provenance: Object.assign({}, provenance) // uncomment after provenence is implemented
+    };
+    this.setState({
+      viewMode: NCUI.VIEWMODE.EDIT,
+      selectedTab,
+      previousState
+    });
+  }
+  uiCancelEditMode() {
+    const { previousState } = this.state;
+    // restore previous state
+    this.setState(
+      {
+        sourceId: previousState.sourceId,
+        targetId: previousState.targetId,
+        attributes: previousState.attributes
+        // provenance: Object.assign({}, provenance) // uncomment after provenence is implemented
+      },
+      () => this.uiDisableEditMode()
+    );
+  }
+  uiDisableEditMode() {
+    this.unlockEdge(() => {
+      this.setState({
+        viewMode: NCUI.VIEWMODE.VIEW,
+        isLockedByDB: false
+      });
+      UDATA.NetCall('SRV_RELEASE_EDIT_LOCK', { editor: EDITORTYPE.EDGE });
+    });
+  }
+
+  uiInputUpdate(key, value) {
+    if (BUILTIN_FIELDS.includes(key)) {
+      const data = {};
+      data[key] = value;
+      this.setState(data);
+    } else {
+      const { attributes } = this.state;
+      attributes[key] = value;
+      this.setState({ attributes }, () => this.setBackgroundColor());
+    }
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// RENDER METHODS
+  renderView() {
+    const {
+      selectedTab,
+      backgroundColor,
+      animateHeight,
+      editBtnDisable,
+      editBtnHide,
+      editLockMessage,
+      sourceNode,
+      targetNode
+    } = this.state;
+    const bgcolor = backgroundColor + '44'; // hack opacity
+    const label = sourceNode.label + ' \u2794 ' + targetNode.label;
+    const defs = UDATA.AppState('TEMPLATE').edgeDefs;
+
+    return (
+      <div className={`nccomponent ncedge ${animateHeight}`}>
+        <div
+          className="view"
+          style={{ background: bgcolor }}
+          onClick={this.uiDeselectEdge}
+        >
+          {/* BUILT-IN - - - - - - - - - - - - - - - - - */}
+          <div className="nodelabel">{NCUI.RenderStringValue('label', label)}</div>
+          <div className="formview">
+            {NCUI.RenderLabel('source', defs['source'].displayLabel)}
+            {NCUI.RenderStringValue('source', sourceNode.label)}
+            {NCUI.RenderLabel('target', defs['target'].displayLabel)}
+            {NCUI.RenderStringValue('target', targetNode.label)}
+          </div>
+          {/* TABS - - - - - - - - - - - - - - - - - - - */}
+          <div className="tabcontainer">
+            {NCUI.RenderTabSelectors(TABS, this.state, this.uiSelectTab)}
+            <div className="tabview">
+              {selectedTab === TABS.ATTRIBUTES &&
+                NCUI.RenderAttributesTabView(this.state, defs)}
+              {selectedTab === TABS.PROVENANCE &&
+                NCUI.RenderProvenanceTab(this.state, defs)}
+            </div>
+          </div>
+          {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
+          <div className="controlbar">
+            {!editBtnHide && selectedTab !== TABS.EDGES && (
+              <button
+                id="editbtn"
+                onClick={this.uiRequestEditEdge}
+                disabled={editBtnDisable}
+              >
+                Edit
+              </button>
+            )}
+          </div>
+          {editLockMessage && (
+            <div className="message warning">{editLockMessage}</div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  renderEdit() {
+    const {
+      selectedTab,
+      backgroundColor,
+      animateHeight,
+      editBtnDisable,
+      editBtnHide,
+      editLockMessage,
+      sourceNode,
+      targetNode
+    } = this.state;
+    const label = sourceNode.label + ' \u2794 ' + targetNode.label;
+    const bgcolor = backgroundColor + '66'; // hack opacity
+    const defs = UDATA.AppState('TEMPLATE').edgeDefs;
+    // const matchList = matchingNodeLabels
+    //   ? matchingNodeLabels.map(l => <div key={l}>{l}</div>)
+    //   : undefined;
+    // console.log(
+    //   'matchlist',
+    //   label,
+    //   matchingNodeLabels && matchingNodeLabels.includes(label),
+    //   matchList,
+    //   matchingNodeLabels
+    // );
+    return (
+      <div>
+        <div className="screen"></div>
+        <div className={`nccomponent ncedge ${animateHeight}`}>
+          <div
+            className="edit"
+            style={{
+              background: bgcolor,
+              borderColor: backgroundColor
+            }}
+          >
+            {/* BUILT-IN - - - - - - - - - - - - - - - - - */}
+            <div className="nodelabel">{NCUI.RenderStringValue('label', label)}</div>
+            {/* {matchList && <div className="matchlist">{matchList}</div>} */}
+            {/* TABS - - - - - - - - - - - - - - - - - - - */}
+            <div className="tabcontainer">
+              {NCUI.RenderTabSelectors(TABS, this.state, this.uiSelectTab)}
+              <div className="tabview">
+                {selectedTab === TABS.ATTRIBUTES &&
+                  NCUI.RenderAttributesTabEdit(this.state, defs, this.uiInputUpdate)}
+                {selectedTab === TABS.PROVENANCE &&
+                  NCUI.RenderProvenanceTab(this.state, defs)}
+              </div>
+            </div>
+            {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
+            <div className="controlbar">
+              <button className="cancelbtn" onClick={this.uiCancelEditMode}>
+                Cancel
+              </button>
+              <button onClick={this.saveEdge}>Save</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// MAIN RENDER
+  render() {
+    const { id, viewMode } = this.state;
+    if (!id) return ''; // nothing selected
+    if (viewMode === NCUI.VIEWMODE.VIEW) {
+      return this.renderView();
+    } else {
+      return this.renderEdit();
+    }
+  }
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = NCEdge;

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -81,6 +81,7 @@ class NCEdge extends UNISYS.Component {
     this.lockEdge = this.lockEdge.bind(this);
     this.unlockEdge = this.unlockEdge.bind(this);
     this.isEdgeLocked = this.isEdgeLocked.bind(this);
+    this.editEdge = this.editEdge.bind(this);
     this.saveEdge = this.saveEdge.bind(this);
     // HELPER METHODS
     this.setBackgroundColor = this.setBackgroundColor.bind(this);
@@ -105,7 +106,7 @@ class NCEdge extends UNISYS.Component {
     UDATA.HandleMessage('EDGE_OPEN', this.reqLoadEdge);
     UDATA.HandleMessage('EDGE_DESELECT', this.clearSelection);
     UDATA.HandleMessage('EDIT_PERMISSIONS_UPDATE', this.setPermissions);
-    // UDATA.HandleMessage('NODE_EDIT', this.uiRequestEditNode); // Node Table request
+    UDATA.HandleMessage('EDGE_EDIT', this.editEdge); // EdgeTable request
   }
 
   componentDidMount() {
@@ -122,7 +123,7 @@ class NCEdge extends UNISYS.Component {
     UDATA.UnhandleMessage('EDGE_OPEN', this.reqLoadEdge);
     UDATA.UnhandleMessage('EDGE_DESELECT', this.clearSelection);
     UDATA.UnhandleMessage('EDIT_PERMISSIONS_UPDATE', this.setPermissions);
-    // UDATA.UnhandleMessage('NODE_EDIT', this.uiRequestEditNode);
+    UDATA.UnhandleMessage('EDGE_EDIT', this.editEdge);
     window.removeEventListener('beforeunload', this.checkUnload);
     window.removeEventListener('unload', this.doUnload);
   }
@@ -373,6 +374,17 @@ class NCEdge extends UNISYS.Component {
       if (typeof cb === 'function') cb(edgeIsLocked);
     });
   }
+  /**
+   * If `lockEdge` is not successful, then that means the edge was
+   * already locked, so we can't edit.
+   */
+  editEdge() {
+    this.lockEdge(lockSuccess => {
+      this.setState({ isLockedByDB: !lockSuccess }, () => {
+        if (lockSuccess) this.enableEditMode();
+      });
+    });
+  }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// DATA SAVING
@@ -415,17 +427,9 @@ class NCEdge extends UNISYS.Component {
     this.setState({ selectedTab: event.target.value });
   }
 
-  /**
-   * If `lockEdge` is not successful, then that means the edge was
-   * already locked, so we can't edit.
-   */
   uiRequestEditEdge(event) {
     event.stopPropagation();
-    this.lockEdge(lockSuccess => {
-      this.setState({ isLockedByDB: !lockSuccess }, () => {
-        if (lockSuccess) this.enableEditMode();
-      });
-    });
+    this.editEdge();
   }
 
   uiDeselectEdge() {

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -29,22 +29,12 @@ const PR = 'NCEdge';
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const React = require('react');
 const UNISYS = require('unisys/client');
-const { EDITORTYPE } = require('system/util/enum');
+const { EDITORTYPE, BUILTIN_FIELDS_EDGE } = require('system/util/enum');
 const NCUI = require('../nc-ui');
 const NCAutoSuggest = require('./NCAutoSuggest');
 const NCDialog = require('./NCDialog');
 
 let UDATA;
-const BUILTIN_FIELDS = [
-  'id',
-  'source',
-  'target',
-  'provenance',
-  'degrees',
-  'created',
-  'updated',
-  'revision'
-];
 const TABS = {
   // Also used as labels
   ATTRIBUTES: 'ATTRIBUTES',
@@ -341,7 +331,7 @@ class NCEdge extends UNISYS.Component {
     const EDGEDEFS = UDATA.AppState('TEMPLATE').edgeDefs;
     const attributes = {};
     Object.keys(EDGEDEFS).forEach(k => {
-      if (BUILTIN_FIELDS.includes(k)) return; // skip built-in fields
+      if (BUILTIN_FIELDS_EDGE.includes(k)) return; // skip built-in fields
       const attr_def = EDGEDEFS[k];
       if (attr_def.hidden) return; // skip hidden fields
       attributes[k] = edge[k];
@@ -743,7 +733,7 @@ class NCEdge extends UNISYS.Component {
   }
 
   UIInputUpdate(key, value) {
-    if (BUILTIN_FIELDS.includes(key)) {
+    if (BUILTIN_FIELDS_EDGE.includes(key)) {
       const data = {};
       data[key] = value;
       this.setState(data);

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -68,25 +68,25 @@ class NCEdge extends UNISYS.Component {
     }; // initialized on componentDidMount and clearSelection
 
     // STATE MANAGEMENT
-    this.resetState = this.resetState.bind(this);
-    this.updateSession = this.updateSession.bind(this);
-    this.isLoggedIn = this.isLoggedIn.bind(this);
-    this.setPermissions = this.setPermissions.bind(this);
-    this.updatePermissions = this.updatePermissions.bind(this);
+    this.ResetState = this.ResetState.bind(this);
+    this.UpdateSession = this.UpdateSession.bind(this);
+    this.IsLoggedIn = this.IsLoggedIn.bind(this);
+    this.SetPermissions = this.SetPermissions.bind(this);
+    this.UpdatePermissions = this.UpdatePermissions.bind(this);
 
     // EVENT HANDLERS
-    this.checkUnload = this.checkUnload.bind(this);
-    this.doUnload = this.doUnload.bind(this);
-    this.clearSelection = this.clearSelection.bind(this);
-    this.updateSelection = this.updateSelection.bind(this);
-    this.reqLoadEdge = this.reqLoadEdge.bind(this);
+    this.CheckUnload = this.CheckUnload.bind(this);
+    this.DoUnload = this.DoUnload.bind(this);
+    this.ClearSelection = this.ClearSelection.bind(this);
+    this.UpdateSelection = this.UpdateSelection.bind(this);
+    this.ReqLoadEdge = this.ReqLoadEdge.bind(this);
     // DATA LOADING
-    this.loadEdge = this.loadEdge.bind(this);
-    this.loadAttributes = this.loadAttributes.bind(this);
-    this.lockEdge = this.lockEdge.bind(this);
+    this.LoadEdge = this.LoadEdge.bind(this);
+    this.LoadAttributes = this.LoadAttributes.bind(this);
+    this.LockEdge = this.LockEdge.bind(this);
     this.UnlockEdge = this.UnlockEdge.bind(this);
-    this.isEdgeLocked = this.isEdgeLocked.bind(this);
-    this.editEdge = this.editEdge.bind(this);
+    this.IsEdgeLocked = this.IsEdgeLocked.bind(this);
+    this.EditEdge = this.EditEdge.bind(this);
     this.UpdateDerivedValues = this.UpdateDerivedValues.bind(this);
     this.ValidateSourceTarget = this.ValidateSourceTarget.bind(this);
     this.OfferToCreateNewNode = this.OfferToCreateNewNode.bind(this);
@@ -97,18 +97,18 @@ class NCEdge extends UNISYS.Component {
     // DATA SAVING
     this.SaveEdge = this.SaveEdge.bind(this);
     // HELPER METHODS
-    this.setBackgroundColor = this.setBackgroundColor.bind(this);
+    this.SetBackgroundColor = this.SetBackgroundColor.bind(this);
     this.SetSourceTargetNodeColor = this.SetSourceTargetNodeColor.bind(this);
     this.SwapSourceAndTarget = this.SwapSourceAndTarget.bind(this);
     // UI MANIPULATION METHODS
     this.EnableEditMode = this.EnableEditMode.bind(this);
     // UI EVENT HANDLERS
-    this.uiSelectTab = this.uiSelectTab.bind(this);
-    this.uiRequestEditEdge = this.uiRequestEditEdge.bind(this);
-    this.uiDeselectEdge = this.uiDeselectEdge.bind(this);
-    this.uiCancelEditMode = this.uiCancelEditMode.bind(this);
-    this.uiDisableEditMode = this.uiDisableEditMode.bind(this);
-    this.uiInputUpdate = this.uiInputUpdate.bind(this);
+    this.UISelectTab = this.UISelectTab.bind(this);
+    this.UIRequestEditEdge = this.UIRequestEditEdge.bind(this);
+    this.UIDeselectEdge = this.UIDeselectEdge.bind(this);
+    this.UICancelEditMode = this.UICancelEditMode.bind(this);
+    this.UIDisableEditMode = this.UIDisableEditMode.bind(this);
+    this.UIInputUpdate = this.UIInputUpdate.bind(this);
     this.UIEnableSourceTargetSelect = this.UIEnableSourceTargetSelect.bind(this);
     this.UISourceTargetInputUpdate = this.UISourceTargetInputUpdate.bind(this);
     this.UISourceTargetInputSelect = this.UISourceTargetInputSelect.bind(this);
@@ -123,40 +123,40 @@ class NCEdge extends UNISYS.Component {
 
     /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     /// REGISTER LISTENERS
-    UDATA.OnAppStateChange('SESSION', this.updateSession);
-    UDATA.OnAppStateChange('SELECTION', this.updateSelection);
-    UDATA.HandleMessage('EDGE_OPEN', this.reqLoadEdge);
-    UDATA.HandleMessage('EDGE_DESELECT', this.clearSelection);
-    UDATA.HandleMessage('EDIT_PERMISSIONS_UPDATE', this.setPermissions);
-    UDATA.HandleMessage('EDGE_EDIT', this.editEdge); // EdgeTable request
+    UDATA.OnAppStateChange('SESSION', this.UpdateSession);
+    UDATA.OnAppStateChange('SELECTION', this.UpdateSelection);
+    UDATA.HandleMessage('EDGE_OPEN', this.ReqLoadEdge);
+    UDATA.HandleMessage('EDGE_DESELECT', this.ClearSelection);
+    UDATA.HandleMessage('EDIT_PERMISSIONS_UPDATE', this.SetPermissions);
+    UDATA.HandleMessage('EDGE_EDIT', this.EditEdge); // EdgeTable request
     UDATA.HandleMessage('SELECT_SOURCETARGET', this.SetSourceTarget);
   }
 
   componentDidMount() {
-    this.resetState(); // Initialize State
+    this.ResetState(); // Initialize State
 
     const { edge } = this.props;
-    this.loadEdge(edge);
+    this.LoadEdge(edge);
 
-    window.addEventListener('beforeunload', this.checkUnload);
-    window.addEventListener('unload', this.doUnload);
+    window.addEventListener('beforeunload', this.CheckUnload);
+    window.addEventListener('unload', this.DoUnload);
   }
   componentWillUnmount() {
-    UDATA.AppStateChangeOff('SESSION', this.updateSession);
-    UDATA.AppStateChangeOff('SELECTION', this.updateSelection);
-    UDATA.UnhandleMessage('EDGE_OPEN', this.reqLoadEdge);
-    UDATA.UnhandleMessage('EDGE_DESELECT', this.clearSelection);
-    UDATA.UnhandleMessage('EDIT_PERMISSIONS_UPDATE', this.setPermissions);
-    UDATA.UnhandleMessage('EDGE_EDIT', this.editEdge);
+    UDATA.AppStateChangeOff('SESSION', this.UpdateSession);
+    UDATA.AppStateChangeOff('SELECTION', this.UpdateSelection);
+    UDATA.UnhandleMessage('EDGE_OPEN', this.ReqLoadEdge);
+    UDATA.UnhandleMessage('EDGE_DESELECT', this.ClearSelection);
+    UDATA.UnhandleMessage('EDIT_PERMISSIONS_UPDATE', this.SetPermissions);
+    UDATA.UnhandleMessage('EDGE_EDIT', this.EditEdge);
     UDATA.UnhandleMessage('SELECT_SOURCETARGET', this.SetSourceTarget);
-    window.removeEventListener('beforeunload', this.checkUnload);
-    window.removeEventListener('unload', this.doUnload);
+    window.removeEventListener('beforeunload', this.CheckUnload);
+    window.removeEventListener('unload', this.DoUnload);
   }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// STATE MANAGEMENT
   ///
-  resetState() {
+  ResetState() {
     this.setState({
       // EDGE DEFS 'core state data'
       id: null,
@@ -198,7 +198,7 @@ class NCEdge extends UNISYS.Component {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// SYSTEM/NETWORK EVENT HANDLERS
   ///
-  checkUnload(event) {
+  CheckUnload(event) {
     event.preventDefault();
     if (this.state.uViewMode === NCUI.VIEWMODE.EDIT) {
       (event || window.event).returnValue = null;
@@ -207,7 +207,7 @@ class NCEdge extends UNISYS.Component {
     }
     return event;
   }
-  doUnload(event) {
+  DoUnload(event) {
     if (this.state.uViewMode === NCUI.VIEWMODE.EDIT) {
       UDATA.NetCall('SRV_DBUNLOCKEDGE', { edgeID: this.state.id });
       UDATA.NetCall('SRV_RELEASE_EDIT_LOCK', { editor: EDITORTYPE.EDGE });
@@ -222,8 +222,8 @@ class NCEdge extends UNISYS.Component {
    * its handleChange() when active typing is occuring, and also during
    * SessionShell.componentWillMount()
    */
-  updateSession(decoded) {
-    this.setState({ isLoggedIn: decoded.isValid }, () => this.updatePermissions());
+  UpdateSession(decoded) {
+    this.setState({ isLoggedIn: decoded.isValid }, () => this.UpdatePermissions());
   }
   /**
    * Checks current SESSION state to see if user is logged in.
@@ -232,13 +232,13 @@ class NCEdge extends UNISYS.Component {
    * NOTE updates state.
    * @returns {boolean} True if user is logged in
    */
-  isLoggedIn() {
+  IsLoggedIn() {
     const SESSION = UDATA.AppState('SESSION');
     const isLoggedIn = SESSION.isValid;
     this.setState({ isLoggedIn });
     return isLoggedIn;
   }
-  setPermissions(data) {
+  SetPermissions(data) {
     const { id } = this.state;
     const edgeIsLocked = data.lockedEdges.includes(id);
     this.setState(
@@ -247,12 +247,12 @@ class NCEdge extends UNISYS.Component {
         uIsLockedByTemplate: data.templateBeingEdited,
         uIsLockedByImport: data.importActive
       },
-      () => this.updatePermissions()
+      () => this.UpdatePermissions()
     );
   }
-  updatePermissions() {
+  UpdatePermissions() {
     const { uIsLockedByDB, uIsLockedByTemplate, uIsLockedByImport } = this.state;
-    const isLoggedIn = this.isLoggedIn();
+    const isLoggedIn = this.IsLoggedIn();
     const TEMPLATE = UDATA.AppState('TEMPLATE');
     let uEditLockMessage = '';
     let uEditBtnDisable = false;
@@ -272,10 +272,10 @@ class NCEdge extends UNISYS.Component {
     }
     this.setState({ uEditBtnDisable, uEditBtnHide, uEditLockMessage });
   }
-  clearSelection() {
-    this.resetState();
+  ClearSelection() {
+    this.ResetState();
   }
-  updateSelection(data) {
+  UpdateSelection(data) {
     const { sourceTargetSelect } = this.state;
     const selectedNode = data.nodes[0]; // select the first node
     if (sourceTargetSelect === 'source') {
@@ -292,15 +292,15 @@ class NCEdge extends UNISYS.Component {
       // ignore the selection
     }
   }
-  reqLoadEdge(data) {
+  ReqLoadEdge(data) {
     // handler for UDATA call, interprets the net `data`
-    this.loadEdge(data.edge);
+    this.LoadEdge(data.edge);
   }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// DATA LOADING
   ///
-  loadEdge(edge) {
+  LoadEdge(edge) {
     const { uViewMode } = this.state;
 
     // If we're editing, ignore the select!
@@ -308,12 +308,12 @@ class NCEdge extends UNISYS.Component {
 
     // If no edge was selected, deselect
     if (!edge) {
-      this.clearSelection();
+      this.ClearSelection();
       return;
     }
 
     // Load the edge
-    const attributes = this.loadAttributes(edge);
+    const attributes = this.LoadAttributes(edge);
     this.setState(
       {
         id: edge.id,
@@ -337,7 +337,7 @@ class NCEdge extends UNISYS.Component {
    * @param {Object} edge
    * @returns {Object} { ...attr-key: attr-value }
    */
-  loadAttributes(edge) {
+  LoadAttributes(edge) {
     const EDGEDEFS = UDATA.AppState('TEMPLATE').edgeDefs;
     const attributes = {};
     Object.keys(EDGEDEFS).forEach(k => {
@@ -356,7 +356,7 @@ class NCEdge extends UNISYS.Component {
    * @param {function} cb callback function
    * @returns {boolean} true if lock was successful
    */
-  lockEdge(cb) {
+  LockEdge(cb) {
     const { id } = this.state;
     let lockSuccess = false;
     UDATA.NetCall('SRV_DBLOCKEDGE', { edgeID: id }).then(data => {
@@ -393,7 +393,7 @@ class NCEdge extends UNISYS.Component {
       if (typeof cb === 'function') cb(unlockSuccess);
     });
   }
-  isEdgeLocked(cb) {
+  IsEdgeLocked(cb) {
     const { id } = this.state;
     let edgeIsLocked = false;
     UDATA.NetCall('SRV_DBISEDGELOCKED', { edgeID: id }).then(data => {
@@ -415,8 +415,8 @@ class NCEdge extends UNISYS.Component {
    * If `lockEdge` is not successful, then that means the edge was
    * already locked, so we can't edit.
    */
-  editEdge() {
-    this.lockEdge(lockSuccess => {
+  EditEdge() {
+    this.LockEdge(lockSuccess => {
       this.setState({ uIsLockedByDB: !lockSuccess }, () => {
         if (lockSuccess) this.EnableEditMode();
       });
@@ -443,14 +443,14 @@ class NCEdge extends UNISYS.Component {
         dTargetNode
       },
       () => {
-        this.setBackgroundColor();
+        this.SetBackgroundColor();
         this.SetSourceTargetNodeColor();
         // setTimeout(() => {
         this.setState({ animateHeight: 'fullheight' }); // animate transition
         // }, 500);
-        this.isEdgeLocked(edgeIsLocked => {
+        this.IsEdgeLocked(edgeIsLocked => {
           this.setState({ uIsLockedByDB: edgeIsLocked }, () =>
-            this.updatePermissions()
+            this.UpdatePermissions()
           );
         });
       }
@@ -627,7 +627,7 @@ class NCEdge extends UNISYS.Component {
    * Currently the background color is determined by the template edge type
    * color mapping.  This will eventually be replaced with a color manager.
    */
-  setBackgroundColor() {
+  SetBackgroundColor() {
     const { attributes } = this.state;
     const type = attributes && attributes.type;
     const COLORMAP = UDATA.AppState('COLORMAP');
@@ -696,21 +696,21 @@ class NCEdge extends UNISYS.Component {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// UI EVENT HANDLERS
   ///
-  uiSelectTab(event) {
+  UISelectTab(event) {
     event.stopPropagation();
     this.setState({ uSelectedTab: event.target.value });
   }
 
-  uiRequestEditEdge(event) {
+  UIRequestEditEdge(event) {
     event.stopPropagation();
-    this.editEdge();
+    this.EditEdge();
   }
 
-  uiDeselectEdge() {
+  UIDeselectEdge() {
     UDATA.LocalCall('EDGE_DESELECT');
   }
 
-  uiCancelEditMode() {
+  UICancelEditMode() {
     const { previousState } = this.state;
     // restore previous state
     this.setState(
@@ -723,11 +723,11 @@ class NCEdge extends UNISYS.Component {
       },
       () => {
         this.UpdateDerivedValues();
-        this.uiDisableEditMode();
+        this.UIDisableEditMode();
       }
     );
   }
-  uiDisableEditMode() {
+  UIDisableEditMode() {
     this.UnlockEdge(() => {
       this.setState({
         uViewMode: NCUI.VIEWMODE.VIEW,
@@ -742,7 +742,7 @@ class NCEdge extends UNISYS.Component {
     });
   }
 
-  uiInputUpdate(key, value) {
+  UIInputUpdate(key, value) {
     if (BUILTIN_FIELDS.includes(key)) {
       const data = {};
       data[key] = value;
@@ -750,7 +750,7 @@ class NCEdge extends UNISYS.Component {
     } else {
       const { attributes } = this.state;
       attributes[key] = value;
-      this.setState({ attributes }, () => this.setBackgroundColor());
+      this.setState({ attributes }, () => this.SetBackgroundColor());
     }
   }
 
@@ -807,7 +807,7 @@ class NCEdge extends UNISYS.Component {
         <div
           className="view"
           style={{ backgroundColor: bgcolor }}
-          onClick={this.uiDeselectEdge}
+          onClick={this.UIDeselectEdge}
         >
           {/* BUILT-IN - - - - - - - - - - - - - - - - - */}
           <div className="formview">
@@ -828,7 +828,7 @@ class NCEdge extends UNISYS.Component {
           </div>
           {/* TABS - - - - - - - - - - - - - - - - - - - */}
           <div className="tabcontainer">
-            {NCUI.RenderTabSelectors(TABS, this.state, this.uiSelectTab)}
+            {NCUI.RenderTabSelectors(TABS, this.state, this.UISelectTab)}
             <div className="tabview">
               {uSelectedTab === TABS.ATTRIBUTES &&
                 NCUI.RenderAttributesTabView(this.state, defs)}
@@ -841,7 +841,7 @@ class NCEdge extends UNISYS.Component {
             {!uEditBtnHide && uSelectedTab !== TABS.EDGES && (
               <button
                 id="editbtn"
-                onClick={this.uiRequestEditEdge}
+                onClick={this.UIRequestEditEdge}
                 disabled={uEditBtnDisable}
               >
                 Edit
@@ -921,17 +921,17 @@ class NCEdge extends UNISYS.Component {
             </div>
             {/* TABS - - - - - - - - - - - - - - - - - - - */}
             <div className="tabcontainer">
-              {NCUI.RenderTabSelectors(TABS, this.state, this.uiSelectTab)}
+              {NCUI.RenderTabSelectors(TABS, this.state, this.UISelectTab)}
               <div className="tabview">
                 {uSelectedTab === TABS.ATTRIBUTES &&
-                  NCUI.RenderAttributesTabEdit(this.state, defs, this.uiInputUpdate)}
+                  NCUI.RenderAttributesTabEdit(this.state, defs, this.UIInputUpdate)}
                 {uSelectedTab === TABS.PROVENANCE &&
                   NCUI.RenderProvenanceTab(this.state, defs)}
               </div>
             </div>
             {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
             <div className="controlbar">
-              <button className="cancelbtn" onClick={this.uiCancelEditMode}>
+              <button className="cancelbtn" onClick={this.UICancelEditMode}>
                 Cancel
               </button>
               <button onClick={this.SaveEdge} disabled={saveIsDisabled}>

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -882,6 +882,7 @@ class NCEdge extends UNISYS.Component {
     ) : (
       ''
     );
+    const saveIsDisabled = uSelectSourceTarget || isNaN(sourceId) || isNaN(targetId);
     return (
       <div>
         <div className="screen"></div>
@@ -933,7 +934,7 @@ class NCEdge extends UNISYS.Component {
               <button className="cancelbtn" onClick={this.uiCancelEditMode}>
                 Cancel
               </button>
-              <button onClick={this.SaveEdge} disabled={uSelectSourceTarget}>
+              <button onClick={this.SaveEdge} disabled={saveIsDisabled}>
                 Save
               </button>
             </div>

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -823,7 +823,7 @@ class NCEdge extends UNISYS.Component {
               {uSelectedTab === TABS.ATTRIBUTES &&
                 NCUI.RenderAttributesTabView(this.state, defs)}
               {uSelectedTab === TABS.PROVENANCE &&
-                NCUI.RenderProvenanceTab(this.state, defs)}
+                NCUI.RenderProvenanceTabView(this.state, defs)}
             </div>
           </div>
           {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
@@ -916,7 +916,7 @@ class NCEdge extends UNISYS.Component {
                 {uSelectedTab === TABS.ATTRIBUTES &&
                   NCUI.RenderAttributesTabEdit(this.state, defs, this.UIInputUpdate)}
                 {uSelectedTab === TABS.PROVENANCE &&
-                  NCUI.RenderProvenanceTab(this.state, defs)}
+                  NCUI.RenderProvenanceTabEdit(this.state, defs)}
               </div>
             </div>
             {/* CONTROL BAR - - - - - - - - - - - - - - - - */}

--- a/app/view/netcreate/components/NCGraphRenderer.js
+++ b/app/view/netcreate/components/NCGraphRenderer.js
@@ -488,7 +488,6 @@ class NCGraphRenderer {
     }
 
     // SELECTION ARROW
-    // Theoretically can show more than one
     this.d3svg.selectAll('#selectorArrow').remove();
 
     // SINGLE ARROW APPROACH
@@ -704,7 +703,8 @@ class NCGraphRenderer {
   /*/
   Dragstarted(d, self) {
     if (DBG) console.log(PR, 'Dragstarted', d.x, d.y);
-    if (!d3.event.active) self.simulation.alphaTarget(0.3).restart();
+    // if (!d3.event.active) self.simulation.alphaTarget(0.3).restart(); // orig value results in a lot of movement after selection
+    if (!d3.event.active) self.simulation.alphaTarget(0.01).restart(); // minimize shift after selection
     d.fx = d.x;
     d.fy = d.y;
   }

--- a/app/view/netcreate/components/NCGraphRenderer.js
+++ b/app/view/netcreate/components/NCGraphRenderer.js
@@ -16,7 +16,7 @@
     The data is:
       data = { nodes, edges }
       nodes = [ ...{id, label, selected,
-                    size, color, opacity, strokeColor, strokeWidth, help}],
+                    size, color, opacity, strokeColor, strokeWidth, textColor, help}],
       edges = [ ...{id, sourceId, targetId, size, color, opacity}]
 
     This uses D3 Version 4.0.
@@ -423,7 +423,7 @@ class NCGraphRenderer {
     nodeElements
       .merge(nodeElements)
       .selectAll('text')
-      .attr('fill', d => d.strokeColor)
+      .attr('fill', d => d.textColor)
       // .attr('stroke', d => d.strokeColor) // stroke overlaps on text
       // .attr('stroke-width', '0.5px') // stroke overlaps on text
       .attr('font-weight', d => {

--- a/app/view/netcreate/components/NCGraphRenderer.js
+++ b/app/view/netcreate/components/NCGraphRenderer.js
@@ -459,6 +459,7 @@ class NCGraphRenderer {
       .classed('edge', true)
       .style('stroke', e => e.color)
       .style('stroke-width', e => e.width)
+      .style('stroke-linecap', 'round')
       // Edge selection disabled.
       // .on("click",   (d) => {
       //   if (DBG) console.log('clicked on',d.label,d.id)
@@ -472,6 +473,7 @@ class NCGraphRenderer {
       // .classed("selected", e => e.selected) // is this used?
       .style('stroke', e => e.color)
       .style('stroke-width', e => e.width)
+      .style('stroke-linecap', 'round')
       .transition()
       .duration(500)
       .style('opacity', e => e.opacity);

--- a/app/view/netcreate/components/NCGraphRenderer.js
+++ b/app/view/netcreate/components/NCGraphRenderer.js
@@ -179,9 +179,10 @@ class NCGraphRenderer {
     this.zoom = d3.zoom().on('zoom', this.m_HandleZoom);
 
     /*/ Create svg element which will contain our D3 DOM elements.
-      Add default click handler so when clicking empty space, deselect all.
-      NOTE: the svg element is actualy d3.selection object, not an svg obj.
-  /*/ this.d3svg = d3
+        Add default click handler so when clicking empty space, deselect all.
+        NOTE: the svg element is actualy d3.selection object, not an svg obj.
+    /*/
+    this.d3svg = d3
       .select(rootElement)
       .append('svg')
       .attr('id', 'netgraph')
@@ -189,7 +190,9 @@ class NCGraphRenderer {
       .attr('height', '100%') // then set center dynamically below
       .on('click', (e, event) => {
         // Deselect
-        UDATA.LocalCall('SOURCE_SELECT', { nodeLabels: [] });
+        UDATA.LocalCall('D3_SELECT_NODE', { nodeLabels: [] });
+        // DEPRECATED for now 7/2023 -- use D3_SELECT_NODE instead
+        // UDATA.LocalCall('SOURCE_SELECT', { nodeLabels: [] });
       })
       .on('mouseover', d => {
         UDATA.LocalCall('USER_HILITE_NODE', { nodeId: undefined });
@@ -363,7 +366,9 @@ class NCGraphRenderer {
       )
       .on('click', d => {
         if (DBG) console.log('clicked on', d.label, d.id);
-        UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [d.id] });
+        UDATA.LocalCall('D3_SELECT_NODE', { nodeIDs: [d.id] });
+        // DEPRECATED for now 7/2023 -- use D3_SELECT_NODE instead
+        // UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [d.id] });
         d3.event.stopPropagation();
       })
       .on('mouseover', d => {

--- a/app/view/netcreate/components/NCGraphRenderer.js
+++ b/app/view/netcreate/components/NCGraphRenderer.js
@@ -15,7 +15,8 @@
 
     The data is:
       data = { nodes, edges }
-      nodes = [ ...{id, label, size, color, opacity}]
+      nodes = [ ...{id, label, selected,
+                    size, color, opacity, strokeColor, strokeWidth, help}],
       edges = [ ...{id, sourceId, targetId, size, color, opacity}]
 
     This uses D3 Version 4.0.
@@ -236,7 +237,7 @@ class NCGraphRenderer {
       // FIXME: REVIEW: is this not necessary?  Just check initialize once?
       if (!options.skipForceUpdate) this.Initialize();
       if (!options.skipForceUpdate) this.UpdateForces();
-      this.UpdateGraph();
+      this.UpdateGraph(options.skipForceUpdate);
 
       // updates ignored until this is run restarts the simulation
       // (important if simulation has already slowed down)
@@ -282,7 +283,8 @@ class NCGraphRenderer {
     This method actually does more than just "update" an existing graph; in D3
     you can write code that initializes AND updates data.
 
-/*/ UpdateGraph() {
+  /*/
+  UpdateGraph() {
     // DATA JOIN
     // select all elemnts with class .node in d3svg
     // bind selected elements with elements in this.data.nodes,
@@ -482,6 +484,75 @@ class NCGraphRenderer {
     if (this.data.edges) {
       this.simulation.force('link').links(this.data.edges);
     }
+
+    // SELECTION ARROW
+    // Theoretically can show more than one
+    this.d3svg.selectAll('#selectorArrow').remove();
+
+    // SINGLE ARROW APPROACH
+    // nodeElements
+    //   .merge(nodeElements)
+    //   .filter(d => d.selected)
+    //   .append('g')
+    //   .attr('id', 'selectorArrow')
+    //   .attr('transform', d => `translate(${- d.size - 5},0)`)
+    //   .append('polygon')
+    //   .attr('points', '0,0 -10,5 -10,-5 ')
+    //   .attr('fill', 'red')
+    //   .append('animateTransform')
+    //   .attr('attributeName', 'transform')
+    //   .attr('attributeType', 'XML')
+    //   .attr('type', 'rotate')
+    //   .attr('from', d => `0 ${d.size + 5} 0`)
+    //   .attr('to', d => `360 ${d.size + 5} 0`)
+    //   .attr('dur', '2s')
+    //   .attr('repeatCount', 'indefinite')
+
+    // MULTIPLE ARROW APPROACH
+    this.selectorArrows = nodeElements
+      .merge(nodeElements)
+      .filter(d => d.selected)
+      .append('g')
+      .attr('id', 'selectorArrow')
+      .attr('transform', d => `translate(${- d.size - 5},0)`)
+    this.selectorArrows
+      .append('polygon')
+      .attr('points', '0,0 -10,5 -10,-5 ')
+      .attr('fill', d => d.strokeColor)
+      .append('animateTransform')
+      .attr('attributeName', 'transform')
+      .attr('attributeType', 'XML')
+      .attr('type', 'rotate')
+      .attr('from', d => `0 ${d.size + 5} 0`)
+      .attr('to', d => `360 ${d.size + 5} 0`)
+      .attr('dur', '6s')
+      .attr('repeatCount', 'indefinite')
+    this.selectorArrows
+      .append('polygon')
+      .attr('transform', d => `translate(${d.size + 5},0)`)
+      .attr('points', '0,0 -10,5 -10,-5 ')
+      .attr('fill', d => d.strokeColor)
+      .append('animateTransform')
+      .attr('attributeName', 'transform')
+      .attr('attributeType', 'XML')
+      .attr('type', 'rotate')
+      .attr('from', d => `120 ${d.size + 5} 0`) // different rotation start
+      .attr('to', d => `480 ${d.size + 5} 0`) // different rotation end
+      .attr('dur', '6s')
+      .attr('repeatCount', 'indefinite')
+    this.selectorArrows
+      .append('polygon')
+      .attr('transform', d => `translate(${d.size + 5},0)`)
+      .attr('points', '0,0 -10,5 -10,-5 ')
+      .attr('fill', d => d.strokeColor)
+      .append('animateTransform')
+      .attr('attributeName', 'transform')
+      .attr('attributeType', 'XML')
+      .attr('type', 'rotate')
+      .attr('from', d => `240 ${d.size + 5} 0`) // different rotation start
+      .attr('to', d => `600 ${d.size + 5} 0`) // different rotation end
+      .attr('dur', '6s')
+      .attr('repeatCount', 'indefinite')
   }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/view/netcreate/components/NCGraphRenderer.js
+++ b/app/view/netcreate/components/NCGraphRenderer.js
@@ -26,6 +26,7 @@
       nodes = [ ...{ id :number,
                      label :string,
                      selected :boolean,
+                     selectedSecondary :boolean,  // for selected source/target node
                      size :number,
                      color :string(css),
                      opacity :number(0-1),
@@ -536,6 +537,7 @@ class NCGraphRenderer {
 
     // SELECTION ARROW
     this.d3svg.selectAll('#selectorArrow').remove();
+    this.d3svg.selectAll('#secondarySelectorArrow').remove();
 
     // SINGLE ARROW APPROACH
     // nodeElements
@@ -601,6 +603,27 @@ class NCGraphRenderer {
       .attr('to', d => `600 ${d.size + 5} 0`) // different rotation end
       .attr('dur', '6s')
       .attr('repeatCount', 'indefinite')
+
+    // SECONDARY SELECTOR ARROW
+    nodeElements
+      .merge(nodeElements)
+      .filter(d => d.selectedSecondary)
+      .append('g')
+      .attr('id', 'secondarySelectorArrow')
+      .attr('transform', d => `translate(${- d.size - 5},0)`)
+      .append('polygon')
+      .attr('points', '0,0 -10,5 -10,-5 ')
+      .attr('fill', 'blue')
+      // .attr('fill', d => d.strokeColor)
+      .append('animateTransform')
+      .attr('attributeName', 'transform')
+      .attr('attributeType', 'XML')
+      .attr('type', 'rotate')
+      .attr('from', d => `0 ${d.size + 5} 0`)
+      .attr('to', d => `360 ${d.size + 5} 0`)
+      .attr('dur', '2s')
+      .attr('repeatCount', 'indefinite')
+
   }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/view/netcreate/components/NCGraphRenderer.js
+++ b/app/view/netcreate/components/NCGraphRenderer.js
@@ -559,7 +559,7 @@ class NCGraphRenderer {
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /*/ Apply new force properties
-    Call this on construct and if forceProperties have changed.
+      Call this on construct and if forceProperties have changed.
   /*/
   UpdateForces() {
     this.simulation

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -73,6 +73,9 @@
   padding: 0 8px;
   text-align: left;
 }
+.nccomponent button.sourcetargetbtn.selected {
+  outline: 1px solid blue;
+}
 .nccomponent button.sourcetargetbtn:disabled {
   border: none;
   color: #333;

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -8,7 +8,7 @@
   z-index: 1;
 }
 
-.ncnode {
+.nccomponent {
   background-color: #fff; /* knock out gray body bg */
   border-radius: 15px;
   position: relative;
@@ -16,7 +16,7 @@
 }
 
 /* HTML Components */
-.ncnode button {
+.nccomponent button {
   background-color: #fff6;
   border-radius: 5px;
   border-color: #0006;
@@ -25,13 +25,17 @@
   color: #333;
   margin-left: 15px;
 }
-.ncnode button:disabled {
+.nccomponent button:hover,
+.nccomponent button.cancelbtn:hover {
+  background-color: #fff9;
+}
+.nccomponent button:disabled {
   background-color: #fff3;
   border-color: #0003;
   color: #3333;
   cursor: not-allowed;
 }
-.ncnode input {
+.nccomponent input {
   width: 100%;
   border-radius: 5px;
   border-color: #0006;
@@ -41,7 +45,7 @@
   margin-bottom: 5px;
   padding: 0 5px;
 }
-.ncnode select {
+.nccomponent select {
   width: 100%;
   border-radius: 5px;
   border-color: #0006;
@@ -51,40 +55,64 @@
   margin-bottom: 5px;
 }
 /* HTML Component Subtypes */
-.ncnode button.cancelbtn {
+.nccomponent button.cancelbtn {
   background-color: transparent;
   border-color: #999;
   color: #666;
 }
 
 /* Text Style */
-.ncnode .message {
+.nccomponent .message {
   font-size: 12px;
 }
-.ncnode .warning {
+.nccomponent .warning {
   color: red;
 }
 
 /* Layout Components */
+.nccomponent.ncedge {
+  /* position: fixed;
+  left: 290px;
+  top: 130px; */
+  /* margin: 0 20px; */
+  margin: 10px 0;
+  height: 0;
+  overflow: hidden;
+  z-index: 15;
+}
+.nccomponent.ncedge.fullheight {
+  height: fit-content;
+  transition-property: height;
+  transition-duration: 4s;
+  transition-timing-function: ease-in-out;
+  transition-delay: 2s;
+}
 
-.ncnode .view,
-.ncnode .edit {
+.nccomponent.ncedge,
+.nccomponent.ncedge .view,
+.nccomponent.ncedge .edit {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.nccomponent .view,
+.nccomponent .edit {
   border-radius: 15px;
   padding: 8px;
 }
 
-.ncnode .edit {
+.nccomponent .edit {
   border: 2px;
   border-style: solid;
 }
 
-.ncnode .nodelabel {
+.nccomponent .nodelabel {
   padding: 5px 10px;
   font-size: 18px;
   font-weight: bold;
   overflow: hidden;
 }
-.ncnode .matchlist {
+.nccomponent .matchlist {
   position: fixed;
   color: #3339;
   background-color: #fff;
@@ -93,7 +121,7 @@
   font-size: 12px;
   z-index: 15;
 }
-.ncnode .edgebutton {
+.nccomponent .edgebutton {
   background-color: #0003;
   border-radius: 10px;
   border-color: transparent;
@@ -102,32 +130,32 @@
   text-align: left;
   overflow: hidden;
 }
-.ncnode .formview {
+.nccomponent .formview {
   display: grid;
   grid-template-columns: 70px auto;
   column-gap: 10px;
 }
-.ncnode .formview label {
+.nccomponent .formview label {
   font-size: 10px;
   line-height: 18px;
   opacity: 0.7;
   text-align: right;
 }
-.ncnode .formview div {
+.nccomponent .formview div {
   padding-left: 10px;
   font-size: 16px;
   text-align: left;
   opacity: 1;
 }
 
-.ncnode .tabcontainer {
+.nccomponent .tabcontainer {
 }
-.ncnode .tabcontainer .tabselectors {
+.nccomponent .tabcontainer .tabselectors {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   padding-top: 3px;
 }
-.ncnode .tabcontainer .tabselectors button {
+.nccomponent .tabcontainer .tabselectors button {
   border: none;
   color: #0006;
   background-color: transparent;
@@ -135,32 +163,32 @@
   font-size: 10px;
   overflow: hidden;
 }
-.ncnode .tabcontainer .tabselectors button:hover {
+.nccomponent .tabcontainer .tabselectors button:hover {
   background-color: #fff2;
 }
-.ncnode .tabcontainer .tabselectors button.selected {
+.nccomponent .tabcontainer .tabselectors button.selected {
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
   color: #666;
   background-color: #fff4;
 }
-.ncnode .tabcontainer .tabselectors button.selected:focus {
+.nccomponent .tabcontainer .tabselectors button.selected:focus {
   outline: none;
 }
-.ncnode .tabcontainer .tabview {
+.nccomponent .tabcontainer .tabview {
   padding: 10px 5px 5px 5px;
   background-color: #fff4;
 }
-.ncnode .provenance label {
+.nccomponent .provenance label {
   line-height: 12px;
   margin-bottom: 0.25rem; /* override bootstrap */
 }
-.ncnode .provenance div {
+.nccomponent .provenance div {
   font-size: 10px;
   opacity: 0.7;
 }
 
-.ncnode .controlbar {
+.nccomponent .controlbar {
   display: flex;
   justify-content: flex-end;
   padding: 10px 0 0 0;

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -122,6 +122,7 @@
   transition-duration: 4s;
   transition-timing-function: ease-in-out;
   transition-delay: 2s;
+  overflow: visible; /* show "click on node" help */
 }
 
 .nccomponent.ncedge,
@@ -247,7 +248,7 @@
 
 .nccomponent .formview .helptop {
   position: absolute;
-  margin-top: -22px;
+  bottom: 120%;
   padding: 0 5px;
   color: #666;
   background-color: #ff0c;

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -51,6 +51,21 @@
   outline: #f00;
   border-color: #f00;
 }
+.nccomponent textarea {
+  width: 100%;
+  border-radius: 2px;
+  border-color: #0006;
+  border-width: 1px;
+  border-style: solid;
+  background-color: #fff8;
+  margin-bottom: 5px;
+  padding: 0 5px;
+  resize: none;
+}
+.nccomponent textarea.long {
+  padding: 0 5px;
+  resize: vertical;
+}
 .nccomponent select {
   width: 100%;
   border-radius: 5px;

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -238,10 +238,12 @@
 .nccomponent .controlbar {
   display: flex;
   justify-content: flex-end;
+  align-items: top;
   padding: 10px 0 0 0;
 }
 
 .nccomponent .controlbar.deletenode {
+  justify-content: space-between;
   background-color: #0003;
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
@@ -249,8 +251,9 @@
   padding: 10px;
 }
 .nccomponent .controlbar .deleteinput {
-  width: 4em;
+  width: 7em;
+  margin: 0px;
 }
 .nccomponent .controlbar .deleteinput.invalid {
-  border: 1px solid red;
+  border: 5px double red;
 }

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -224,8 +224,33 @@
   opacity: 0.7;
 }
 
+.nccomponent .titlebar {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.nccomponent .titlebar .nodenumber {
+  font-size: 12px;
+  color: #0005;
+  padding-right: 2px;
+}
+
 .nccomponent .controlbar {
   display: flex;
   justify-content: flex-end;
   padding: 10px 0 0 0;
+}
+
+.nccomponent .controlbar.deletenode {
+  background-color: #0003;
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+  margin-top: 10px;
+  padding: 10px;
+}
+.nccomponent .controlbar .deleteinput {
+  width: 4em;
+}
+.nccomponent .controlbar .deleteinput.invalid {
+  border: 1px solid red;
 }

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -152,26 +152,7 @@
   text-align: left;
   overflow: hidden;
 }
-.nccomponent .matchlist {
-  position: fixed;
-  color: #3339;
-  background-color: #fff;
-  margin: -5px 0 0 10px;
-  padding: 3px 0;
-  font-size: 12px;
-  z-index: 15;
-}
-.nccomponent .matchlist div {
-  padding: 0 10px;
-}
-.nccomponent .matchlist div:hover {
-  background-color: #ddd;
-  cursor: pointer;
-}
-.nccomponent .matchlist div.highlighted {
-  background-color: #ccc;
-  cursor: pointer;
-}
+
 .nccomponent .formview {
   display: grid;
   grid-template-columns: 70px auto;
@@ -247,13 +228,4 @@
   display: flex;
   justify-content: flex-end;
   padding: 10px 0 0 0;
-}
-
-.nccomponent .formview .helptop {
-  position: absolute;
-  bottom: 120%;
-  padding: 0 5px;
-  color: #666;
-  background-color: #ff0c;
-  font-size: 12px;
 }

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -63,7 +63,7 @@
   outline: none;
 }
 .ncnode .tabcontainer .tabview {
-  padding: 5px;
+  padding: 10px 5px 5px 5px;
   background-color: #fff4;
 }
 .ncnode .provenance label {

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -1,0 +1,76 @@
+.ncnode {
+  border-radius: 15px;
+  padding: 8px;
+}
+
+.ncnode .nodelabel {
+  padding: 5px 10px;
+  font-size: 18px;
+  font-weight: bold;
+  overflow: hidden;
+}
+.ncnode .edgebutton {
+  background-color: #0003;
+  border-radius: 10px;
+  border-color: transparent;
+  width: 100%;
+  margin-bottom: 3px;
+  text-align: left;
+  overflow: hidden;
+}
+.ncnode .formview {
+  display: grid;
+  grid-template-columns: 70px auto;
+}
+.ncnode .formview label {
+  font-size: 10px;
+  line-height: 18px;
+  opacity: 0.7;
+  text-align: right;
+}
+.ncnode .formview div {
+  padding-left: 10px;
+  font-size: 16px;
+  text-align: left;
+  opacity: 1;
+}
+
+.ncnode .tabcontainer {
+}
+.ncnode .tabcontainer .tabselectors {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  padding-top: 3px;
+}
+.ncnode .tabcontainer .tabselectors button {
+  border: none;
+  color: #999;
+  background-color: transparent;
+  height: 25px;
+  font-size: 10px;
+  overflow: hidden;
+}
+.ncnode .tabcontainer .tabselectors button:hover {
+  background-color: #fff2;
+}
+.ncnode .tabcontainer .tabselectors button.selected {
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  color: #666;
+  background-color: #fff4;
+}
+.ncnode .tabcontainer .tabselectors button.selected:focus {
+  outline: none;
+}
+.ncnode .tabcontainer .tabview {
+  padding: 5px;
+  background-color: #fff4;
+}
+.ncnode .provenance label {
+  line-height: 12px;
+  margin-bottom: 0.25rem; /* override bootstrap */
+}
+.ncnode .provenance div {
+  font-size: 10px;
+  opacity: 0.7;
+}

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -12,6 +12,7 @@
   background-color: #fff; /* knock out gray body bg */
   border-radius: 15px;
   position: relative;
+  font-size: 14px;
   z-index: 10;
 }
 
@@ -37,13 +38,18 @@
 }
 .nccomponent input {
   width: 100%;
-  border-radius: 5px;
+  border-radius: 2px;
   border-color: #0006;
   border-width: 1px;
   border-style: solid;
   background-color: #fff8;
   margin-bottom: 5px;
   padding: 0 5px;
+}
+.nccomponent input.invalid,
+.nccomponent input.invalid:focus {
+  outline: #f00;
+  border-color: #f00;
 }
 .nccomponent select {
   width: 100%;
@@ -59,6 +65,36 @@
   background-color: transparent;
   border-color: #999;
   color: #666;
+}
+.nccomponent button.sourcetargetbtn {
+  border-radius: 15px;
+  width: 100%;
+  margin-left: 0;
+  padding: 0 8px;
+  text-align: left;
+}
+.nccomponent button.sourcetargetbtn:disabled {
+  border: none;
+  color: #333;
+}
+.nccomponent button.swapbtn {
+  font-size: 18px;
+  line-height: 18px;
+  width: 25px;
+  margin: 7px 0 5px 0;
+  padding: 3px;
+}
+.nccomponent button.edgebutton {
+  background-color: #0003;
+  border-radius: 10px;
+  border-color: transparent;
+  width: 100%;
+  margin: 0 0 3px 0;
+  text-align: left;
+  overflow: hidden;
+}
+.nccomponent button.addedgebutton {
+  margin: 5px;
 }
 
 /* Text Style */
@@ -92,7 +128,7 @@
 .nccomponent.ncedge .view,
 .nccomponent.ncedge .edit {
   border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .nccomponent .view,
@@ -108,32 +144,35 @@
 
 .nccomponent .nodelabel {
   padding: 5px 10px;
-  font-size: 18px;
   font-weight: bold;
+  text-align: left;
   overflow: hidden;
 }
 .nccomponent .matchlist {
   position: fixed;
   color: #3339;
   background-color: #fff;
-  margin: -10px 0 0 10px;
-  padding: 3px 10px;
+  margin: -5px 0 0 10px;
+  padding: 3px 0;
   font-size: 12px;
   z-index: 15;
 }
-.nccomponent .edgebutton {
-  background-color: #0003;
-  border-radius: 10px;
-  border-color: transparent;
-  width: 100%;
-  margin: 0 0 3px 0;
-  text-align: left;
-  overflow: hidden;
+.nccomponent .matchlist div {
+  padding: 0 10px;
+}
+.nccomponent .matchlist div:hover {
+  background-color: #ddd;
+  cursor: pointer;
+}
+.nccomponent .matchlist div.highlighted {
+  background-color: #ccc;
+  cursor: pointer;
 }
 .nccomponent .formview {
   display: grid;
   grid-template-columns: 70px auto;
   column-gap: 10px;
+  margin-bottom: 10px;
 }
 .nccomponent .formview label {
   font-size: 10px;
@@ -141,18 +180,25 @@
   opacity: 0.7;
   text-align: right;
 }
-.nccomponent .formview div {
+.nccomponent .formview .viewvalue {
   padding-left: 10px;
-  font-size: 16px;
   text-align: left;
   opacity: 1;
+  overflow: hidden;
+  overflow-wrap: anywhere; /* prevents form extending into graph */
 }
-
+.nccomponent .formview div.targetarrow {
+  margin-top: -5px;
+  text-align: center;
+  font-size: 18px;
+  font-weight: bold;
+}
 .nccomponent .tabcontainer {
+  margin-top: 5px;
 }
 .nccomponent .tabcontainer .tabselectors {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: 1fr; /* overriden */
   padding-top: 3px;
 }
 .nccomponent .tabcontainer .tabselectors button {
@@ -169,15 +215,20 @@
 .nccomponent .tabcontainer .tabselectors button.selected {
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
+  border-bottom-left-radius: 0px;
+  border-bottom-right-radius: 0px;
   color: #666;
-  background-color: #fff4;
+  background-color: #fff8;
 }
 .nccomponent .tabcontainer .tabselectors button.selected:focus {
   outline: none;
 }
 .nccomponent .tabcontainer .tabview {
   padding: 10px 5px 5px 5px;
-  background-color: #fff4;
+  background-color: #fff8;
+}
+.nccomponent .tabcontainer .tabview .edges {
+  text-align: center;
 }
 .nccomponent .provenance label {
   line-height: 12px;
@@ -192,4 +243,13 @@
   display: flex;
   justify-content: flex-end;
   padding: 10px 0 0 0;
+}
+
+.nccomponent .formview .helptop {
+  position: absolute;
+  margin-top: -22px;
+  padding: 0 5px;
+  color: #666;
+  background-color: #ff0c;
+  font-size: 12px;
 }

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -1,4 +1,62 @@
 .ncnode {
+  background-color: #fff; /* knock out gray body bg */
+  border-radius: 15px;
+}
+
+/* HTML Components */
+.ncnode button {
+  background-color: #fff6;
+  border-radius: 5px;
+  border-color: #0006;
+  border-width: 1px;
+  border-style: solid;
+  color: #333;
+  margin-left: 15px;
+}
+.ncnode button:disabled {
+  background-color: #fff3;
+  border-color: #0003;
+  color: #3333;
+  cursor: not-allowed;
+}
+.ncnode input {
+  width: 100%;
+  border-radius: 5px;
+  border-color: #0006;
+  border-width: 1px;
+  border-style: solid;
+  background-color: #fff8;
+  margin-bottom: 5px;
+  padding: 0 5px;
+}
+.ncnode select {
+  width: 100%;
+  border-radius: 5px;
+  border-color: #0006;
+  border-width: 1px;
+  border-style: solid;
+  background-color: #fff8;
+  margin-bottom: 5px;
+}
+/* HTML Component Subtypes */
+.ncnode button.cancelbtn {
+  background-color: transparent;
+  border-color: #999;
+  color: #666;
+}
+
+/* Text Style */
+.ncnode .message {
+  font-size: 12px;
+}
+.ncnode .warning {
+  color: red;
+}
+
+/* Layout Components */
+
+.ncnode .view,
+.ncnode .edit {
   border-radius: 15px;
   padding: 8px;
 }
@@ -21,6 +79,7 @@
 .ncnode .formview {
   display: grid;
   grid-template-columns: 70px auto;
+  column-gap: 10px;
 }
 .ncnode .formview label {
   font-size: 10px;
@@ -44,7 +103,7 @@
 }
 .ncnode .tabcontainer .tabselectors button {
   border: none;
-  color: #999;
+  color: #0006;
   background-color: transparent;
   height: 25px;
   font-size: 10px;
@@ -73,4 +132,10 @@
 .ncnode .provenance div {
   font-size: 10px;
   opacity: 0.7;
+}
+
+.ncnode .controlbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 10px 0 0 0;
 }

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -1,6 +1,18 @@
+.screen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #0003;
+  z-index: 1;
+}
+
 .ncnode {
   background-color: #fff; /* knock out gray body bg */
   border-radius: 15px;
+  position: relative;
+  z-index: 10;
 }
 
 /* HTML Components */

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -84,6 +84,15 @@
   font-weight: bold;
   overflow: hidden;
 }
+.ncnode .matchlist {
+  position: fixed;
+  color: #3339;
+  background-color: #fff;
+  margin: -10px 0 0 10px;
+  padding: 3px 10px;
+  font-size: 12px;
+  z-index: 15;
+}
 .ncnode .edgebutton {
   background-color: #0003;
   border-radius: 10px;

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -61,6 +61,11 @@
   padding: 8px;
 }
 
+.ncnode .edit {
+  border: 2px;
+  border-style: solid;
+}
+
 .ncnode .nodelabel {
   padding: 5px 10px;
   font-size: 18px;
@@ -72,7 +77,7 @@
   border-radius: 10px;
   border-color: transparent;
   width: 100%;
-  margin-bottom: 3px;
+  margin: 0 0 3px 0;
   text-align: left;
   overflow: hidden;
 }

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -225,7 +225,7 @@ class NCNode extends UNISYS.Component {
    * SessionShell.componentWillMount()
    */
   updateSession(decoded) {
-    this.setState({ isLoggedIn: decoded.isValid });
+    this.setState({ isLoggedIn: decoded.isValid }, () => this.updatePermissions());
   }
   /*
       Called by NCDATA AppState updates

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -1,0 +1,293 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+    Prototype Simple NetCreate Node Editor
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+const DBG = false;
+const PR = 'NCNode';
+
+/// LIBRARIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const React = require('react');
+const UNISYS = require('unisys/client');
+const EDGEMGR = require('../edge-mgr'); // handles edge synthesis
+
+let UDATA;
+
+const VIEWMODE = {
+  EDIT: 'edit',
+  VIEW: 'view'
+};
+const TABS = {
+  // Also used as labels
+  ATTRIBUTES: 'ATTRIBUTES',
+  EDGES: 'EDGES',
+  PROVENANCE: 'PROVENANCE'
+};
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// export a class object for consumption by brunch/require
+class NCNode extends UNISYS.Component {
+  constructor(props) {
+    super(props);
+
+    this.clearSelection = this.clearSelection.bind(this);
+    this.updateSelection = this.updateSelection.bind(this);
+    this.loadNode = this.loadNode.bind(this);
+    this.loadEdges = this.loadEdges.bind(this);
+    this.uiSelectTab = this.uiSelectTab.bind(this);
+    this.renderView = this.renderView.bind(this);
+    this.renderEdit = this.renderEdit.bind(this);
+    this.renderTabSelectors = this.renderTabSelectors.bind(this);
+    this.renderAttributesTab = this.renderAttributesTab.bind(this);
+    this.renderEdgesTab = this.renderEdgesTab.bind(this);
+    this.renderProvenanceTab = this.renderProvenanceTab.bind(this);
+    this.renderLabel = this.renderLabel.bind(this);
+    this.renderStringValue = this.renderStringValue.bind(this);
+
+    /// Initialize UNISYS DATA LINK for REACT
+    UDATA = UNISYS.NewDataLink(this);
+
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    /// REGISTER LISTENERS
+    UDATA.OnAppStateChange('SELECTION', this.updateSelection);
+  }
+
+  componentWillMount() {
+    this.clearSelection(); // Initialize State
+  }
+  componentWillUnmount() {
+    UDATA.AppStateChangeOff('SELECTION', this.updateSelection);
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// EVENT HANDLERS
+  clearSelection() {
+    this.setState({
+      viewMode: VIEWMODE.VIEW,
+      selectedTab: TABS.ATTRIBUTES,
+      backgroundColor: 'transparent',
+      // NODE DEFS
+      id: null,
+      label: '',
+      attributes: [],
+      provenance: [],
+      created: undefined,
+      updated: undefined,
+      revision: 0,
+      // EDGES
+      edges: []
+    });
+  }
+  updateSelection(data) {
+    const node = data.nodes[0]; // select the first node
+    this.loadNode(node);
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// DATA LOADING
+  loadNode(node) {
+    if (!node) {
+      this.clearSelection();
+      return;
+    }
+    // REVIEW: Does ui-mgr define this mapping?  Or do we read it from the template?
+    const attributes = {
+      type: node.type,
+      notes: node.notes,
+      info: node.info
+    };
+    this.setState(
+      {
+        id: node.id,
+        label: node.label,
+        attributes: attributes,
+        provenance: node.provenance,
+        created: node.created,
+        updated: node.updated,
+        revision: node.revision
+      },
+      () => {
+        this.setBackgroundColor();
+        this.loadEdges(node.id);
+      }
+    );
+  }
+  loadEdges(id) {
+    // -- First, sort edges by source, then target
+    const NCDATA = UDATA.AppState('NCDATA');
+    const linkedEdges = NCDATA.edges.filter(e => e.source === id || e.target === id);
+    linkedEdges.sort((a, b) => {
+      // same source label, sort on target
+      if (a.sourceLabel === b.sourceLabel) {
+        if (a.targetLabel < b.targetLabel) return -1;
+        if (a.targetLabel > b.targetLabel) return 1;
+      }
+      // Always list `this` node first
+      if (a.source === id) return -1;
+      if (b.source === id) return 1;
+      // Otherwise sort on source
+      if (a.sourceLabel < b.sourceLabel) return -1;
+      if (a.sourceLabel > b.sourceLabel) return 1;
+      return 0;
+    });
+    this.setState({ edges: linkedEdges });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// HELPER METHODS
+  setBackgroundColor() {
+    // This will eventually be replaced with a proper color manager
+    const { attributes } = this.state;
+    const type = attributes ? attributes.type : undefined;
+    if (!type) return;
+    const COLORMAP = UDATA.AppState('COLORMAP');
+    this.setState({ backgroundColor: COLORMAP.nodeColorMap[type] });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// UI EVENT HANDLERS
+  uiSelectTab(event) {
+    this.setState({ selectedTab: event.target.value });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// RENDER METHODS
+  renderView() {
+    const { selectedTab, backgroundColor, id, label } = this.state;
+    const bgcolor = backgroundColor + '33'; // hack opacity
+    return (
+      <div
+        className="ncnode view"
+        style={{
+          background: bgcolor
+        }}
+      >
+        {/* BUILT-IN - - - - - - - - - - - - - - - - - */}
+        <div className="nodelabel">{this.renderStringValue(id, 'LABEL', label)}</div>
+        {/* TABS - - - - - - - - - - - - - - - - - - - */}
+        <div className="tabcontainer">
+          {this.renderTabSelectors()}
+          <div className="tabview">
+            {selectedTab === TABS.ATTRIBUTES && this.renderAttributesTab()}
+            {selectedTab === TABS.EDGES && this.renderEdgesTab()}
+            {selectedTab === TABS.PROVENANCE && this.renderProvenanceTab()}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  renderEdit() {}
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// RENDER HELPERS
+  renderTabSelectors() {
+    const { selectedTab } = this.state;
+    return (
+      <div className="tabselectors">
+        {Object.keys(TABS).map(k => {
+          return (
+            <button
+              id={k}
+              key={k}
+              type="button"
+              className={selectedTab === TABS[k] ? 'selected' : ''}
+              onClick={this.uiSelectTab}
+              value={TABS[k]}
+            >
+              {TABS[k]}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+  renderAttributesTab() {
+    const { id, attributes } = this.state;
+    const items = [];
+    Object.keys(attributes).forEach(k => {
+      items.push(this.renderLabel(id, k));
+      items.push(this.renderStringValue(id, k, attributes[k]));
+    });
+    return <div className="formview">{items}</div>;
+  }
+  renderEdgesTab() {
+    const { id, label, edges } = this.state;
+    const NCDATA = UDATA.AppState('NCDATA');
+    const TEMPLATE = UDATA.AppState('TEMPLATE');
+    const me = (
+      <span style={{ color: 'rgba(0,0,0,0.2)', fontStyle: 'italic' }}>this node</span>
+    );
+    return (
+      <div className="edges">
+        {edges.map(e => {
+          const sourceNode = NCDATA.nodes.find(n => n.id === e.source);
+          const targetNode = NCDATA.nodes.find(n => n.id === e.target);
+          const color = EDGEMGR.LookupEdgeColor(e, TEMPLATE);
+          const bgcolor = color + '33'; // opacity hack
+          return (
+            <div key={e.id}>
+              <button
+                size="sm"
+                className="edgebutton"
+                onClick={this.onEdgeClick}
+                style={{ backgroundColor: bgcolor }}
+              >
+                {id === e.source ? me : sourceNode.label}
+                &nbsp;<span title={e.type}>&#x2794;</span>&nbsp;
+                {id === e.target ? me : targetNode.label}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+  renderProvenanceTab() {
+    const { id, provenance, created, updated, revision } = this.state;
+    return (
+      <div className="provenance formview">
+        {this.renderLabel(id, 'PROVENANCE')}
+        {this.renderStringValue(id, 'PROVENANCE', provenance)}
+        {this.renderLabel(id, 'CREATED')}
+        {this.renderStringValue(id, 'CREATED', created)}
+        {this.renderLabel(id, 'UPDATED')}
+        {this.renderStringValue(id, 'UPDATED', updated)}
+        {this.renderLabel(id, 'REVISION')}
+        {this.renderStringValue(id, 'REVISION', revision)}
+      </div>
+    );
+  }
+  renderLabel(id, label) {
+    return (
+      <label htmlFor={`${id}.${label}`} key={`${id}.${label}label`}>
+        {label}
+      </label>
+    );
+  }
+  renderStringValue(id, label, value) {
+    return (
+      <div id={`${id}.${label}`} key={`${id}.${label}value`}>
+        {value}
+      </div>
+    );
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// MAIN RENDER
+  render() {
+    const { id, viewMode } = this.state;
+    if (!id) return ''; // nothing selected
+    if (viewMode === VIEWMODE.VIEW) {
+      return this.renderView();
+    }
+    return this.renderEdit();
+  }
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = NCNode;

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -824,7 +824,7 @@ class NCNode extends UNISYS.Component {
             onClick={this.UIAddEdge}
             disabled={editBtnDisable}
           >
-            Add New Edge
+            New Edge
           </button>
         )}
       </div>

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -46,6 +46,7 @@ const React = require('react');
 const UNISYS = require('unisys/client');
 const EDGEMGR = require('../edge-mgr'); // handles edge synthesis
 const { EDITORTYPE } = require('system/util/enum');
+const NCUI = require('../nc-ui');
 const NCEdge = require('./NCEdge');
 
 let UDATA;
@@ -83,91 +84,79 @@ class NCNode extends UNISYS.Component {
     }; // initialized on componentDidMount and clearSelection
 
     // STATE MANAGEMENT
-    this.resetState = this.resetState.bind(this);
-    this.updateSession = this.updateSession.bind(this);
+    this.ResetState = this.ResetState.bind(this);
+    this.UpdateSession = this.UpdateSession.bind(this);
     this.UpdateNCData = this.UpdateNCData.bind(this);
-    this.setPermissions = this.setPermissions.bind(this);
-    this.updatePermissions = this.updatePermissions.bind(this);
+    this.SetPermissions = this.SetPermissions.bind(this);
+    this.UpdatePermissions = this.UpdatePermissions.bind(this);
 
     // EVENT HANDLERS
-    this.checkUnload = this.checkUnload.bind(this);
-    this.doUnload = this.doUnload.bind(this);
-    this.clearSelection = this.clearSelection.bind(this);
-    this.updateSelection = this.updateSelection.bind(this);
-    this.selectEdgeAndEdit = this.selectEdgeAndEdit.bind(this);
-    this.deselectEdge = this.deselectEdge.bind(this);
+    this.CheckUnload = this.CheckUnload.bind(this);
+    this.DoUnload = this.DoUnload.bind(this);
+    this.ClearSelection = this.ClearSelection.bind(this);
+    this.UpdateSelection = this.UpdateSelection.bind(this);
+    this.SelectEdgeAndEdit = this.SelectEdgeAndEdit.bind(this);
+    this.SeselectEdge = this.SeselectEdge.bind(this);
     // DATA LOADING
-    this.loadNode = this.loadNode.bind(this);
-    this.loadEdges = this.loadEdges.bind(this);
-    this.loadAttributes = this.loadAttributes.bind(this);
-    this.lockNode = this.lockNode.bind(this);
-    this.unlockNode = this.unlockNode.bind(this);
-    this.isNodeLocked = this.isNodeLocked.bind(this);
-    this.saveNode = this.saveNode.bind(this);
+    this.LoadNode = this.LoadNode.bind(this);
+    this.LoadEdges = this.LoadEdges.bind(this);
+    this.LoadAttributes = this.LoadAttributes.bind(this);
+    this.LockNode = this.LockNode.bind(this);
+    this.UnlockNode = this.UnlockNode.bind(this);
+    this.IsNodeLocked = this.IsNodeLocked.bind(this);
+    this.SaveNode = this.SaveNode.bind(this);
     // HELPER METHODS
-    this.setBackgroundColor = this.setBackgroundColor.bind(this);
+    this.SetBackgroundColor = this.SetBackgroundColor.bind(this);
     // UI HANDLERS
-    this.uiSelectTab = this.uiSelectTab.bind(this);
-    this.uiRequestEditNode = this.uiRequestEditNode.bind(this);
+    this.UISelectTab = this.UISelectTab.bind(this);
+    this.UIRequestEditNode = this.UIRequestEditNode.bind(this);
     this.UIAddEdge = this.UIAddEdge.bind(this);
-    this.enableEditMode = this.enableEditMode.bind(this);
-    this.uiCancelEditMode = this.uiCancelEditMode.bind(this);
-    this.uiDisableEditMode = this.uiDisableEditMode.bind(this);
-    this.uiStringInputUpdate = this.uiStringInputUpdate.bind(this);
-    this.uiLabelInputUpdate = this.uiLabelInputUpdate.bind(this);
-    this.uiNumberInputUpdate = this.uiNumberInputUpdate.bind(this);
-    this.uiSelectInputUpdate = this.uiSelectInputUpdate.bind(this);
-    this.uiViewEdge = this.uiViewEdge.bind(this);
+    this.EnableEditMode = this.EnableEditMode.bind(this);
+    this.UICancelEditMode = this.UICancelEditMode.bind(this);
+    this.UIDisableEditMode = this.UIDisableEditMode.bind(this);
+    this.UIInputUpdate = this.UIInputUpdate.bind(this);
+    this.UILabelInputUpdate = this.UILabelInputUpdate.bind(this);
+    this.UIViewEdge = this.UIViewEdge.bind(this);
     this.UIEditEdge = this.UIEditEdge.bind(this);
     // RENDERERS -- Main
-    this.renderView = this.renderView.bind(this);
-    this.renderEdit = this.renderEdit.bind(this);
+    this.RenderView = this.RenderView.bind(this);
+    this.RenderEdit = this.RenderEdit.bind(this);
     // RENDER HELPERS
-    this.renderTabSelectors = this.renderTabSelectors.bind(this);
-    this.renderAttributesTabView = this.renderAttributesTabView.bind(this);
-    this.renderAttributesTabEdit = this.renderAttributesTabEdit.bind(this);
-    this.renderEdgesTab = this.renderEdgesTab.bind(this);
-    this.renderProvenanceTab = this.renderProvenanceTab.bind(this);
-    this.renderLabel = this.renderLabel.bind(this);
-    this.renderStringValue = this.renderStringValue.bind(this);
-    this.renderStringInput = this.renderStringInput.bind(this);
-    this.renderLabelInput = this.renderLabelInput.bind(this);
-    this.renderNumberInput = this.renderNumberInput.bind(this);
-    this.renderOptionsInput = this.renderOptionsInput.bind(this);
+    this.RenderEdgesTab = this.RenderEdgesTab.bind(this);
 
     /// Initialize UNISYS DATA LINK for REACT
     UDATA = UNISYS.NewDataLink(this);
 
     /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     /// REGISTER LISTENERS
-    UDATA.OnAppStateChange('SESSION', this.updateSession);
+    UDATA.OnAppStateChange('SESSION', this.UpdateSession);
     UDATA.OnAppStateChange('NCDATA', this.UpdateNCData);
-    UDATA.OnAppStateChange('SELECTION', this.updateSelection);
-    UDATA.HandleMessage('EDIT_PERMISSIONS_UPDATE', this.setPermissions);
-    UDATA.HandleMessage('NODE_EDIT', this.uiRequestEditNode); // Node Table request
-    UDATA.HandleMessage('EDGE_SELECT_AND_EDIT', this.selectEdgeAndEdit);
-    UDATA.HandleMessage('EDGE_DESELECT', this.deselectEdge);
+    UDATA.OnAppStateChange('SELECTION', this.UpdateSelection);
+    UDATA.HandleMessage('EDIT_PERMISSIONS_UPDATE', this.SetPermissions);
+    UDATA.HandleMessage('NODE_EDIT', this.UIRequestEditNode); // Node Table request
+    UDATA.HandleMessage('EDGE_SELECT_AND_EDIT', this.SelectEdgeAndEdit);
+    UDATA.HandleMessage('EDGE_DESELECT', this.SeselectEdge);
   }
 
   componentDidMount() {
-    this.resetState(); // Initialize State
-    window.addEventListener('beforeunload', this.checkUnload);
-    window.addEventListener('unload', this.doUnload);
+    this.ResetState(); // Initialize State
+    window.addEventListener('beforeunload', this.CheckUnload);
+    window.addEventListener('unload', this.DoUnload);
   }
   componentWillUnmount() {
-    UDATA.AppStateChangeOff('SESSION', this.updateSession);
+    UDATA.AppStateChangeOff('SESSION', this.UpdateSession);
     UDATA.AppStateChangeOff('NCDATA', this.UpdateNCData);
-    UDATA.AppStateChangeOff('SELECTION', this.updateSelection);
-    UDATA.UnhandleMessage('EDIT_PERMISSIONS_UPDATE', this.setPermissions);
-    UDATA.UnhandleMessage('NODE_EDIT', this.uiRequestEditNode);
-    window.removeEventListener('beforeunload', this.checkUnload);
-    window.removeEventListener('unload', this.doUnload);
+    UDATA.AppStateChangeOff('SELECTION', this.UpdateSelection);
+    UDATA.UnhandleMessage('EDIT_PERMISSIONS_UPDATE', this.SetPermissions);
+    UDATA.UnhandleMessage('NODE_EDIT', this.UIRequestEditNode);
+    window.removeEventListener('beforeunload', this.CheckUnload);
+    window.removeEventListener('unload', this.DoUnload);
   }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// STATE MANAGEMENT
   ///
-  resetState() {
+  ResetState() {
     this.setState({
       // SYSTEM STATE
       // isLoggedIn: false, // don't clear session state!
@@ -176,7 +165,7 @@ class NCNode extends UNISYS.Component {
       editBtnDisable: false,
       editBtnHide: false,
       viewMode: VIEWMODE.VIEW,
-      selectedTab: TABS.ATTRIBUTES,
+      uSelectedTab: TABS.ATTRIBUTES,
       selectedEdgeId: null,
       backgroundColor: 'transparent',
       isLockedByDB: false, // shows db lock message next to Edit Node button
@@ -199,7 +188,7 @@ class NCNode extends UNISYS.Component {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// EVENT HANDLERS
   ///
-  checkUnload(event) {
+  CheckUnload(event) {
     event.preventDefault();
     if (this.state.viewMode === VIEWMODE.EDIT) {
       (event || window.event).returnValue = null;
@@ -208,7 +197,7 @@ class NCNode extends UNISYS.Component {
     }
     return event;
   }
-  doUnload(event) {
+  DoUnload(event) {
     if (this.state.viewMode === VIEWMODE.EDIT) {
       UDATA.NetCall('SRV_DBUNLOCKNODE', { nodeID: this.state.id });
       UDATA.NetCall('SRV_RELEASE_EDIT_LOCK', { editor: EDITORTYPE.NODE });
@@ -224,16 +213,16 @@ class NCNode extends UNISYS.Component {
    * its handleChange() when active typing is occuring, and also during
    * SessionShell.componentWillMount()
    */
-  updateSession(decoded) {
-    this.setState({ isLoggedIn: decoded.isValid }, () => this.updatePermissions());
+  UpdateSession(decoded) {
+    this.setState({ isLoggedIn: decoded.isValid }, () => this.UpdatePermissions());
   }
   /*
       Called by NCDATA AppState updates
   */
   UpdateNCData() {
-    this.loadEdges(this.state.id);
+    this.LoadEdges(this.state.id);
   }
-  setPermissions(data) {
+  SetPermissions(data) {
     const { id } = this.state;
     const nodeIsLocked = data.lockedNodes.includes(id);
     this.setState(
@@ -242,10 +231,10 @@ class NCNode extends UNISYS.Component {
         isLockedByTemplate: data.templateBeingEdited,
         isLockedByImport: data.importActive
       },
-      () => this.updatePermissions()
+      () => this.UpdatePermissions()
     );
   }
-  updatePermissions() {
+  UpdatePermissions() {
     const { isLoggedIn, isLockedByDB, isLockedByTemplate, isLockedByImport } =
       this.state;
     const TEMPLATE = UDATA.AppState('TEMPLATE');
@@ -267,12 +256,12 @@ class NCNode extends UNISYS.Component {
     }
     this.setState({ editBtnDisable, editBtnHide, editLockMessage });
   }
-  clearSelection() {
-    this.resetState();
+  ClearSelection() {
+    this.ResetState();
   }
-  updateSelection(data) {
+  UpdateSelection(data) {
     const node = data.nodes[0]; // select the first node
-    this.loadNode(node);
+    this.LoadNode(node);
   }
   /**
    * In order to edit an edge, we must first select the source
@@ -283,9 +272,9 @@ class NCNode extends UNISYS.Component {
    * @param {Object} data
    * @param {string} data.edgeId
    */
-  selectEdgeAndEdit(data) {
+  SelectEdgeAndEdit(data) {
     const { edgeId } = data;
-    this.setState({ selectedTab: TABS.EDGES, selectedEdgeId: edgeId }, () => {
+    this.setState({ uSelectedTab: TABS.EDGES, selectedEdgeId: edgeId }, () => {
       const { edges } = this.state;
       const edge = edges.find(e => e.id === Number(edgeId));
       this.setState({ selectedEdgeId: edgeId });
@@ -294,14 +283,14 @@ class NCNode extends UNISYS.Component {
       });
     });
   }
-  deselectEdge() {
+  SeselectEdge() {
     this.setState({ selectedEdgeId: null });
   }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// DATA LOADING
   ///
-  loadNode(node) {
+  LoadNode(node) {
     const { id, viewMode } = this.state;
 
     // If we're editing, ignore the select!
@@ -309,7 +298,7 @@ class NCNode extends UNISYS.Component {
 
     // If no node was selected, deselect
     if (!node) {
-      this.clearSelection();
+      this.ClearSelection();
       return;
     }
 
@@ -317,7 +306,7 @@ class NCNode extends UNISYS.Component {
     if (node.id !== id) UDATA.LocalCall('EDGE_DESELECT');
 
     // Load the node
-    const attributes = this.loadAttributes(node);
+    const attributes = this.LoadAttributes(node);
     this.setState(
       {
         id: node.id,
@@ -329,20 +318,20 @@ class NCNode extends UNISYS.Component {
         revision: node.revision
       },
       () => {
-        this.setBackgroundColor();
-        this.loadEdges(node.id);
-        this.isNodeLocked(nodeIsLocked => {
+        this.SetBackgroundColor();
+        this.LoadEdges(node.id);
+        this.IsNodeLocked(nodeIsLocked => {
           this.setState(
             {
               isLockedByDB: nodeIsLocked
             },
-            () => this.updatePermissions()
+            () => this.UpdatePermissions()
           );
         });
       }
     );
   }
-  loadEdges(id) {
+  LoadEdges(id) {
     // -- First, sort edges by source, then target
     const NCDATA = UDATA.AppState('NCDATA');
     const linkedEdges = NCDATA.edges.filter(e => e.source === id || e.target === id);
@@ -371,7 +360,7 @@ class NCNode extends UNISYS.Component {
    * @param {Object} node
    * @returns {Object} { ...attr-key: attr-value }
    */
-  loadAttributes(node) {
+  LoadAttributes(node) {
     const NODEDEFS = UDATA.AppState('TEMPLATE').nodeDefs;
     const attributes = {};
     Object.keys(NODEDEFS).forEach(k => {
@@ -390,7 +379,7 @@ class NCNode extends UNISYS.Component {
    * @param {function} cb callback function
    * @returns {boolean} true if lock was successful
    */
-  lockNode(cb) {
+  LockNode(cb) {
     const { id } = this.state;
     let lockSuccess = false;
     UDATA.NetCall('SRV_DBLOCKNODE', { nodeID: id }).then(data => {
@@ -406,7 +395,7 @@ class NCNode extends UNISYS.Component {
       if (typeof cb === 'function') cb(lockSuccess);
     });
   }
-  unlockNode(cb) {
+  UnlockNode(cb) {
     const { id } = this.state;
     let unlockSuccess = false;
     UDATA.NetCall('SRV_DBUNLOCKNODE', { nodeID: id }).then(data => {
@@ -423,7 +412,7 @@ class NCNode extends UNISYS.Component {
       if (typeof cb === 'function') cb(unlockSuccess);
     });
   }
-  isNodeLocked(cb) {
+  IsNodeLocked(cb) {
     const { id } = this.state;
     let nodeIsLocked = false;
     UDATA.NetCall('SRV_DBISNODELOCKED', { nodeID: id }).then(data => {
@@ -442,7 +431,7 @@ class NCNode extends UNISYS.Component {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// DATA SAVING
   ///
-  saveNode() {
+  SaveNode() {
     const { id, label, attributes, provenance, created, updated, revision } =
       this.state;
 
@@ -453,7 +442,7 @@ class NCNode extends UNISYS.Component {
     // setting dbWrite to true will distinguish this update
     // from a remote one
     this.AppCall('DB_UPDATE', { node }).then(() => {
-      this.unlockNode(() => {
+      this.UnlockNode(() => {
         this.setState({
           viewMode: VIEWMODE.VIEW,
           isLockedByDB: false
@@ -469,7 +458,7 @@ class NCNode extends UNISYS.Component {
    * Currently the background color is determined by the template node type
    * color mapping.  This will eventually be replaced with a color manager.
    */
-  setBackgroundColor() {
+  SetBackgroundColor() {
     const { attributes } = this.state;
     const type = attributes && attributes.type;
     const COLORMAP = UDATA.AppState('COLORMAP');
@@ -480,9 +469,9 @@ class NCNode extends UNISYS.Component {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// UI EVENT HANDLERS
 
-  uiSelectTab(event) {
-    const selectedTab = event.target.value;
-    this.setState({ selectedTab });
+  UISelectTab(event) {
+    const uSelectedTab = event.target.value;
+    this.setState({ uSelectedTab });
     if (event.target.value !== TABS.EDGES) UDATA.LocalCall('EDGE_DESELECT');
   }
 
@@ -490,10 +479,10 @@ class NCNode extends UNISYS.Component {
    * If `lockNode` is not successful, then that means the node was
    * already locked, so we can't edit.
    */
-  uiRequestEditNode() {
-    this.lockNode(lockSuccess => {
+  UIRequestEditNode() {
+    this.LockNode(lockSuccess => {
       this.setState({ isLockedByDB: !lockSuccess }, () => {
-        if (lockSuccess) this.enableEditMode();
+        if (lockSuccess) this.EnableEditMode();
       });
     });
   }
@@ -506,11 +495,11 @@ class NCNode extends UNISYS.Component {
     });
   }
 
-  enableEditMode() {
-    const { selectedTab, label, attributes, provenance } = this.state;
+  EnableEditMode() {
+    const { uSelectedTab, label, attributes, provenance } = this.state;
     // If user was on Edges tab while requesting edit (e.g. from Node Table), then
     // switch to Attributes tab first.
-    const editableTab = selectedTab === TABS.EDGES ? TABS.ATTRIBUTES : selectedTab;
+    const editableTab = uSelectedTab === TABS.EDGES ? TABS.ATTRIBUTES : uSelectedTab;
     const previousState = {
       label,
       attributes: Object.assign({}, attributes)
@@ -518,12 +507,12 @@ class NCNode extends UNISYS.Component {
     };
     this.setState({
       viewMode: VIEWMODE.EDIT,
-      selectedTab: editableTab,
+      uSelectedTab: editableTab,
       previousState
     });
   }
 
-  uiCancelEditMode() {
+  UICancelEditMode() {
     const { previousState } = this.state;
     // restore previous state
     this.setState(
@@ -532,12 +521,12 @@ class NCNode extends UNISYS.Component {
         attributes: previousState.attributes
         // provenance: previousState.provenance // uncomment after provenence is implemented
       },
-      () => this.uiDisableEditMode()
+      () => this.UIDisableEditMode()
     );
   }
 
-  uiDisableEditMode() {
-    this.unlockNode(() => {
+  UIDisableEditMode() {
+    this.UnlockNode(() => {
       this.setState({
         viewMode: VIEWMODE.VIEW,
         isLockedByDB: false
@@ -545,61 +534,32 @@ class NCNode extends UNISYS.Component {
       UDATA.NetCall('SRV_RELEASE_EDIT_LOCK', { editor: EDITORTYPE.NODE });
     });
   }
-
-  uiStringInputUpdate(event) {
-    const nodeDefKey = event.target.id;
-    if (BUILTIN_FIELDS.includes(nodeDefKey)) {
+  UIInputUpdate(key, value) {
+    if (BUILTIN_FIELDS.includes(key)) {
       const data = {};
-      data[nodeDefKey] = event.target.value;
+      data[key] = value;
       this.setState(data);
     } else {
       const { attributes } = this.state;
-      attributes[nodeDefKey] = event.target.value;
-      this.setState({ attributes }, () => this.setBackgroundColor());
+      attributes[key] = value;
+      this.setState({ attributes }, () => this.SetBackgroundColor());
     }
   }
-  uiLabelInputUpdate(event) {
-    const { id } = this.state;
-    const nodeDefKey = event.target.id;
+  UILabelInputUpdate(key, value) {
     const data = {};
-    data[nodeDefKey] = event.target.value;
+    data[key] = value;
+    console.warn('Labelinput', key, value);
     this.setState(data);
-    UDATA.LocalCall('FIND_MATCHING_NODES', { searchString: event.target.value }).then(
-      data => {
-        const foundLabels =
-          data.nodes && data.nodes.length > 0
-            ? data.nodes.map(d => d.label)
-            : undefined;
-        this.setState({ matchingNodeLabels: foundLabels });
-      }
-    );
-  }
-  uiNumberInputUpdate(event) {
-    const nodeDefKey = event.target.id;
-    if (BUILTIN_FIELDS.includes(nodeDefKey)) {
-      const data = {};
-      data[nodeDefKey] = Number(event.target.value);
-      this.setState(data);
-    } else {
-      const { attributes } = this.state;
-      attributes[nodeDefKey] = Number(event.target.value);
-      this.setState({ attributes }, () => this.setBackgroundColor());
-    }
-  }
-  uiSelectInputUpdate(event) {
-    const nodeDefKey = event.target.id;
-    if (BUILTIN_FIELDS.includes(nodeDefKey)) {
-      const data = {};
-      data[nodeDefKey] = event.target.value;
-      this.setState(data);
-    } else {
-      const { attributes } = this.state;
-      attributes[nodeDefKey] = event.target.value;
-      this.setState({ attributes }, () => this.setBackgroundColor());
-    }
+    UDATA.LocalCall('FIND_MATCHING_NODES', { searchString: value }).then(data => {
+      const foundLabels =
+        data.nodes && data.nodes.length > 0
+          ? data.nodes.map(d => d.label)
+          : undefined;
+      this.setState({ matchingNodeLabels: foundLabels });
+    });
   }
 
-  uiViewEdge(edgeId) {
+  UIViewEdge(edgeId) {
     const { edges } = this.state;
     const edge = edges.find(e => e.id === Number(edgeId));
     this.setState({ selectedEdgeId: edgeId });
@@ -617,36 +577,39 @@ class NCNode extends UNISYS.Component {
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// RENDER METHODS
-  renderView() {
+  RenderView() {
     const {
-      selectedTab,
+      uSelectedTab,
       backgroundColor,
       editBtnDisable,
       editBtnHide,
       editLockMessage,
       label
     } = this.state;
+    const defs = UDATA.AppState('TEMPLATE').nodeDefs;
     const bgcolor = backgroundColor + '44'; // hack opacity
     return (
       <div className="nccomponent">
         <div className="view" style={{ background: bgcolor }}>
           {/* BUILT-IN - - - - - - - - - - - - - - - - - */}
-          <div className="nodelabel">{this.renderStringValue('label', label)}</div>
+          <div className="nodelabel">{NCUI.RenderLabel('label', label)}</div>
           {/* TABS - - - - - - - - - - - - - - - - - - - */}
           <div className="tabcontainer">
-            {this.renderTabSelectors()}
+            {NCUI.RenderTabSelectors(TABS, this.state, this.UISelectTab)}
             <div className="tabview">
-              {selectedTab === TABS.ATTRIBUTES && this.renderAttributesTabView()}
-              {selectedTab === TABS.EDGES && this.renderEdgesTab()}
-              {selectedTab === TABS.PROVENANCE && this.renderProvenanceTab()}
+              {uSelectedTab === TABS.ATTRIBUTES &&
+                NCUI.RenderAttributesTabView(this.state, defs)}
+              {uSelectedTab === TABS.EDGES && this.RenderEdgesTab()}
+              {uSelectedTab === TABS.PROVENANCE &&
+                NCUI.RenderProvenanceTab(this.state, defs)}
             </div>
           </div>
           {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
           <div className="controlbar">
-            {!editBtnHide && selectedTab !== TABS.EDGES && (
+            {!editBtnHide && uSelectedTab !== TABS.EDGES && (
               <button
                 id="editbtn"
-                onClick={this.uiRequestEditNode}
+                onClick={this.UIRequestEditNode}
                 disabled={editBtnDisable}
               >
                 Edit
@@ -661,8 +624,9 @@ class NCNode extends UNISYS.Component {
     );
   }
 
-  renderEdit() {
-    const { selectedTab, backgroundColor, matchingNodeLabels, label } = this.state;
+  RenderEdit() {
+    const { uSelectedTab, backgroundColor, matchingNodeLabels, label } = this.state;
+    const defs = UDATA.AppState('TEMPLATE').nodeDefs;
     const bgcolor = backgroundColor + '66'; // hack opacity
     const matchList = matchingNodeLabels
       ? matchingNodeLabels.map(l => <div key={l}>{l}</div>)
@@ -681,7 +645,10 @@ class NCNode extends UNISYS.Component {
             }}
           >
             {/* BUILT-IN - - - - - - - - - - - - - - - - - */}
-            <div className="nodelabel">{this.renderLabelInput('label', label)}</div>
+            <div className="nodelabel">
+              {NCUI.RenderStringInput('label', label, this.UILabelInputUpdate)}
+            </div>
+            {/* <div className="nodelabel">{this.renderLabelInput('label', label)}</div> */}
             {matchList && (
               <div className="matchlist">
                 {isDuplicate && (
@@ -692,19 +659,21 @@ class NCNode extends UNISYS.Component {
             )}
             {/* TABS - - - - - - - - - - - - - - - - - - - */}
             <div className="tabcontainer">
-              {this.renderTabSelectors()}
+              {NCUI.RenderTabSelectors(TABS, this.state, this.UISelectTab)}
               <div className="tabview">
-                {selectedTab === TABS.ATTRIBUTES && this.renderAttributesTabEdit()}
-                {selectedTab === TABS.EDGES && this.renderEdgesTab()}
-                {selectedTab === TABS.PROVENANCE && this.renderProvenanceTab()}
+                {uSelectedTab === TABS.ATTRIBUTES &&
+                  NCUI.RenderAttributesTabEdit(this.state, defs, this.UIInputUpdate)}
+                {uSelectedTab === TABS.EDGES && this.RenderEdgesTab()}
+                {uSelectedTab === TABS.PROVENANCE &&
+                  NCUI.RenderProvenanceTab(this.state, defs)}
               </div>
             </div>
             {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
             <div className="controlbar">
-              <button className="cancelbtn" onClick={this.uiCancelEditMode}>
+              <button className="cancelbtn" onClick={this.UICancelEditMode}>
                 Cancel
               </button>
-              <button onClick={this.saveNode}>Save</button>
+              <button onClick={this.SaveNode}>Save</button>
             </div>
           </div>
         </div>
@@ -714,69 +683,10 @@ class NCNode extends UNISYS.Component {
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// RENDER HELPERS
-  renderTabSelectors() {
-    const { selectedTab, viewMode } = this.state;
-    const columnsDef = `repeat(${Object.keys(TABS).length}, 1fr)`;
-    return (
-      <div
-        className="tabselectors"
-        style={{ color: 'red', gridTemplateColumns: columnsDef }}
-      >
-        {Object.keys(TABS).map(k => {
-          return (
-            <button
-              id={k}
-              key={k}
-              type="button"
-              className={selectedTab === TABS[k] ? 'selected' : ''}
-              onClick={this.uiSelectTab}
-              value={TABS[k]}
-              disabled={viewMode === VIEWMODE.EDIT}
-            >
-              {TABS[k]}
-            </button>
-          );
-        })}
-      </div>
-    );
-  }
-  renderAttributesTabView() {
-    const { id, attributes } = this.state;
-    const NODEDEFS = UDATA.AppState('TEMPLATE').nodeDefs;
-    const items = [];
-    Object.keys(attributes).forEach(k => {
-      items.push(this.renderLabel(k, NODEDEFS[k].displayLabel));
-      items.push(this.renderStringValue(k, attributes[k]));
-    });
-    return <div className="formview">{items}</div>;
-  }
-  renderAttributesTabEdit() {
-    const { id, attributes } = this.state;
-    const NODEDEFS = UDATA.AppState('TEMPLATE').nodeDefs;
-    const items = [];
-    Object.keys(attributes).forEach(k => {
-      items.push(this.renderLabel(k, NODEDEFS[k].displayLabel));
-      const type = NODEDEFS[k].type;
-      const value = attributes[k] || ''; // catch `undefined` or React will complain about changing from uncontrolled to controlled
-      switch (type) {
-        case 'string':
-          items.push(this.renderStringInput(k, value));
-          break;
-        case 'number':
-          items.push(this.renderNumberInput(k, value));
-          break;
-        case 'select':
-          items.push(this.renderOptionsInput(k, value));
-          break;
-        default:
-          items.push(this.renderStringValue(k, value)); // display unsupported type
-      }
-    });
-    return <div className="formview">{items}</div>;
-  }
-  renderEdgesTab() {
+  ///
+  RenderEdgesTab() {
     const {
-      selectedTab,
+      uSelectedTab,
       selectedEdgeId,
       editBtnDisable,
       editBtnHide,
@@ -807,7 +717,7 @@ class NCNode extends UNISYS.Component {
               <div key={e.id}>
                 <button
                   className="edgebutton"
-                  onClick={() => this.uiViewEdge(e.id)}
+                  onClick={() => this.UIViewEdge(e.id)}
                   style={{ backgroundColor: bgcolor }}
                 >
                   {id === e.source ? me : sourceNode.label}
@@ -818,7 +728,7 @@ class NCNode extends UNISYS.Component {
             );
           }
         })}
-        {!editBtnHide && selectedTab === TABS.EDGES && (
+        {!editBtnHide && uSelectedTab === TABS.EDGES && (
           <button
             className="addedgebutton"
             onClick={this.UIAddEdge}
@@ -830,91 +740,6 @@ class NCNode extends UNISYS.Component {
       </div>
     );
   }
-  renderProvenanceTab() {
-    const { provenance, degrees, created, updated, revision } = this.state;
-    const NODEDEFS = UDATA.AppState('TEMPLATE').nodeDefs;
-    return (
-      <div className="provenance formview">
-        {this.renderLabel('provenancelabel', NODEDEFS.provenance.displayLabel)}
-        {this.renderStringValue('provenancelabel', provenance)}
-        {this.renderLabel('createdlabel', NODEDEFS.created.displayLabel)}
-        {this.renderStringValue('createdlabel', created)}
-        {this.renderLabel('updatedlabel', NODEDEFS.updated.displayLabel)}
-        {this.renderStringValue('updatedlabel', updated)}
-        {this.renderLabel('revisionlabel', NODEDEFS.revision.displayLabel)}
-        {this.renderStringValue('revisionlabel', revision)}
-        {this.renderLabel('degreeslabel', NODEDEFS.degrees.displayLabel)}
-        {this.renderStringValue('degreeslabel', degrees)}
-      </div>
-    );
-  }
-  renderLabel(nodeDefKey, label) {
-    return (
-      <label htmlFor={nodeDefKey} key={`${nodeDefKey}label`}>
-        {label}
-      </label>
-    );
-  }
-  renderStringValue(nodeDefKey, value) {
-    return (
-      <div id={nodeDefKey} key={`${nodeDefKey}value`}>
-        {value}
-      </div>
-    );
-  }
-  renderStringInput(nodeDefKey, value) {
-    return (
-      <input
-        id={nodeDefKey}
-        key={`${nodeDefKey}input`}
-        value={value}
-        type="string"
-        onChange={this.uiStringInputUpdate}
-      />
-    );
-  }
-  // special handler for node label
-  // onChange handler is `uiLabelInputUpdate` which autosuggests matching nodes
-  renderLabelInput(nodeDefKey, value) {
-    return (
-      <input
-        id={nodeDefKey}
-        key={`${nodeDefKey}input`}
-        value={value}
-        type="string"
-        onChange={this.uiLabelInputUpdate}
-      />
-    );
-  }
-  renderNumberInput(nodeDefKey, value) {
-    return (
-      <input
-        id={nodeDefKey}
-        key={`${nodeDefKey}input`}
-        value={value}
-        type="number"
-        onChange={this.uiNumberInputUpdate}
-      />
-    );
-  }
-  renderOptionsInput(nodeDefKey, value) {
-    const NODEDEFS = UDATA.AppState('TEMPLATE').nodeDefs;
-    const options = NODEDEFS[nodeDefKey].options;
-    return (
-      <select
-        id={nodeDefKey}
-        key={`${nodeDefKey}select`}
-        value={value}
-        onChange={this.uiSelectInputUpdate}
-      >
-        {options.map(o => (
-          <option key={o.label} value={o.label}>
-            {o.label}
-          </option>
-        ))}
-      </select>
-    );
-  }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// MAIN RENDER
@@ -922,9 +747,9 @@ class NCNode extends UNISYS.Component {
     const { id, viewMode } = this.state;
     if (!id) return ''; // nothing selected
     if (viewMode === VIEWMODE.VIEW) {
-      return this.renderView();
+      return this.RenderView();
     } else {
-      return this.renderEdit();
+      return this.RenderEdit();
     }
   }
 }

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -163,6 +163,7 @@ class NCNode extends UNISYS.Component {
   /// STATE MANAGEMENT
   ///
   ResetState() {
+    const TEMPLATE = this.AppState('TEMPLATE');
     this.setState({
       // SYSTEM STATE
       // isLoggedIn: false, // don't clear session state!
@@ -179,6 +180,7 @@ class NCNode extends UNISYS.Component {
       isLockedByTemplate: false,
       isLockedByImport: false,
       editLockMessage: '',
+      uHideDeleteNodeButton: TEMPLATE.hideDeleteNodeButton,
       uReplacementNodeId: '',
       uIsValidReplacementNodeID: true,
       // NODE DEFS
@@ -625,6 +627,7 @@ class NCNode extends UNISYS.Component {
       editBtnDisable,
       editBtnHide,
       editLockMessage,
+      uHideDeleteNodeButton,
       uReplacementNodeId,
       uIsValidReplacementNodeID,
       id,
@@ -666,7 +669,7 @@ class NCNode extends UNISYS.Component {
           {editLockMessage && (
             <div className="message warning">{editLockMessage}</div>
           )}
-          {isAdmin && !editBtnDisable && (
+          {isAdmin && !editBtnDisable && !uHideDeleteNodeButton && (
             <div className="controlbar deletenode">
               <div className="message">
                 Re-link edges to this Node ID (leave blank to delete edge)

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -2,12 +2,38 @@
 
     Prototype Simple NetCreate Node Editor
 
+    Built for Version 2.0 ITEST.
+
+    Provides a viewer and editor for the currently selected node.
+
+    USAGE
+
+      <NCNode />
+
+    Main changes for 2.0:
+    * Node data is made up of built-in parameters (e.g. label, provenance),
+      and arbitrary custom parameters defined via the template.  This Node
+      editor can support wide variety of data.
+
+    DATA UPDATES
+    * Updates are triggered mostly by:
+      1.  SELECTION state updates when nodes and edges change
+      2.  PERMISSION state updates when locks are set and released.
+
     Data is currently in a transitional state.
     Currently all properties are saved in a flat list.
     Eventually we might want to differentiate between
     built-in properties (e.g. id, created), and template-defined custom
     `attributes`.  There is an awkward translation between these two
     representations during data load, update, and save.
+
+
+    PERMISSIONS
+    Editting is restricted by:
+    * User must be logged in
+    * Template is not being edited
+    * Data is not beingimported
+    * Someone else is not editing the node (and has placed a lock on it)
 
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
 
@@ -101,6 +127,7 @@ class NCNode extends UNISYS.Component {
     UDATA.OnAppStateChange('SESSION', this.updateSession);
     UDATA.OnAppStateChange('SELECTION', this.updateSelection);
     UDATA.HandleMessage('EDIT_PERMISSIONS_UPDATE', this.setPermissions);
+    UDATA.HandleMessage('NODE_EDIT', this.uiRequestEditNode); // Node Table request
   }
 
   componentDidMount() {
@@ -112,6 +139,7 @@ class NCNode extends UNISYS.Component {
     UDATA.AppStateChangeOff('SESSION', this.updateSession);
     UDATA.AppStateChangeOff('SELECTION', this.updateSelection);
     UDATA.UnhandleMessage('EDIT_PERMISSIONS_UPDATE', this.setPermissions);
+    UDATA.UnhandleMessage('NODE_EDIT', this.uiRequestEditNode);
     window.removeEventListener('beforeunload', this.checkUnload);
     window.removeEventListener('unload', this.doUnload);
   }

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -223,7 +223,8 @@ class NCNode extends UNISYS.Component {
     );
   }
   updatePermissions() {
-    const { isLoggedIn, isLockedByDB, isLockedByTemplate, isLockedByImport } = this.state;
+    const { isLoggedIn, isLockedByDB, isLockedByTemplate, isLockedByImport } =
+      this.state;
     const TEMPLATE = UDATA.AppState('TEMPLATE');
     let editLockMessage = '';
     let editBtnDisable = false;
@@ -363,7 +364,9 @@ class NCNode extends UNISYS.Component {
       if (data.NOP) {
         console.log(`SERVER SAYS: ${data.NOP} ${data.INFO}`);
       } else if (data.unlocked) {
-        console.log(`SERVER SAYS: unlock success! you have released Node ${data.nodeID}`);
+        console.log(
+          `SERVER SAYS: unlock success! you have released Node ${data.nodeID}`
+        );
         unlockSuccess = true;
         // Release Template lock
         UDATA.NetCall('SRV_RELEASE_EDIT_LOCK', { editor: EDITORTYPE.NODE });
@@ -378,7 +381,9 @@ class NCNode extends UNISYS.Component {
       if (data.NOP) {
         console.log(`SERVER SAYS: ${data.NOP} ${data.INFO}`);
       } else if (data.locked) {
-        console.log(`SERVER SAYS: Node is locked! You cannot edit Node ${data.nodeID}`);
+        console.log(
+          `SERVER SAYS: Node is locked! You cannot edit Node ${data.nodeID}`
+        );
         nodeIsLocked = true;
       }
       if (typeof cb === 'function') cb(nodeIsLocked);
@@ -389,7 +394,8 @@ class NCNode extends UNISYS.Component {
   /// DATA SAVING
   ///
   saveNode() {
-    const { id, label, attributes, provenance, created, updated, revision } = this.state;
+    const { id, label, attributes, provenance, created, updated, revision } =
+      this.state;
 
     const node = { id, label, provenance, created, updated, revision };
     Object.keys(attributes).forEach(k => (node[k] = attributes[k]));
@@ -502,7 +508,9 @@ class NCNode extends UNISYS.Component {
     UDATA.LocalCall('FIND_MATCHING_NODES', { searchString: event.target.value }).then(
       data => {
         const foundLabels =
-          data.nodes && data.nodes.length > 0 ? data.nodes.map(d => d.label) : undefined;
+          data.nodes && data.nodes.length > 0
+            ? data.nodes.map(d => d.label)
+            : undefined;
         this.setState({ matchingNodeLabels: foundLabels });
       }
     );
@@ -570,7 +578,9 @@ class NCNode extends UNISYS.Component {
               </button>
             )}
           </div>
-          {editLockMessage && <div className="message warning">{editLockMessage}</div>}
+          {editLockMessage && (
+            <div className="message warning">{editLockMessage}</div>
+          )}
         </div>
       </div>
     );
@@ -599,7 +609,9 @@ class NCNode extends UNISYS.Component {
             <div className="nodelabel">{this.renderLabelInput('label', label)}</div>
             {matchList && (
               <div className="matchlist">
-                {isDuplicate && <div className="message warning">{duplicateWarning}</div>}
+                {isDuplicate && (
+                  <div className="message warning">{duplicateWarning}</div>
+                )}
                 {matchList}
               </div>
             )}

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -666,7 +666,7 @@ class NCNode extends UNISYS.Component {
           {editLockMessage && (
             <div className="message warning">{editLockMessage}</div>
           )}
-          {isAdmin && (
+          {isAdmin && !editBtnDisable && (
             <div className="controlbar deletenode">
               <div className="message">
                 Re-link edges to this Node ID (leave blank to delete edge)

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -454,8 +454,8 @@ class NCNode extends UNISYS.Component {
     const editableTab = selectedTab === TABS.EDGES ? TABS.ATTRIBUTES : selectedTab;
     const previousState = {
       label,
-      attributes: Object.assign({}, attributes),
-      provenance: Object.assign({}, provenance)
+      attributes: Object.assign({}, attributes)
+      // provenance: Object.assign({}, provenance) // uncomment after provenence is implemented
     };
     this.setState({
       viewMode: VIEWMODE.EDIT,
@@ -470,8 +470,8 @@ class NCNode extends UNISYS.Component {
     this.setState(
       {
         label: previousState.label,
-        attributes: previousState.attributes,
-        provenance: previousState.provenance
+        attributes: previousState.attributes
+        // provenance: previousState.provenance // uncomment after provenence is implemented
       },
       () => this.uiDisableEditMode()
     );

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -177,6 +177,7 @@ class NCNode extends UNISYS.Component {
       // NODE DEFS
       id: null,
       label: '',
+      degrees: null,
       attributes: [],
       provenance: [],
       created: undefined,
@@ -314,6 +315,7 @@ class NCNode extends UNISYS.Component {
       {
         id: node.id,
         label: node.label,
+        degrees: node.degrees,
         attributes: attributes,
         provenance: node.provenance,
         created: node.created,

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -642,7 +642,7 @@ class NCNode extends UNISYS.Component {
                 NCUI.RenderAttributesTabView(this.state, defs)}
               {uSelectedTab === TABS.EDGES && this.RenderEdgesTab()}
               {uSelectedTab === TABS.PROVENANCE &&
-                NCUI.RenderProvenanceTab(this.state, defs)}
+                NCUI.RenderProvenanceTabView(this.state, defs)}
             </div>
           </div>
           {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
@@ -728,7 +728,7 @@ class NCNode extends UNISYS.Component {
                   NCUI.RenderAttributesTabEdit(this.state, defs, this.UIInputUpdate)}
                 {uSelectedTab === TABS.EDGES && this.RenderEdgesTab()}
                 {uSelectedTab === TABS.PROVENANCE &&
-                  NCUI.RenderProvenanceTab(this.state, defs)}
+                  NCUI.RenderProvenanceTabEdit(this.state, defs, this.UIInputUpdate)}
               </div>
             </div>
             {/* CONTROL BAR - - - - - - - - - - - - - - - - */}

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -442,13 +442,20 @@ class NCNode extends UNISYS.Component {
   }
 
   enableEditMode() {
-    const { label, attributes, provenance } = this.state;
+    const { selectedTab, label, attributes, provenance } = this.state;
+    // If user was on Edges tab while requesting edit (e.g. from Node Table), then
+    // switch to Attributes tab first.
+    const editableTab = selectedTab === TABS.EDGES ? TABS.ATTRIBUTES : selectedTab;
     const previousState = {
       label,
       attributes: Object.assign({}, attributes),
       provenance: Object.assign({}, provenance)
     };
-    this.setState({ viewMode: VIEWMODE.EDIT, previousState });
+    this.setState({
+      viewMode: VIEWMODE.EDIT,
+      selectedTab: editableTab,
+      previousState
+    });
   }
 
   uiCancelEditMode() {

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -113,7 +113,6 @@ class NCNode extends UNISYS.Component {
   /// STATE MANAGEMENT
   ///
   resetState() {
-    console.error('reset state');
     this.setState({
       // SYSTEM STATE
       // allowedToEdit: false, // don't clear session state!
@@ -525,18 +524,19 @@ class NCNode extends UNISYS.Component {
     Object.keys(attributes).forEach(k => {
       items.push(this.renderLabel(k, NODEDEFS[k].displayLabel));
       const type = NODEDEFS[k].type;
+      const value = attributes[k] || ''; // catch `undefined` or React will complain about changing from uncontrolled to controlled
       switch (type) {
         case 'string':
-          items.push(this.renderStringInput(k, attributes[k]));
+          items.push(this.renderStringInput(k, value));
           break;
         case 'number':
-          items.push(this.renderNumberInput(k, attributes[k]));
+          items.push(this.renderNumberInput(k, value));
           break;
         case 'select':
-          items.push(this.renderOptionsInput(k, attributes[k]));
+          items.push(this.renderOptionsInput(k, value));
           break;
         default:
-          items.push(this.renderStringValue(k, attributes[k])); // display unsupported type
+          items.push(this.renderStringValue(k, value)); // display unsupported type
       }
     });
     return <div className="formview">{items}</div>;

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -349,8 +349,8 @@ class NCNode extends UNISYS.Component {
   uiStringInputUpdate(event) {
     const nodeDefKey = event.target.id;
     if (BUILTIN_FIELDS.includes(nodeDefKey)) {
-      data[nodeDefKey] = event.target.value;
       const data = {};
+      data[nodeDefKey] = event.target.value;
       this.setState(data);
     } else {
       const { attributes } = this.state;
@@ -361,8 +361,8 @@ class NCNode extends UNISYS.Component {
   uiNumberInputUpdate(event) {
     const nodeDefKey = event.target.id;
     if (BUILTIN_FIELDS.includes(nodeDefKey)) {
-      data[nodeDefKey] = Number(event.target.value);
       const data = {};
+      data[nodeDefKey] = Number(event.target.value);
       this.setState(data);
     } else {
       const { attributes } = this.state;
@@ -373,8 +373,8 @@ class NCNode extends UNISYS.Component {
   uiSelectInputUpdate(event) {
     const nodeDefKey = event.target.id;
     if (BUILTIN_FIELDS.includes(nodeDefKey)) {
-      data[nodeDefKey] = event.target.value;
       const data = {};
+      data[nodeDefKey] = event.target.value;
       this.setState(data);
     } else {
       const { attributes } = this.state;

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -51,6 +51,7 @@ class NCNode extends UNISYS.Component {
     this.state = {
       allowedToEdit: false
     }; // initialized on componentDidMount and clearSelection
+
     // STATE MANAGEMENT
     this.resetState = this.resetState.bind(this);
     this.updateSession = this.updateSession.bind(this);
@@ -431,9 +432,9 @@ class NCNode extends UNISYS.Component {
           </div>
           {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
           <div className="controlbar">
-            {allowedToEdit && (
+            {allowedToEdit && selectedTab !== TABS.EDGES && (
               <button id="editbtn" onClick={this.uiRequestEditNode} disabled={dbIsLocked}>
-                Edit Node
+                Edit
               </button>
             )}
           </div>
@@ -449,31 +450,34 @@ class NCNode extends UNISYS.Component {
     const { selectedTab, backgroundColor, id, label } = this.state;
     const bgcolor = backgroundColor + '66'; // hack opacity
     return (
-      <div className="ncnode">
-        <div
-          className="edit"
-          style={{
-            background: bgcolor,
-            borderColor: backgroundColor
-          }}
-        >
-          {/* BUILT-IN - - - - - - - - - - - - - - - - - */}
-          <div className="nodelabel">{this.renderStringInput('label', label)}</div>
-          {/* TABS - - - - - - - - - - - - - - - - - - - */}
-          <div className="tabcontainer">
-            {this.renderTabSelectors()}
-            <div className="tabview">
-              {selectedTab === TABS.ATTRIBUTES && this.renderAttributesTabEdit()}
-              {selectedTab === TABS.EDGES && this.renderEdgesTab()}
-              {selectedTab === TABS.PROVENANCE && this.renderProvenanceTab()}
+      <div>
+        <div className="screen"></div>
+        <div className="ncnode">
+          <div
+            className="edit"
+            style={{
+              background: bgcolor,
+              borderColor: backgroundColor
+            }}
+          >
+            {/* BUILT-IN - - - - - - - - - - - - - - - - - */}
+            <div className="nodelabel">{this.renderStringInput('label', label)}</div>
+            {/* TABS - - - - - - - - - - - - - - - - - - - */}
+            <div className="tabcontainer">
+              {this.renderTabSelectors()}
+              <div className="tabview">
+                {selectedTab === TABS.ATTRIBUTES && this.renderAttributesTabEdit()}
+                {selectedTab === TABS.EDGES && this.renderEdgesTab()}
+                {selectedTab === TABS.PROVENANCE && this.renderProvenanceTab()}
+              </div>
             </div>
-          </div>
-          {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
-          <div className="controlbar">
-            <button className="cancelbtn" onClick={this.uiDisableEditMode}>
-              Cancel
-            </button>
-            <button onClick={this.saveNode}>Save</button>
+            {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
+            <div className="controlbar">
+              <button className="cancelbtn" onClick={this.uiDisableEditMode}>
+                Cancel
+              </button>
+              <button onClick={this.saveNode}>Save</button>
+            </div>
           </div>
         </div>
       </div>
@@ -483,7 +487,7 @@ class NCNode extends UNISYS.Component {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// RENDER HELPERS
   renderTabSelectors() {
-    const { selectedTab } = this.state;
+    const { selectedTab, viewMode } = this.state;
     return (
       <div className="tabselectors">
         {Object.keys(TABS).map(k => {
@@ -495,6 +499,7 @@ class NCNode extends UNISYS.Component {
               className={selectedTab === TABS[k] ? 'selected' : ''}
               onClick={this.uiSelectTab}
               value={TABS[k]}
+              disabled={viewMode === VIEWMODE.EDIT}
             >
               {TABS[k]}
             </button>
@@ -648,8 +653,9 @@ class NCNode extends UNISYS.Component {
     if (!id) return ''; // nothing selected
     if (viewMode === VIEWMODE.VIEW) {
       return this.renderView();
+    } else {
+      return this.renderEdit();
     }
-    return this.renderEdit();
   }
 }
 

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -45,7 +45,7 @@ const PR = 'NCNode';
 const React = require('react');
 const UNISYS = require('unisys/client');
 const EDGEMGR = require('../edge-mgr'); // handles edge synthesis
-const { EDITORTYPE } = require('system/util/enum');
+const { EDITORTYPE, BUILTIN_FIELDS_NODE } = require('system/util/enum');
 const NCUI = require('../nc-ui');
 const NCEdge = require('./NCEdge');
 const SETTINGS = require('settings');
@@ -53,15 +53,6 @@ const SETTINGS = require('settings');
 const isAdmin = SETTINGS.IsAdmin();
 
 let UDATA;
-const BUILTIN_FIELDS = [
-  'id',
-  'label',
-  'provenance',
-  'degrees',
-  'created',
-  'updated',
-  'revision'
-];
 const VIEWMODE = {
   EDIT: 'edit',
   VIEW: 'view'
@@ -376,7 +367,7 @@ class NCNode extends UNISYS.Component {
     const NODEDEFS = UDATA.AppState('TEMPLATE').nodeDefs;
     const attributes = {};
     Object.keys(NODEDEFS).forEach(k => {
-      if (BUILTIN_FIELDS.includes(k)) return; // skip built-in fields
+      if (BUILTIN_FIELDS_NODE.includes(k)) return; // skip built-in fields
       const attr_def = NODEDEFS[k];
       if (attr_def.hidden) return; // skip hidden fields
       attributes[k] = node[k];
@@ -578,7 +569,7 @@ class NCNode extends UNISYS.Component {
     });
   }
   UIInputUpdate(key, value) {
-    if (BUILTIN_FIELDS.includes(key)) {
+    if (BUILTIN_FIELDS_NODE.includes(key)) {
       const data = {};
       data[key] = value;
       this.setState(data);

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -48,6 +48,8 @@ class NCNode extends UNISYS.Component {
   constructor(props) {
     super(props);
 
+    this.state = {}; // initialized on componentDidMount and clearSelection
+
     this.clearSelection = this.clearSelection.bind(this);
     this.updateSelection = this.updateSelection.bind(this);
 
@@ -86,7 +88,7 @@ class NCNode extends UNISYS.Component {
     UDATA.OnAppStateChange('SELECTION', this.updateSelection);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.clearSelection(); // Initialize State
   }
   componentWillUnmount() {

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -549,11 +549,13 @@ class NCNode extends UNISYS.Component {
   }
 
   renderEdit() {
-    const { selectedTab, backgroundColor, matchingNodeLabels, id, label } = this.state;
+    const { selectedTab, backgroundColor, matchingNodeLabels, label } = this.state;
     const bgcolor = backgroundColor + '66'; // hack opacity
     const matchList = matchingNodeLabels
       ? matchingNodeLabels.map(l => <div key={l}>{l}</div>)
       : undefined;
+    const duplicateWarning = UDATA.AppState('TEMPLATE').duplicateWarning;
+    const isDuplicate = matchingNodeLabels && matchingNodeLabels.includes(label);
     return (
       <div>
         <div className="screen"></div>
@@ -567,7 +569,12 @@ class NCNode extends UNISYS.Component {
           >
             {/* BUILT-IN - - - - - - - - - - - - - - - - - */}
             <div className="nodelabel">{this.renderLabelInput('label', label)}</div>
-            {matchList && <div className="matchlist">{matchList}</div>}
+            {matchList && (
+              <div className="matchlist">
+                {isDuplicate && <div className="message warning">{duplicateWarning}</div>}
+                {matchList}
+              </div>
+            )}
             {/* TABS - - - - - - - - - - - - - - - - - - - */}
             <div className="tabcontainer">
               {this.renderTabSelectors()}

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -381,7 +381,7 @@ class NCNode extends UNISYS.Component {
     } else {
       const { attributes } = this.state;
       attributes[nodeDefKey] = event.target.value;
-      this.setState({ attributes });
+      this.setState({ attributes }, () => this.setBackgroundColor());
     }
   }
   uiNumberInputUpdate(event) {
@@ -393,7 +393,7 @@ class NCNode extends UNISYS.Component {
     } else {
       const { attributes } = this.state;
       attributes[nodeDefKey] = Number(event.target.value);
-      this.setState({ attributes });
+      this.setState({ attributes }, () => this.setBackgroundColor());
     }
   }
   uiSelectInputUpdate(event) {
@@ -405,7 +405,7 @@ class NCNode extends UNISYS.Component {
     } else {
       const { attributes } = this.state;
       attributes[nodeDefKey] = event.target.value;
-      this.setState({ attributes });
+      this.setState({ attributes }, () => this.setBackgroundColor());
     }
   }
 

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -350,7 +350,7 @@ class NCNode extends UNISYS.Component {
     const { selectedTab, backgroundColor, dbIsLocked, label } = this.state;
     const TEMPLATE = UDATA.AppState('TEMPLATE');
     const nodeIsLockedMessage = TEMPLATE.nodeIsLockedMessage;
-    const bgcolor = backgroundColor + '33'; // hack opacity
+    const bgcolor = backgroundColor + '44'; // hack opacity
     return (
       <div className="ncnode">
         <div
@@ -384,13 +384,14 @@ class NCNode extends UNISYS.Component {
 
   renderEdit() {
     const { selectedTab, backgroundColor, id, label } = this.state;
-    const bgcolor = backgroundColor + '33'; // hack opacity
+    const bgcolor = backgroundColor + '66'; // hack opacity
     return (
       <div className="ncnode">
         <div
           className="edit"
           style={{
-            background: bgcolor
+            background: bgcolor,
+            borderColor: backgroundColor
           }}
         >
           {/* BUILT-IN - - - - - - - - - - - - - - - - - */}

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -101,6 +101,7 @@ class NCNode extends UNISYS.Component {
     this.uiSelectTab = this.uiSelectTab.bind(this);
     this.uiRequestEditNode = this.uiRequestEditNode.bind(this);
     this.enableEditMode = this.enableEditMode.bind(this);
+    this.uiCancelEditMode = this.uiCancelEditMode.bind(this);
     this.uiDisableEditMode = this.uiDisableEditMode.bind(this);
     this.uiStringInputUpdate = this.uiStringInputUpdate.bind(this);
     this.uiLabelInputUpdate = this.uiLabelInputUpdate.bind(this);
@@ -154,6 +155,7 @@ class NCNode extends UNISYS.Component {
     this.setState({
       // SYSTEM STATE
       // isLoggedIn: false, // don't clear session state!
+      previousState: {},
       // UI State
       editBtnDisable: false,
       editBtnHide: false,
@@ -440,7 +442,26 @@ class NCNode extends UNISYS.Component {
   }
 
   enableEditMode() {
-    this.setState({ viewMode: VIEWMODE.EDIT });
+    const { label, attributes, provenance } = this.state;
+    const previousState = {
+      label,
+      attributes: Object.assign({}, attributes),
+      provenance: Object.assign({}, provenance)
+    };
+    this.setState({ viewMode: VIEWMODE.EDIT, previousState });
+  }
+
+  uiCancelEditMode() {
+    const { previousState } = this.state;
+    // restore previous state
+    this.setState(
+      {
+        label: previousState.label,
+        attributes: previousState.attributes,
+        provenance: previousState.provenance
+      },
+      () => this.uiDisableEditMode()
+    );
   }
 
   uiDisableEditMode() {
@@ -586,7 +607,7 @@ class NCNode extends UNISYS.Component {
             </div>
             {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
             <div className="controlbar">
-              <button className="cancelbtn" onClick={this.uiDisableEditMode}>
+              <button className="cancelbtn" onClick={this.uiCancelEditMode}>
                 Cancel
               </button>
               <button onClick={this.saveNode}>Save</button>

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -48,6 +48,9 @@ const EDGEMGR = require('../edge-mgr'); // handles edge synthesis
 const { EDITORTYPE } = require('system/util/enum');
 const NCUI = require('../nc-ui');
 const NCEdge = require('./NCEdge');
+const SETTINGS = require('settings');
+
+const isAdmin = SETTINGS.IsAdmin();
 
 let UDATA;
 const BUILTIN_FIELDS = [
@@ -163,6 +166,7 @@ class NCNode extends UNISYS.Component {
     this.setState({
       // SYSTEM STATE
       // isLoggedIn: false, // don't clear session state!
+      // isAdmin: false,
       previousState: {},
       // UI State
       editBtnDisable: false,
@@ -662,19 +666,28 @@ class NCNode extends UNISYS.Component {
           {editLockMessage && (
             <div className="message warning">{editLockMessage}</div>
           )}
-          <div className="controlbar deletenode">
-            <div className="message">
-              Re-link edges to this Node ID (leave blank to delete edge)
+          {isAdmin && (
+            <div className="controlbar deletenode">
+              <div className="message">
+                Re-link edges to this Node ID (leave blank to delete edge)
+              </div>
+              <div>
+                <input
+                  type="number"
+                  id="replacementNodeID"
+                  className={`deleteinput ${
+                    uIsValidReplacementNodeID ? '' : 'invalid'
+                  }`}
+                  value={uReplacementNodeId || ''}
+                  onChange={this.UIReplacementNodeIdUpdate}
+                />
+                {!uIsValidReplacementNodeID && (
+                  <div className="message warning">Invalid Node ID!</div>
+                )}
+              </div>
+              <button onClick={this.DeleteNode}>Delete</button>
             </div>
-            <input
-              type="number"
-              id="replacementNodeID"
-              className={`deleteinput ${uIsValidReplacementNodeID ? '' : 'invalid'}`}
-              value={uReplacementNodeId || ''}
-              onChange={this.UIReplacementNodeIdUpdate}
-            />
-            <button onClick={this.DeleteNode}>Delete</button>
-          </div>
+          )}
         </div>
       </div>
     );

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -125,10 +125,18 @@ class NCNode extends UNISYS.Component {
   /// DATA LOADING
   ///
   loadNode(node) {
+    const { viewMode } = this.state;
+
+    // If we're editing, ignore the select!
+    if (viewMode === VIEWMODE.EDIT) return;
+
+    // If no node was selected, deselect
     if (!node) {
       this.clearSelection();
       return;
     }
+
+    // Load the node
     const attributes = this.loadAttributes(node);
     this.setState(
       {

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -801,7 +801,7 @@ class NCNode extends UNISYS.Component {
           const color = EDGEMGR.LookupEdgeColor(e, TEMPLATE);
           const bgcolor = color + '33'; // opacity hack
           if (e.id === selectedEdgeId) {
-            return <NCEdge key={e.id} edge={e} />;
+            return <NCEdge key={e.id} edge={e} parentNodeId={id} />;
           } else {
             return (
               <div key={e.id}>

--- a/app/view/netcreate/components/NCSearch.css
+++ b/app/view/netcreate/components/NCSearch.css
@@ -1,0 +1,40 @@
+.ncsearch {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-auto-columns: 100px;
+  grid-auto-flow: column;
+  column-gap: 10px;
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+.ncsearch button {
+  background-color: #fff6;
+  border-radius: 5px;
+  border-color: #0006;
+  border-width: 1px;
+  border-style: solid;
+  color: #333;
+}
+.ncsearch button:disabled {
+  background-color: #fff3;
+  border-color: #0003;
+  color: #3333;
+  cursor: not-allowed;
+}
+.ncsearch input {
+  width: 100%;
+  padding: 0 5px;
+  font-size: 16px;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+}
+
+/* override help */
+.ncsearch .helptop {
+  position: absolute;
+  bottom: 120%;
+  padding: 0 5px;
+  color: #666;
+  background-color: transparent;
+  font-size: 12px;
+}

--- a/app/view/netcreate/components/NCSearch.jsx
+++ b/app/view/netcreate/components/NCSearch.jsx
@@ -34,16 +34,37 @@ class NCSearch extends UNISYS.Component {
     super(props);
 
     this.state = {
-      value: '',
-      disabled: false
+      isLoggedIn: false,
+      value: ''
     }; // initialized on componentDidMount and clearSelection
 
+    this.UpdateSession = this.UpdateSession.bind(this);
     this.UIOnChange = this.UIOnChange.bind(this);
     this.UIOnSelect = this.UIOnSelect.bind(this);
     this.UINewNode = this.UINewNode.bind(this);
 
     /// Initialize UNISYS DATA LINK for REACT
     UDATA = UNISYS.NewDataLink(this);
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    /// REGISTER LISTENERS
+    UDATA.OnAppStateChange('SESSION', this.UpdateSession);
+  }
+
+  componentWillUnmount() {
+    UDATA.AppStateChangeOff('SESSION', this.UpdateSession);
+  }
+
+  /**
+   * Handle change in SESSION data
+   * SESSION is called by SessionShell when the ID changes
+   * set system-wide. data: { classId, projId, hashedId, groupId, isValid }
+   * Called both by componentWillMount() and AppStateChange handler.
+   * The 'SESSION' state change is triggered in two places in SessionShell during
+   * its handleChange() when active typing is occuring, and also during
+   * SessionShell.componentWillMount()
+   */
+  UpdateSession(decoded) {
+    this.setState({ isLoggedIn: decoded.isValid });
   }
 
   UIOnChange(key, value) {
@@ -82,7 +103,8 @@ class NCSearch extends UNISYS.Component {
   /// MAIN RENDER
   ///
   render() {
-    const { value, disabled } = this.state;
+    const { value, isLoggedIn } = this.state;
+    const newNodeBtnDisabled = !isLoggedIn || value === '';
     const key = 'search'; // used for source/target, placeholder for search
     return (
       <div className="ncsearch">
@@ -92,7 +114,7 @@ class NCSearch extends UNISYS.Component {
           onChange={this.UIOnChange}
           onSelect={this.UIOnSelect}
         />
-        <button disabled={value === ''} onClick={this.UINewNode}>
+        <button disabled={newNodeBtnDisabled} onClick={this.UINewNode}>
           New Node
         </button>
       </div>

--- a/app/view/netcreate/components/NCSearch.jsx
+++ b/app/view/netcreate/components/NCSearch.jsx
@@ -1,0 +1,105 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+    Prototype Simple NetCreate Search Field
+
+    Built for Version 2.0 ITEST.
+
+    Provides a:
+    * Search Field
+    * "Add New Node" button
+    * Autosuggest highlighter
+
+    USAGE
+
+      <NCSearch />
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+const DBG = false;
+const PR = 'NCSearch';
+
+/// LIBRARIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const React = require('react');
+const UNISYS = require('unisys/client');
+const NCAutoSuggest = require('./NCAutoSuggest');
+
+let UDATA;
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// export a class object for consumption by brunch/require
+class NCSearch extends UNISYS.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: '',
+      disabled: false
+    }; // initialized on componentDidMount and clearSelection
+
+    this.UIOnChange = this.UIOnChange.bind(this);
+    this.UIOnSelect = this.UIOnSelect.bind(this);
+    this.UINewNode = this.UINewNode.bind(this);
+
+    /// Initialize UNISYS DATA LINK for REACT
+    UDATA = UNISYS.NewDataLink(this);
+  }
+
+  UIOnChange(key, value) {
+    // Pass the input value (node label search string) to UDATA
+    // which will in turn pass the searchLabel back to the SEARCH
+    // state handler in the constructor, which will in turn set the state
+    // of the input value to be passed on to AutoSuggest
+    this.AppCall('SOURCE_SEARCH', { searchString: value });
+    // Update current input value
+    this.setState({ value });
+  }
+
+  UIOnSelect(key, value, id) {
+    // match existing vs create new
+    this.setState({ value }, () => {
+      if (id) {
+        // open existing node
+        UDATA.LocalCall('D3_SELECT_NODE', { nodeIDs: [id] });
+      } else {
+        // create a new node
+        this.UINewNode();
+      }
+    }); // Enter will create a new node
+  }
+
+  UINewNode() {
+    const { value } = this.state;
+    const data = {};
+    data.label = value;
+    UDATA.LocalCall('NODE_CREATE', data).then(node => {
+      UDATA.LocalCall('D3_SELECT_NODE', { nodeIDs: [node.id] });
+    });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// MAIN RENDER
+  ///
+  render() {
+    const { value, disabled } = this.state;
+    const key = 'search'; // used for source/target, placeholder for search
+    return (
+      <div className="ncsearch">
+        <NCAutoSuggest
+          statekey={key}
+          value={value}
+          onChange={this.UIOnChange}
+          onSelect={this.UIOnSelect}
+        />
+        <button disabled={value === ''} onClick={this.UINewNode}>
+          New Node
+        </button>
+      </div>
+    );
+  }
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = NCSearch;

--- a/app/view/netcreate/components/NCSearch.jsx
+++ b/app/view/netcreate/components/NCSearch.jsx
@@ -95,7 +95,9 @@ class NCSearch extends UNISYS.Component {
     const data = {};
     data.label = value;
     UDATA.LocalCall('NODE_CREATE', data).then(node => {
-      UDATA.LocalCall('D3_SELECT_NODE', { nodeIDs: [node.id] });
+      UDATA.LocalCall('D3_SELECT_NODE', { nodeIDs: [node.id] }).then(() => {
+        UDATA.LocalCall('NODE_EDIT', { nodeID: node.id });
+      });
     });
   }
 

--- a/app/view/netcreate/components/NodeSelector.jsx
+++ b/app/view/netcreate/components/NodeSelector.jsx
@@ -1040,7 +1040,7 @@ class NodeSelector extends UNISYS.Component {
       }
         return (
         <div>
-          <FormGroup className="text-right" style={{marginTop:'-20px',paddingRight:'5px'}}>
+          <FormGroup className="text-right" style={{marginTop:'10px',paddingRight:'5px'}}>
             <Button outline size="sm"
               disabled={disableEdit}
               hidden={isLocked || isBeingEdited}

--- a/app/view/netcreate/components/NodeTable.jsx
+++ b/app/view/netcreate/components/NodeTable.jsx
@@ -138,7 +138,8 @@ class NodeTable extends UNISYS.Component {
     var time = d.toTimeString().substr(0, 5);
     var dateTime = date + ' at ' + time;
     var titleString = 'v' + nodeEdge.meta.revision;
-    if (nodeEdge._nlog) titleString += ' by ' + nodeEdge._nlog[nodeEdge._nlog.length - 1];
+    if (nodeEdge._nlog)
+      titleString += ' by ' + nodeEdge._nlog[nodeEdge._nlog.length - 1];
     var tag = <span title={titleString}> {dateTime} </span>;
 
     return tag;
@@ -469,7 +470,10 @@ class NodeTable extends UNISYS.Component {
                 <div style={{ color: '#f3f3ff' }}>_Edit_</div>
               </th>
               <th width="4%" hidden={!DBG}>
-                <Button size="sm" onClick={() => this.setSortKey('id', nodeDefs.id.type)}>
+                <Button
+                  size="sm"
+                  onClick={() => this.setSortKey('id', nodeDefs.id.type)}
+                >
                   ID
                 </Button>
               </th>
@@ -550,7 +554,12 @@ class NodeTable extends UNISYS.Component {
                 onMouseOver={() => this.onHighlightRow(node.id)}
               >
                 <td>
-                  <Button size="sm" outline value={node.id} onClick={this.onButtonClick}>
+                  <Button
+                    size="sm"
+                    outline
+                    value={node.id}
+                    onClick={this.onButtonClick}
+                  >
                     {isLocked ? 'View' : 'Edit'}
                   </Button>
                 </td>

--- a/app/view/netcreate/components/NodeTable.jsx
+++ b/app/view/netcreate/components/NodeTable.jsx
@@ -29,13 +29,15 @@ var DBG = false;
 
 const SETTINGS = require('settings');
 const isLocalHost =
-  SETTINGS.EJSProp('client').ip === '127.0.0.1' || location.href.includes('admin=true');
+  SETTINGS.EJSProp('client').ip === '127.0.0.1' ||
+  location.href.includes('admin=true');
 
 /// LIBRARIES /////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 import FILTER from './filter/FilterEnums';
 const React = require('react');
 const ReactStrap = require('reactstrap');
+const { BUILTIN_FIELDS_NODE } = require('system/util/enum');
 const { Button } = ReactStrap;
 const MarkdownNote = require('./MarkdownNote');
 const UNISYS = require('unisys/client');
@@ -336,21 +338,12 @@ class NodeTable extends UNISYS.Component {
         return this.sortByID(nodes);
       case 'edgeCount':
         return this.sortByEdgeCount(nodes);
-      case 'type':
-        return this.sortByKey(nodes, 'type', type);
-      case 'notes':
-        return this.sortByKey(nodes, 'notes', type);
-      case 'info':
-        return this.sortByKey(nodes, 'info', type);
-      case 'provenance':
-        return this.sortByKey(nodes, 'provenance', type);
-      case 'comments':
-        return this.sortByKey(nodes, 'comments', type);
-      case 'updated':
-        return this.sortByUpdated(nodes);
+      // case 'updated':
+      //   return this.sortByUpdated(nodes);
       case 'label':
-      default:
         return this.sortByLabel(nodes);
+      default:
+        return this.sortByKey(nodes, sortkey, type);
     }
   }
 
@@ -443,6 +436,9 @@ class NodeTable extends UNISYS.Component {
                   xtbody { overflow: auto; }
                   .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }
                   `;
+    const attributes = Object.keys(nodeDefs).filter(
+      k => !BUILTIN_FIELDS_NODE.includes(k)
+    );
     return (
       <div
         onMouseLeave={() => this.onHighlightRow(undefined)}
@@ -493,38 +489,17 @@ class NodeTable extends UNISYS.Component {
                   {nodeDefs.label.displayLabel} {this.sortSymbol('label')}
                 </Button>
               </th>
-              <th width="10%" hidden={nodeDefs.type.hidden}>
-                <Button
-                  size="sm"
-                  onClick={() => this.setSortKey('type', nodeDefs.type.type)}
-                >
-                  {nodeDefs.type.displayLabel} {this.sortSymbol('type')}
-                </Button>
-              </th>
-              <th width="4%" hidden={nodeDefs.info.hidden}>
-                <Button
-                  size="sm"
-                  onClick={() => this.setSortKey('info', nodeDefs.info.type)}
-                >
-                  {nodeDefs.info.displayLabel} {this.sortSymbol('info')}
-                </Button>
-              </th>
-              <th width="25%" hidden={nodeDefs.notes.hidden}>
-                <Button
-                  size="sm"
-                  onClick={() => this.setSortKey('notes', nodeDefs.notes.type)}
-                >
-                  {nodeDefs.notes.displayLabel} {this.sortSymbol('notes')}
-                </Button>
-              </th>
-              <th width="9%" hidden={nodeDefs.provenance.hidden}>
-                <Button
-                  size="sm"
-                  onClick={() => this.setSortKey('provenance', nodeDefs.provenance.type)}
-                >
-                  {nodeDefs.provenance.displayLabel} {this.sortSymbol('provenance')}
-                </Button>
-              </th>
+              {attributes.map(a => (
+                <th hidden={nodeDefs[a].hidden} key={a}>
+                  <Button
+                    size="sm"
+                    onClick={() => this.setSortKey(a, nodeDefs[a].type)}
+                  >
+                    {nodeDefs[a].displayLabel} {this.sortSymbol(a)}
+                  </Button>
+                </th>
+              ))}
+              {/*
               <th width="10%" hidden={!isLocalHost}>
                 <Button
                   size="sm"
@@ -533,14 +508,7 @@ class NodeTable extends UNISYS.Component {
                   Updated {this.sortSymbol('updated')}
                 </Button>
               </th>
-              <th width="20%" hidden={nodeDefs.comments.hidden}>
-                <Button
-                  size="sm"
-                  onClick={() => this.setSortKey('comments', nodeDefs.comments.type)} // date might be
-                >
-                  {nodeDefs.comments.displayLabel} {this.sortSymbol('comments')}
-                </Button>
-              </th>
+              */}
             </tr>
           </thead>
           <tbody style={{ maxHeight: tableHeight, fontSize: '12px' }}>
@@ -570,14 +538,12 @@ class NodeTable extends UNISYS.Component {
                     {node.label}
                   </a>
                 </td>
-                <td hidden={nodeDefs.type.hidden}>{node.type}</td>
-                <td hidden={nodeDefs.info.hidden}>{node.info}</td>
-                <td hidden={nodeDefs.notes.hidden}>
-                  {node.notes ? <MarkdownNote text={node.notes} /> : ''}
-                </td>
-                <td hidden={nodeDefs.provenance.hidden} style={{ fontSize: '9px' }}>
-                  {node.provenance}
-                </td>
+                {attributes.map(a => (
+                  <td hidden={nodeDefs[a].hidden} key={`${node.id}${a}`}>
+                    {node[a]}
+                  </td>
+                ))}
+                {/*
                 <td hidden={!isLocalHost} style={{ fontSize: '9px' }}>
                   {this.displayUpdated(node)}
                 </td>
@@ -587,6 +553,7 @@ class NodeTable extends UNISYS.Component {
                 >
                   {node.comments}
                 </td>
+                */}
               </tr>
             ))}
           </tbody>

--- a/app/view/netcreate/edge-mgr.js
+++ b/app/view/netcreate/edge-mgr.js
@@ -42,6 +42,23 @@ MOD.Hook("INITIALIZE", () => {
 
 }); // end UNISYS_INIT
 
+/// PUBLIC METHODS ////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/**
+ * Looks up the edge color defined in the passed TEMPLATE
+ * Fall back to default if type is not defined
+ * @param {Object} edge
+ * @param {Object} TEMPLATE
+ * @returns {string} e.g. '#FF00FF' as defined by TEMPLATE type.option
+ *                   or `undefined` if no color type is defined
+ */
+MOD.LookupEdgeColor = (edge, TEMPLATE) => {
+  const type = edge.type;
+  const typeOption = TEMPLATE.edgeDefs.type.options.find(o => o.label === type);
+  return typeOption ? typeOption.color : TEMPLATE.edgeDefs.type.options[0].color;
+}
+
 
 /// MODULE METHODS ////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -82,7 +99,7 @@ function m_RenderEdges(data) {
     // 2. Update Color Weight Map
     if (colorsAreDefined) {
       const colorWeightMap = edgeColorWeightMap.get(edgeKey) || new Map(); // key = color, value = weight
-      const color = m_LookupEdgeColor(e, TEMPLATE);
+      const color = MOD.LookupEdgeColor(e, TEMPLATE);
       const colorWeight = colorWeightMap.get(color) || 0; // default to weight 0 if color was not previously defined
       colorWeightMap.set(color, colorWeight + eWeight);
       edgeColorWeightMap.set(edgeKey, colorWeightMap);
@@ -131,21 +148,6 @@ function m_GetWeightiestColor(edge, edgeColorWeightMap) {
   const colors = [...colorWeightMap.keys()];
   colors.sort((a, b) => colorWeightMap.get(b) - colorWeightMap.get(a)); // descending
   return colors[0];
-}
-
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/**
- * Looks up the edge color defined in the passed TEMPLATE
- * Fall back to default if type is not defined
- * @param {Object} edge
- * @param {Object} TEMPLATE
- * @returns {string} e.g. '#FF00FF' as defined by TEMPLATE type.option
- *                   or `undefined` if no color type is defined
- */
-function m_LookupEdgeColor(edge, TEMPLATE) {
-  const type = edge.type;
-  const typeOption = TEMPLATE.edgeDefs.type.options.find(o => o.label === type);
-  return typeOption ? typeOption.color : TEMPLATE.edgeDefs.type.options[0].color;
 }
 
 /// EXPORT CLASS DEFINITION ///////////////////////////////////////////////////

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -590,12 +590,14 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDNCD
   // let all_no_op = true; // all filters are no_op
   let keepEdge = true;
   const source = FILTEREDNCDATA.nodes.find(e => {
+    if (edge.source === undefined) return false;
     // on init, edge.source is just an id.  only with d3 processing does it
     // get transformed into a node object.  so we have to check the type.
     const sourceId = (typeof edge.source === 'number') ? edge.source : edge.source.id;
     return e.id === sourceId;
   });
   const target = FILTEREDNCDATA.nodes.find(e => {
+    if (edge.target === undefined) return false;
     // on init, edge.target is just an id.  only with d3 processing does it
     // get transformed into a node object.  so we have to check the type.
     const targetId = (typeof edge.target === 'number') ? edge.target : edge.target.id;

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -690,7 +690,7 @@ MOD.Hook('INITIALIZE', () => {
     }
     // if there was one edge
     if (updatedEdges.length === 1) {
-      console.log('nc-logic.EDGE_UPDATE: updating existing edge', updatedEdges);
+      if (DBG) console.log('nc-logic.EDGE_UPDATE: updating existing edge', updatedEdges);
     }
     // if there were more edges than expected
     if (updatedEdges.length > 1) {

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -578,6 +578,10 @@ MOD.Hook('INITIALIZE', () => {
     UDATA.SetAppState('NCDATA', NCDATA);
   });
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
+  UDATA.HandleMessage('FIND_MATCHING_NODES', data => {
+    return { nodes: m_FindMatchingNodesByLabel(data.searchString) };
+  });
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
   /*/ EDGE_TYPES_UPDATE is called by templateEditor-mgr after user has changed the
       edge type options.  This maps changed options to a new name,
       and deleted type options to existing options.

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -494,6 +494,23 @@ MOD.Hook('INITIALIZE', () => {
     UDATA.SetAppState('NCDATA', NCDATA);
   });
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
+  UDATA.HandleMessage('NODE_CREATE', data => {
+    // provenance
+    const session = UDATA.AppState("SESSION");
+    const timestamp = new Date().toLocaleDateString('en-US');
+    const provenance_str = `Added by ${session.token} on ${timestamp}`;
+
+    return DATASTORE.PromiseNewNodeID()
+      .then(newNodeID => {
+        const node = { id: newNodeID, label: data.label, provenance: provenance_str };
+        return UDATA.LocalCall('DB_UPDATE', { node }).then(() => {
+          NCDATA.nodes.push(node);
+          UDATA.SetAppState('NCDATA', NCDATA);
+          return node;
+        });
+      });
+  });
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
   /*/ NODE_DELETE is called by NodeSelector via datastore.js and
       Server.js when an node should be removed
   /*/
@@ -572,14 +589,48 @@ MOD.Hook('INITIALIZE', () => {
 
     // Write to database!
     // IMPORTANT: We have to update the db BEFORE calling SetAppState
-    // because SetAppState will cause d3 to convert edge source/targets
+    // because SetAppseState will cause d3 to convert edge source/targets
     // from ids back to node objects.
     UDATA.LocalCall('DBUPDATE_ALL', NCDATA);
     UDATA.SetAppState('NCDATA', NCDATA);
   });
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
+  UDATA.HandleMessage('FIND_NODE_BY_PROP', data => {
+    const searchParameters = {};
+    searchParameters[data.key] = data.searchString;
+    return { nodes: m_FindMatchingNodeByProp(searchParameters) };
+  });
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
   UDATA.HandleMessage('FIND_MATCHING_NODES', data => {
     return { nodes: m_FindMatchingNodesByLabel(data.searchString) };
+  });
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
+  /**
+   * When creating a new edge, we first
+   * 1. Add a bare bones edge object with a new ID to the local state.edges
+   * 2. Pass it to render, so that a new EdgeEditor will be created.
+   * 3. In EdgeEditor, we create a dummy edge object
+   * @param {Object} data
+   * @param {string} data.nodeId
+   */
+  UDATA.HandleMessage('EDGE_CREATE', data => {
+    // call server to retrieve an unused edge ID
+    return DATASTORE.PromiseNewEdgeID()
+      .then(newEdgeID => {
+        // Add it to local state for now
+        const edge = {
+          id: newEdgeID,
+          source: data.nodeId,
+          target: undefined,
+          attributes: {}
+        };
+        return UDATA.LocalCall('DB_UPDATE', { edge }).then(() => {
+          console.log('...DB_UPDATE node is now', edge)
+          NCDATA.edges.push(edge);
+          UDATA.SetAppState('NCDATA', NCDATA);
+          return edge;
+        });
+      });
   });
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
   /*/ EDGE_TYPES_UPDATE is called by templateEditor-mgr after user has changed the

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -113,7 +113,7 @@ function RenderAttributesTabView(state, defs) {
   return <div className="formview">{items}</div>;
 }
 function RenderAttributesTabEdit(state, defs, onchange) {
-  const { id, attributes } = state;
+  const { attributes } = state;
   const items = [];
   Object.keys(attributes).forEach(k => {
     items.push(RenderLabel(k, defs[k].displayLabel));
@@ -136,13 +136,32 @@ function RenderAttributesTabEdit(state, defs, onchange) {
   return <div className="formview">{items}</div>;
 }
 
-function RenderProvenanceTab(state, defs) {
+function RenderProvenanceTabView(state, defs) {
   const { provenance, degrees, created, updated, revision } = state;
   // FIXME: These will be dynamically generated with the new Provenance template
   return (
     <div className="provenance formview">
       {RenderLabel('provenancelabel', defs.provenance.displayLabel)}
       {RenderStringValue('provenancelabel', provenance)}
+      {RenderLabel('createdlabel', defs.created.displayLabel)}
+      {RenderStringValue('createdlabel', created)}
+      {RenderLabel('updatedlabel', defs.updated.displayLabel)}
+      {RenderStringValue('updatedlabel', updated)}
+      {RenderLabel('revisionlabel', defs.revision.displayLabel)}
+      {RenderStringValue('revisionlabel', revision)}
+      {/* {RenderLabel('degreeslabel', defs.degrees.displayLabel)}
+      {RenderStringValue('degreeslabel', degrees)} */}
+    </div>
+  );
+}
+
+function RenderProvenanceTabEdit(state, defs, onchange) {
+  const { provenance, degrees, created, updated, revision } = state;
+  // FIXME: These will be dynamically generated with the new Provenance template
+  return (
+    <div className="provenance formview">
+      {RenderLabel('provenancelabel', defs.provenance.displayLabel)}
+      {RenderStringInput('provenance', provenance, onchange)}
       {RenderLabel('createdlabel', defs.created.displayLabel)}
       {RenderStringValue('createdlabel', created)}
       {RenderLabel('updatedlabel', defs.updated.displayLabel)}
@@ -244,7 +263,8 @@ module.exports = {
   RenderTabSelectors,
   RenderAttributesTabView,
   RenderAttributesTabEdit,
-  RenderProvenanceTab,
+  RenderProvenanceTabView,
+  RenderProvenanceTabEdit,
   RenderLabel,
   RenderStringValue,
   RenderStringInput

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -104,16 +104,23 @@ function RenderTabSelectors(TABS, state, onclick) {
 }
 
 function RenderAttributesTabView(state, defs) {
-  const { attributes } = state;
+  const { attributes, degrees } = state;
   const items = [];
   Object.keys(attributes).forEach(k => {
     items.push(RenderLabel(k, defs[k].displayLabel));
     items.push(RenderStringValue(k, attributes[k]));
   });
+
+  // degrees hack -- `degrees` is a built-in field, but is displayed in attributes
+  if (defs['degrees']) { // only if defined, e.g. for nodeDefs
+    items.push(RenderLabel('degrees', defs['degrees'].displayLabel));
+    items.push(RenderStringValue('degrees', degrees));
+  }
+
   return <div className="formview">{items}</div>;
 }
 function RenderAttributesTabEdit(state, defs, onchange) {
-  const { attributes } = state;
+  const { attributes, degrees } = state;
   const items = [];
   Object.keys(attributes).forEach(k => {
     items.push(RenderLabel(k, defs[k].displayLabel));
@@ -133,6 +140,14 @@ function RenderAttributesTabEdit(state, defs, onchange) {
         items.push(RenderStringValue(k, value, onchange)); // display unsupported type
     }
   });
+
+
+  // degrees hack -- `degrees` is a built-in field, but is displayed in attributes
+  if (defs['degrees']) { // only if defined, e.g. for nodeDefs
+    items.push(RenderLabel('degrees', defs['degrees'].displayLabel));
+    items.push(RenderStringValue('degrees', degrees));
+  }
+
   return <div className="formview">{items}</div>;
 }
 

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -175,14 +175,17 @@ function RenderStringValue(key, value) {
  * @returns
  */
 function RenderStringInput(key, value, cb) {
+  const rows = String(value).length > 35 ? 3 : 1;
   return (
-    <input
+    <textarea
       id={key}
       key={`${key}input`}
-      value={value}
       type="string"
+      value={value}
       onChange={event => m_UIStringInputUpdate(event, cb)}
       autoComplete="off" // turn off Chrome's default autocomplete, which conflicts
+      className={rows > 1 ? `long` : ''}
+      rows={rows}
     />
   );
 }

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -1,0 +1,258 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  nc-ui
+
+  General purpose UI components and snippets.
+  Used by:
+  * NCNode
+  * NCEdge
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+/// LIBRARIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const React = require('react');
+
+
+/// CONSTANTS /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const VIEWMODE = {
+  EDIT: 'edit',
+  VIEW: 'view'
+};
+
+
+/// METHODS ///////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// INPUT FORM CHANGE HANDLERS
+///
+
+/**
+ * This processes the form data before passing it on to the parent handler.
+ * The callback function is generally an input state update method in
+ * NCNode or NCEdge
+ * @param {Object} event
+ * @param {function} cb Callback function
+ */
+function m_UIStringInputUpdate(event, cb) {
+  const key = event.target.id;
+  const value = event.target.value;
+  if (typeof cb === 'function') cb(key, value);
+}
+/**
+ * This processes the form data before passing it on to the parent handler.
+ * The callback function is generally an input state update method in
+ * NCNode or NCEdge
+ * @param {Object} event
+ * @param {function} cb Callback function
+ */
+function m_UINumberInputUpdate(event, cb) {
+  const key = event.target.id;
+  const value = Number(event.target.value);
+  if (typeof cb === 'function') cb(key, value);
+}
+/**
+ * This processes the form data before passing it on to the parent handler.
+ * The callback function is generally an input state update method in
+ * NCNode or NCEdge
+ * @param {Object} event
+ * @param {function} cb Callback function
+ */
+function m_UISelectInputUpdate(event, cb) {
+  console.log('uiselect', event)
+  const key = event.target.id;
+  const value = event.target.value;
+  if (typeof cb === 'function') cb(key, value);
+}
+
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// LAYOUT RENDERERS
+function RenderTabSelectors(TABS, state, onclick) {
+  const { selectedTab, viewMode } = state;
+  return (
+    <div className="tabselectors">
+      {Object.keys(TABS).map(k => {
+        return (
+          <button
+            id={k}
+            key={k}
+            type="button"
+            className={selectedTab === TABS[k] ? 'selected' : ''}
+            onClick={onclick}
+            value={TABS[k]}
+            disabled={viewMode === VIEWMODE.EDIT}
+          >
+            {TABS[k]}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function RenderAttributesTabView(state, defs) {
+  const { attributes } = state;
+  const items = [];
+  Object.keys(attributes).forEach(k => {
+    items.push(RenderLabel(k, defs[k].displayLabel));
+    items.push(RenderStringValue(k, attributes[k]));
+  });
+  return <div className="formview">{items}</div>;
+}
+function RenderAttributesTabEdit(state, defs, onchange) {
+  const { id, attributes } = state;
+  const items = [];
+  Object.keys(attributes).forEach(k => {
+    items.push(RenderLabel(k, defs[k].displayLabel));
+    const type = defs[k].type;
+    const value = attributes[k] || ''; // catch `undefined` or React will complain about changing from uncontrolled to controlled
+    switch (type) {
+      case 'string':
+        items.push(m_RenderStringInput(k, value, onchange));
+        break;
+      case 'number':
+        items.push(m_RenderNumberInput(k, value, onchange));
+        break;
+      case 'select':
+        items.push(m_RenderOptionsInput(k, value, defs, onchange));
+        break;
+      default:
+        items.push(RenderStringValue(k, value, onchange)); // display unsupported type
+    }
+  });
+  return <div className="formview">{items}</div>;
+}
+
+function RenderProvenanceTab(state, defs) {
+  const { provenance, degrees, created, updated, revision } = state;
+  // FIXME: These will be dynamically generated with the new Provenance template
+  return (
+    <div className="provenance formview">
+      {RenderLabel('provenancelabel', defs.provenance.displayLabel)}
+      {RenderStringValue('provenancelabel', provenance)}
+      {RenderLabel('createdlabel', defs.created.displayLabel)}
+      {RenderStringValue('createdlabel', created)}
+      {RenderLabel('updatedlabel', defs.updated.displayLabel)}
+      {RenderStringValue('updatedlabel', updated)}
+      {RenderLabel('revisionlabel', defs.revision.displayLabel)}
+      {RenderStringValue('revisionlabel', revision)}
+      {/* {RenderLabel('degreeslabel', defs.degrees.displayLabel)}
+      {RenderStringValue('degreeslabel', degrees)} */}
+    </div>
+  );
+}
+
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// FORM RENDERERS
+function RenderLabel(key, label) {
+  return <label htmlFor={key} key={`${key}label`}>{label}</label>
+}
+function RenderStringValue(key, value) {
+  return <div id={key} key={`${key}value`}>{value}</div>
+}
+/**
+ * There are two levels of callbacks necessary here.
+ * 1. The `onChange` handler (in this module) processes the input's onChange event, and...
+ * 2. ...then passes the resulting value to the `cb` function in the parent module.
+ * @param {string} key
+ * @param {string} value
+ * @param {function} cb
+ * @returns
+ */
+function m_RenderStringInput(key, value, cb) {
+  return (
+    <input
+      id={key}
+      key={`${key}input`}
+      value={value}
+      type="string"
+      onChange={event => m_UIStringInputUpdate(event, cb)}
+    />
+  );
+}
+/**
+ * There are two levels of callbacks necessary here.
+ * 1. The `onChange` handler (in this module) processes the input's onChange event, and...
+ * 2. ...then passes the resulting value to the `cb` function in the parent module.
+ * @param {string} key
+ * @param {string} value
+ * @param {function} cb
+ * @returns
+ */
+function m_RenderLabelInput(key, value, cb) {
+  return (
+    <input
+      id={key}
+      key={`${key}input`}
+      value={value}
+      type="string"
+      onChange={event => m_UIStringInputUpdate(event, cb)}
+    />
+  );
+}
+/**
+ * There are two levels of callbacks necessary here.
+ * 1. The `onChange` handler (in this module) processes the input's onChange event, and...
+ * 2. ...then passes the resulting value to the `cb` function in the parent module.
+ * @param {string} key
+ * @param {string} value will be converted to a Number()
+ * @param {function} cb
+ * @returns
+ */
+function m_RenderNumberInput(key, value, cb) {
+  return (
+    <input
+      id={key}
+      key={`${key}input`}
+      value={value}
+      type="number"
+      onChange={event => m_UINumberInputUpdate(event, cb)}
+    />
+  );
+}
+/**
+ * There are two levels of callbacks necessary here.
+ * 1. The `onChange` handler (in this module) processes the input's onChange event, and...
+ * 2. ...then passes the resulting value to the `cb` function in the parent module.
+ * @param {string} key
+ * @param {string} value
+ * @param {function} cb
+ * @returns
+ */
+function m_RenderOptionsInput(key, value, defs, cb) {
+  const options = defs[key].options;
+  return (
+    <select
+      id={key}
+      key={`${key}select`}
+      value={value}
+      onChange={event => m_UISelectInputUpdate(event, cb)}
+    >
+      {options.map(o => (
+        <option key={o.label} value={o.label}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = {
+  VIEWMODE,
+  RenderTabSelectors,
+  RenderAttributesTabView,
+  RenderAttributesTabEdit,
+  RenderProvenanceTab,
+  RenderLabel,
+  RenderStringValue
+};

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -164,8 +164,6 @@ function RenderProvenanceTabView(state, defs) {
       {RenderStringValue('updatedlabel', updated)}
       {RenderLabel('revisionlabel', defs.revision.displayLabel)}
       {RenderStringValue('revisionlabel', revision)}
-      {/* {RenderLabel('degreeslabel', defs.degrees.displayLabel)}
-      {RenderStringValue('degreeslabel', degrees)} */}
     </div>
   );
 }
@@ -183,8 +181,6 @@ function RenderProvenanceTabEdit(state, defs, onchange) {
       {RenderStringValue('updatedlabel', updated)}
       {RenderLabel('revisionlabel', defs.revision.displayLabel)}
       {RenderStringValue('revisionlabel', revision)}
-      {/* {RenderLabel('degreeslabel', defs.degrees.displayLabel)}
-      {RenderStringValue('degreeslabel', degrees)} */}
     </div>
   );
 }

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -2,7 +2,8 @@
 
   nc-ui
 
-  General purpose UI components and snippets.
+  General purpose re-usable UI components and snippets.
+
   Used by:
   * NCNode
   * NCEdge
@@ -67,7 +68,6 @@ function m_UINumberInputUpdate(event, cb) {
  * @param {function} cb Callback function
  */
 function m_UISelectInputUpdate(event, cb) {
-  console.log('uiselect', event)
   const key = event.target.id;
   const value = event.target.value;
   if (typeof cb === 'function') cb(key, value);
@@ -121,7 +121,7 @@ function RenderAttributesTabEdit(state, defs, onchange) {
     const value = attributes[k] || ''; // catch `undefined` or React will complain about changing from uncontrolled to controlled
     switch (type) {
       case 'string':
-        items.push(m_RenderStringInput(k, value, onchange));
+        items.push(RenderStringInput(k, value, onchange));
         break;
       case 'number':
         items.push(m_RenderNumberInput(k, value, onchange));
@@ -174,7 +174,7 @@ function RenderStringValue(key, value) {
  * @param {function} cb
  * @returns
  */
-function m_RenderStringInput(key, value, cb) {
+function RenderStringInput(key, value, cb) {
   return (
     <input
       id={key}
@@ -182,6 +182,7 @@ function m_RenderStringInput(key, value, cb) {
       value={value}
       type="string"
       onChange={event => m_UIStringInputUpdate(event, cb)}
+      autoComplete="off" // turn off Chrome's default autocomplete, which conflicts
     />
   );
 }
@@ -242,5 +243,6 @@ module.exports = {
   RenderAttributesTabEdit,
   RenderProvenanceTab,
   RenderLabel,
-  RenderStringValue
+  RenderStringValue,
+  RenderStringInput
 };

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -12,6 +12,9 @@
 /// LIBRARIES /////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const React = require('react');
+const UNISYS = require('unisys/client');
+const MOD = UNISYS.NewModule(module.id);
+const UDATA = UNISYS.NewDataLink(MOD);
 
 
 /// CONSTANTS /////////////////////////////////////////////////////////////////
@@ -73,20 +76,24 @@ function m_UISelectInputUpdate(event, cb) {
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// LAYOUT RENDERERS
+///
 function RenderTabSelectors(TABS, state, onclick) {
-  const { selectedTab, viewMode } = state;
+  const { uSelectedTab, uViewMode } = state;
+  const columnsDef = `repeat(${Object.keys(TABS).length}, 1fr)`;
   return (
-    <div className="tabselectors">
+    <div className="tabselectors"
+      style={{ color: 'red', gridTemplateColumns: columnsDef }}
+    >
       {Object.keys(TABS).map(k => {
         return (
           <button
             id={k}
             key={k}
             type="button"
-            className={selectedTab === TABS[k] ? 'selected' : ''}
+            className={uSelectedTab === TABS[k] ? 'selected' : ''}
             onClick={onclick}
             value={TABS[k]}
-            disabled={viewMode === VIEWMODE.EDIT}
+            disabled={uViewMode === VIEWMODE.EDIT}
           >
             {TABS[k]}
           </button>
@@ -151,11 +158,12 @@ function RenderProvenanceTab(state, defs) {
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// FORM RENDERERS
+///
 function RenderLabel(key, label) {
   return <label htmlFor={key} key={`${key}label`}>{label}</label>
 }
 function RenderStringValue(key, value) {
-  return <div id={key} key={`${key}value`}>{value}</div>
+  return <div id={key} key={`${key}value`} className="viewvalue">{value}</div>
 }
 /**
  * There are two levels of callbacks necessary here.
@@ -167,26 +175,6 @@ function RenderStringValue(key, value) {
  * @returns
  */
 function m_RenderStringInput(key, value, cb) {
-  return (
-    <input
-      id={key}
-      key={`${key}input`}
-      value={value}
-      type="string"
-      onChange={event => m_UIStringInputUpdate(event, cb)}
-    />
-  );
-}
-/**
- * There are two levels of callbacks necessary here.
- * 1. The `onChange` handler (in this module) processes the input's onChange event, and...
- * 2. ...then passes the resulting value to the `cb` function in the parent module.
- * @param {string} key
- * @param {string} value
- * @param {function} cb
- * @returns
- */
-function m_RenderLabelInput(key, value, cb) {
   return (
     <input
       id={key}

--- a/app/view/netcreate/render-mgr.js
+++ b/app/view/netcreate/render-mgr.js
@@ -48,7 +48,7 @@ MOD.Hook("INITIALIZE", () => {
  * Interprets VDATA into a simplified form for the renderer
  * @param {*} data NCDATA { nodes, edges }
  * @returns {Object} {
- *                     nodes: [ ...{id, label, selected,
+ *                     nodes: [ ...{id, label, selected, selectedSecondary,
  *                                  size, color, opacity, strokeColor, strokeWidth,
  *                                  help}],
  *                     edges: [ ...{id, sourceId, targetId, size, color, opacity}]
@@ -94,12 +94,14 @@ function m_UpdateNodes(nodes) {
     const isAutosuggestHilited = autosuggestHiliteNodeId === n.id;
     const isTabletHilited = tableHiliteNodeId === n.id;
     const isSelected = selectedNodes.includes(n.id);
+    const isSecondarySelected = SELECTION.selectedSecondary === n.id;
     const isFound = foundNodes.includes(n.id);
     // FIXME: Just copy over relevant attributes, don't copy the whole object!!!!
     n.color = COLORMAP.nodeColorMap[n.type];
     n.opacity = n.filteredTransparency;
     n.size = Math.min(TEMPLATE.nodeSizeDefault + n.degrees, TEMPLATE.nodeSizeMax);
     n.selected = false;
+    n.selectedSecondary = false;
     if (isAutosuggestHilited) {
       n.textColor = '#ccc';
       n.strokeColor = '#ccc';
@@ -124,6 +126,9 @@ function m_UpdateNodes(nodes) {
     }
     if (isSelected) {
       n.selected = true; // selection state can be displayed simultaneously with hilite
+    }
+    if (isSecondarySelected) {
+      n.selectedSecondary = true; // edge source/target is selected
     }
     n.help = m_GetHelp(n);
     return n;

--- a/app/view/netcreate/render-mgr.js
+++ b/app/view/netcreate/render-mgr.js
@@ -101,21 +101,26 @@ function m_UpdateNodes(nodes) {
     n.size = Math.min(TEMPLATE.nodeSizeDefault + n.degrees, TEMPLATE.nodeSizeMax);
     n.selected = false;
     if (isAutosuggestHilited) {
+      n.textColor = '#ccc';
       n.strokeColor = '#ccc';
       n.strokeWidth = '8px';
     } else if (isTabletHilited) {
+      n.textColor = '#ccc';
       n.strokeColor = '#ccc';
       n.strokeWidth = '8px';
     } else if (isSelected) {
       // n.shape = 'rectangle';
+      n.textColor = highlightStrokeColor;
       n.strokeColor = highlightStrokeColor;
       n.strokeWidth = '5px';
     } else if (isFound) {
+      n.textColor = foundStrokeColor;
       n.strokeColor = foundStrokeColor;
       n.strokeWidth = '5px';
     } else {
-      n.strokeColor = undefined;
-      n.strokeWidth = undefined;
+      n.textColor = '#333';
+      n.strokeColor = '#fff'; // default to white border
+      n.strokeWidth = '3px';
     }
     if (isSelected) {
       n.selected = true; // selection state can be displayed simultaneously with hilite

--- a/app/view/netcreate/render-mgr.js
+++ b/app/view/netcreate/render-mgr.js
@@ -191,13 +191,14 @@ function m_GetHelp(node) {
  * @returns
  */
 function m_GetUpdatedDateText(nodeEdge) {
-  const d = new Date(nodeEdge.meta.revision > 0 ? nodeEdge.meta.updated : nodeEdge.meta.created);
-  const year = String(d.getFullYear());
-  const date = (d.getMonth() + 1) + "/" + d.getDate() + "/" + year.substr(2, 4);
-  const time = d.toTimeString().substr(0, 5);
-  const author = nodeEdge._nlog ? nodeEdge._nlog[nodeEdge._nlog.length - 1] : 'unknown';
-  const dateTime = date + ' at ' + time + " by " + author;
-  return dateTime;
+  // console.warn('skipping m_GetUpdateDateText for now...revise after provenance/meta.revision is removed')
+  // const d = new Date(nodeEdge.meta.revision > 0 ? nodeEdge.meta.updated : nodeEdge.meta.created);
+  // const year = String(d.getFullYear());
+  // const date = (d.getMonth() + 1) + "/" + d.getDate() + "/" + year.substr(2, 4);
+  // const time = d.toTimeString().substr(0, 5);
+  // const author = nodeEdge._nlog ? nodeEdge._nlog[nodeEdge._nlog.length - 1] : 'unknown';
+  // const dateTime = date + ' at ' + time + " by " + author;
+  // return dateTime;
 }
 
 

--- a/app/view/netcreate/render-mgr.js
+++ b/app/view/netcreate/render-mgr.js
@@ -99,8 +99,8 @@ function m_UpdateNodes(nodes) {
     n.color = COLORMAP.nodeColorMap[n.type];
     n.opacity = n.filteredTransparency;
     n.size = Math.min(TEMPLATE.nodeSizeDefault + n.degrees, TEMPLATE.nodeSizeMax);
+    n.selected = false;
     if (isAutosuggestHilited) {
-      // n.shape = 'rectangle';
       n.strokeColor = '#ccc';
       n.strokeWidth = '8px';
     } else if (isTabletHilited) {
@@ -111,13 +111,14 @@ function m_UpdateNodes(nodes) {
       n.strokeColor = highlightStrokeColor;
       n.strokeWidth = '5px';
     } else if (isFound) {
-      // n.shape = 'circle';
       n.strokeColor = foundStrokeColor;
       n.strokeWidth = '5px';
     } else {
-      // n.shape = 'circle';
       n.strokeColor = undefined;
       n.strokeWidth = undefined;
+    }
+    if (isSelected) {
+      n.selected = true; // selection state can be displayed simultaneously with hilite
     }
     n.help = m_GetHelp(n);
     return n;

--- a/app/view/netcreate/selection-mgr.js
+++ b/app/view/netcreate/selection-mgr.js
@@ -23,25 +23,124 @@ var UDATA = UNISYS.NewDataLink(MOD);
 const DBG = false;
 const PR = "selection-mgr: ";
 
+const SELECTION_MODE = {
+  NORMAL: 'normal', // graph is selectable
+  EDGE_EDIT: 'edge_edit', // edge is being edited
+  // NODE_EDIT is not necessary b/c the transparent screen prevents clicks
+  SOURCETARGET: 'sourcetarget' // waiting for a source or target
+}
+
+/// PRIVATE VARS //////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+let m_SelectionMode = SELECTION_MODE.NORMAL; // default
+
 /// UNISYS HANDLERS ///////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ lifecycle INITIALIZE handler
 /*/
 MOD.Hook("INITIALIZE", () => {
-  // DEPRECATED -- using HILITE and hilite-mgr instead
-  // UDATA.HandleMessage('USER_HILITE_NODE', m_UserHighlightNode);
+  UDATA.HandleMessage('SELECTMGR_SET_MODE', m_SetMode);
+  UDATA.HandleMessage('D3_SELECT_NODE', m_D3SelectNode);
+  // NODETABLE_SELECT_NODE
+  // AUTOSUGGEST_SELECT_NODE?
 }); // end UNISYS_INIT
 
 
 /// MODULE METHODS ////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-// DEPRECATED -- keep as example of use
-// function m_UserHighlightNode(data) {
-//   // console.log('mouseover', data.nodeId)
-//   const SELECTION = UDATA.AppState('SELECTION');
-//   SELECTION.userHighlightNodeId = data.nodeId;
-//   UDATA.SetAppState('SELECTION', SELECTION);
-// }
+///
+
+/**
+ * Set Selection Mode via SELECTMGR_SET_MODE
+ * @param {Object} data
+ * @param {Object} data.mode NORMAL || EDGE_EDIT || SOURCETARGET
+ */
+function m_SetMode(data) {
+  let newmode = SELECTION_MODE.NORMAL; // default
+  if (data.mode === 'sourcetarget') newmode = SELECTION_MODE.SOURCETARGET;
+  m_SelectionMode = newmode;
+}
+
+/**
+ * User clicked on d3 graph node
+ * --  Normal mode, clicking on a node selects it
+ * --  SourceTarget mode is for selecting a source or target node while editing an edge
+ * @param {Object} data
+ * @param {array:string} data.nodeLabels
+ * @param {array:number} data.nodeIDs
+ */
+function m_D3SelectNode(data) {
+  const node = m_GetNode(data);
+  if (m_SelectionMode === SELECTION_MODE.NORMAL) {
+    m_SendSelectionUpdate(node);
+  } else if (m_SelectionMode === SELECTION_MODE.SOURCETARGET) {
+    m_SendSourceTargetSelectionUpdate(node);
+  } else {
+    throw `Unknown SELECTION Mode ${m_SelectionMode}`
+  }
+}
+
+/**
+ * Get the node that was passed via the search string
+ * either nodeIDs or nodeLabels
+ * @param {Object} searchdata
+ * @param {array} searchdata.nodeLabels strings
+ * @param {array} searchdata.nodeIDs numbers
+ * @returns {Object} single node
+ */
+function m_GetNode(searchdata) {
+  const NCDATA = UDATA.AppState('NCDATA');
+  const { nodeLabels = [], nodeIDs = [] } = searchdata;
+  const nodeLabel = nodeLabels[0];
+  const nodeId = nodeIDs[0];
+  let node;
+  if (nodeId) {
+    node = NCDATA.nodes.find(n => n.id === nodeId);
+  } else if (nodeLabel) {
+    node = NCDATA.nodes.find(n => n.label === nodeLabel);
+  } else {
+    // No node selected, so deselect
+  }
+  return node;
+}
+
+/**
+ * Broadcast SELECTION and HILITE updates for selecting a single node
+ * @param {*} node
+ */
+function m_SendSelectionUpdate(node) {
+  const NCDATA = UDATA.AppState('NCDATA');
+  let newSelection, newHilite;
+  if (node === undefined) {
+    // Node not found, clear selection state
+    newSelection = { nodes: [], edges: [] };
+    newHilite = { autosuggestHiliteNodeId: undefined };
+  } else {
+    // Load existing node and edges
+    const nid = node.id;
+    let edges = [];
+    if (NCDATA.edges)
+      edges = edges.concat(
+        NCDATA.edges.filter(edge => edge.source === nid || edge.target === nid)
+      );
+    // create select state object
+    newSelection = { nodes: [node], edges };
+    newHilite = { autosuggestHiliteNodeId: undefined };
+  }
+  // Broadcast selection/hilite updates
+  UDATA.SetAppState('SELECTION', newSelection);
+  UDATA.SetAppState('HILITE', newHilite);
+}
+
+/**
+ * Broadcast SELECT_SOURCETARGET updates for selecting a source or target
+ * @param {*} node
+ */
+function m_SendSourceTargetSelectionUpdate(node) {
+  if (node === undefined) return; // skip update
+  UDATA.LocalCall('SELECT_SOURCETARGET', { node });
+}
+
 
 /// EXPORT CLASS DEFINITION ///////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/view/netcreate/selection-mgr.js
+++ b/app/view/netcreate/selection-mgr.js
@@ -60,6 +60,7 @@ let m_SelectionMode = SELECTION_MODE.NORMAL; // default
 MOD.Hook("INITIALIZE", () => {
   UDATA.HandleMessage('SELECTMGR_SET_MODE', m_SetMode);
   UDATA.HandleMessage('D3_SELECT_NODE', m_D3SelectNode);
+  UDATA.HandleMessage('SELECTMGR_SELECT_SECONDARY', m_SelectSecondary);
   UDATA.HandleMessage('SELECTMGR_DESELECT_SECONDARY', m_DeselectSecondary);
   // NODETABLE_SELECT_NODE
   // AUTOSUGGEST_SELECT_NODE?
@@ -129,7 +130,7 @@ function m_GetNode(searchdata) {
 
 /**
  * Broadcast SELECTION and HILITE updates for selecting a single node
- * @param {*} node
+ * @param {Object} node
  */
 function m_SendSelectionUpdate(node) {
   const NCDATA = UDATA.AppState('NCDATA');
@@ -157,19 +158,25 @@ function m_SendSelectionUpdate(node) {
 
 /**
  * Broadcast SELECT_SOURCETARGET updates for selecting a source or target
- * @param {*} node
+ * @param {Object} node
  */
 function m_SendSourceTargetSelectionUpdate(node) {
   if (node === undefined) return; // skip update
-
   UDATA.LocalCall('SELECT_SOURCETARGET', { node });
-
-  // Broadcast secondary selection -- show animated arrow
-  const SELECTION = UDATA.AppState('SELECTION');
-  SELECTION.selectedSecondary = node.id;
-  UDATA.SetAppState('SELECTION', SELECTION);
 }
 
+/**
+ * During Edge editing, show animated cursor after user selects a source
+ * or target node.  (For secondary selections)
+ * Broadcast SELECTMGR_SELECT_SECONDARY updates for selecting a source or target
+ * @param {Object} data
+ * @param {Object} data.node
+ */
+function m_SelectSecondary(data) {
+  const SELECTION = UDATA.AppState('SELECTION');
+  SELECTION.selectedSecondary = data.node.id;
+  UDATA.SetAppState('SELECTION', SELECTION);
+}
 /**
  * Deselect the secondary selection
  * During Edge editing, after the user has selected the source or target

--- a/app/view/netcreate/selection-mgr.js
+++ b/app/view/netcreate/selection-mgr.js
@@ -57,7 +57,7 @@ MOD.Hook("INITIALIZE", () => {
  */
 function m_SetMode(data) {
   let newmode = SELECTION_MODE.NORMAL; // default
-  if (data.mode === 'sourcetarget') newmode = SELECTION_MODE.SOURCETARGET;
+  if (Object.values(SELECTION_MODE).includes(data.mode)) newmode = data.mode;
   m_SelectionMode = newmode;
 }
 
@@ -73,6 +73,9 @@ function m_D3SelectNode(data) {
   const node = m_GetNode(data);
   if (m_SelectionMode === SELECTION_MODE.NORMAL) {
     m_SendSelectionUpdate(node);
+  } else if (m_SelectionMode === SELECTION_MODE.EDGE_EDIT) {
+    // ignore selection during EDGE_EDIT if SOURCE/TARGET has not been selected yet
+    if (DBG) console.log(PR, 'm_D3SelectNode: ignoring selection during edge edit mode')
   } else if (m_SelectionMode === SELECTION_MODE.SOURCETARGET) {
     m_SendSourceTargetSelectionUpdate(node);
   } else {

--- a/app/view/netcreate/template-schema.js
+++ b/app/view/netcreate/template-schema.js
@@ -132,7 +132,7 @@ MOD.EDGETYPEOPTIONS = {
         type: 'string',
         title: 'Label',
         default: '' // leave '' for "No Type Selected"
-      },
+      }
     }
   }
 }

--- a/app/view/netcreate/ui-mgr.js
+++ b/app/view/netcreate/ui-mgr.js
@@ -1,0 +1,67 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  UI MANAGER
+
+  ui-mgr handles the custom definition of a UI
+
+  It maps the template-schema variables to
+  the visual display of components.
+
+
+
+
+  What does it take care of?
+  * order of display items?
+  * visible status?
+
+
+  Available Field Types
+  * string
+  * number
+  * datetime
+  * date
+  * time
+  * enum
+  * color
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+
+/// LIBRARIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const UNISYS = require("unisys/client");
+
+/// INITIALIZE MODULE /////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+var MOD = UNISYS.NewModule(module.id);
+var UDATA = UNISYS.NewDataLink(MOD);
+
+/// CONSTANTS /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const DBG = false;
+const PR = "ui-mgr: ";
+
+// /// UNISYS HANDLERS ///////////////////////////////////////////////////////////
+// /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// /*/ lifecycle INITIALIZE handler
+// /*/
+// MOD.Hook("INITIALIZE", () => {
+//   UDATA.HandleMessage('USER_HILITE_NODE', m_UserHighlightNode);
+//   UDATA.HandleMessage('AUTOSUGGEST_HILITE_NODE', m_AutoSuggestHiliteNode);
+//   UDATA.HandleMessage('TABLE_HILITE_NODE', m_TableHiliteNode);
+// }); // end UNISYS_INIT
+
+
+// /// MODULE METHODS ////////////////////////////////////////////////////////////
+// /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// function m_UserHighlightNode(data) {
+//   // console.log('mouseover', data.nodeId)
+//   const HILITE = UDATA.AppState('HILITE');
+//   HILITE.userHighlightNodeId = data.nodeId;
+//   UDATA.SetAppState('HILITE', HILITE);
+// }
+
+
+/// EXPORT CLASS DEFINITION ///////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = MOD;


### PR DESCRIPTION
# Overview

This is a complete rewrite of `NodeSelector.jsx` and `EdgeEditor.jsx`.

## Main Changes
* Node and Edge properties can now be arbitrarily defined -- Templates can define custom fields, and all custom fields are automatically inputted and displayed.
* The UI is now simpler and more compact.
* Edit and View modes for both Nodes and Edges are better differentiated (in Edit mode, input fields have borders, colors are less transparent)
* Data update cycles have been greatly simplified.  Most updates are triggered by either `SELECTION` updates or `PERMISSIONS` updates (tied to locking due to node edit, template edit, or import).
* ReactStrap has been removed -- all components are now simple HTML components
* Permissions management has been centralized: various local and network state updates will set flags, `updatePermissions` will then interpret all of those flags in one go and either disable or hide the Edit button.

In general, any new components named `NC*.jsx` are Version 2.x components.


## Specific Changes

### Node and Edge Edit Fields
* Text input fields are now <textarea> by default.  They default to single line fields, but will expand as you add more text.

### Search Bar
* `NCSearch.jsx` replaces `Search.jsx`
* The new NCSearch ui replaces the search input, using the new NCAutoSuggest component to highlight matching nodes and create new nodes.
* NEW FEATURE: You can now quickly create new nodes by typing in a new node name and hitting Enter.  (We may want to revisit this in case it's too easy to create too many duplicate nodes)
* The "New Node" button will only be enabled if a search term has been entered.  The "New Node" button is unreachable during Node Edit (because of a transparent screen), so need to disable/hide.

### Node Data
* Node data is now split into built in parameters (`id`, `label`, `provenance`) and arbitrarily defined custom `attributes`.
* It is now possible define any number of `attribute` parameters in the template.  The UI will automatically display and support input for these parameters.
* Three types of attributes are currently available: `string`, `number`, and `select` (options).  We can add `boolean` if necessary.

### Node UI
* `NCNode.jsx` replaces `NodeSelector.jsx`
* The Node UI is now split into three tabs: attributes, edges. and provenance.  
* Node locking due to someone else on the network editing the selected node, template editing, or importing is now flagged in real time.  The "Edit" button will be disabled or hidden according to the locking state.  (Previously updates to the state were sporadic, e.g. you didn't know you edit was disabled until you clicked on "Edit").
* The node viewer/editor background now uses the color of the node type.  (This will need to be revisited once we get the new color scheme and color designation system in).
* Edit mode and View mode are now better differentiated -- View mode just displays simple static text.  In Edit mode form input elements are displayed, the background color is darkened and a stroke is added.
* Edit mode now behaves like a modal -- In Edit mode, the rest of the window is grayed out and clicks are intercepted.  (The exception is that you can still zoom the map with the zoom buttons, though not pan the map).
* During Edit Mode, selections and other data edits are ignored, neither can you navigate to another node tab (e.g. Edges or Provenance).
* You can initiate a node edit from the Node Table (replicated existing functionality)
* As you type in a new node label, the system displays a list of currently matching nodes.  (replicate existing functionality without using AutoSuggest system)
* Warn user of duplicate label name (replicate existing functionality) -- **The warning message will need to be updated since you can no longer use the the AutoSuggest list to select and view the node.**
* Hitting Cancel while editing a node will restore the previous node values.
* "Degrees" are a built-in field, but are displayed as an attribute.
~* Provenance will have its own Edit mode tbd.~
* Rudimentary Provenance is implemented as a simple text field.

### Graph
* Added a white stroke around nodes to offset them from edges.  This makes the whole graph feel more elegant.
* Added a stroke linecap for edges.  Large edges now "wrap" around nodes.  Again, a more elegant look.
* Minimized the amount of animation updates when clicking on a node -- previously any click would result in the graph reapplying forces and moving around.  This squelches that setting so there is minimal movement.  The graph feels much more solid now.  **It's worth checking if this affects layout on more complex graphs.**

### Edge UI
* `NCEdge.jsx` replaces `EdgeEditor.jsx`.
* Edges are now displayed embedded in the NCNode view tabs -- edges should be more easily accessed without having to scroll far down the screen.
* Only one edge can be viewed at a time (we might want to revisit that to make sure we actually want that).
* Only one edge can be edited at a time, avoiding multiple edges stuck in edit mode.
* Source and Target nodes are now colored, matching their source/target node colors.
* Selecting edge `type` will color the edge.  (This will need to be revisited once we get the new color scheme and color designation system in).
* Edges also use Attribute and Provenance tabs to make information more compact, matching Nodes.
* Edge Edit mode locks out node editing but graph selections are still allowed for selecting source/targets.
* Clicking on a source/target allows you to change the source/target.
* To select a new source/target, you have the option of clicking on a node in the graph, start to type in a new node name and use arrows and Enter to select an autosuggest name, type in the full name of an existing node, or type in a new node.
* Entering a new node (that doesn't match an existing node) and hitting Enter will show a dialog offering to create a new node.  Clicking "Create 'xxx' node" will create a new node.  The new node will be immediately displayed.  As soon as you click "Save", the node will be linked.  Clicking "Back to Edge Edit" will not create the node and allow you to continue to editing.
* Clicking "Swap" will swap source and target node direction (replicating existing functionality)


# DEPRECATED
The following components have been deprecated.
* `NodeSelector.jsx`
* `EdgeEditor.jsx`
* `AutoComplete.jsx`


# Pending
These still need to be fixed, but will be added to a new merge request:
* [ ] Provenance needs to be completely revamped
* [ ] It's possible to start creating an edge, but then abandon the edge edit, resulting in an edge with a missing source/target
* [ ] Warn or handle duplicate node labels
* [ ] NodeTables and EdgeTables are still using hard-coded parameters.  The custom template parameters for NodeTable and EdgeTable have not been implemented yet.
* [ ] server-database.m_ValidateTemplate is relying on built-in template parameters for validation -- should validation only be done on built-in core parameters?

# To Test

There's a lot to test, but here are some highlights:
* Create a new node
* Create a new edge
* Edit an existing node -- make sure changes are saved
* Edit an existing edge -- make sure changes are saved

Gotchas
* AutoSuggest -- The search field and the source/target node selection all use the NCAutoSuggest component to allow you to select a node via multiple methods (clicking, partial autosuggest, full name match, clicking on graph).  There might be unexpected interactions.  You'll want to carefully test all of the possible paths and states.

* Edge Editing Selection Arrow -- The source/target secondary selection animated arrow is touchy because there are many ways that selection can happen: Edit an edge, click the source or target to enable setting a new source/target.  Make sure the single animated arrow shows the targetted source/target using all three methods: clicking on graph, type full name, autosuggest, new node.  Make sure the single animated arrow is deselected after saving or canceling the edit.
