### PR TITLE
Bug Fix from netcreate-2018: Edge transparency is now properly restored after changing filters

### DIFF
--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -602,6 +602,10 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDNCD
     return e.id === targetId;
   });
 
+  // 0. First set default transparency
+  // restore default transparency, otherwise it could remain faded out
+  edge.filteredTransparency = EDGE_DEFAULT_TRANSPARENCY; // opaque
+
   // 1. If source or target are missing, then remove the edge
   if (source === undefined || target === undefined) return false;
 
@@ -642,8 +646,6 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDNCD
   } else if (filterAction === FILTER.ACTION.FADE) {
     if (!keepEdge) {
       edge.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
-    } else {
-      edge.filteredTransparency = EDGE_DEFAULT_TRANSPARENCY; // opaque
     }
     return true; // always keep in array
   } else if (filterAction === FILTER.ACTION.REDUCE) {

--- a/app/view/netcreate/template-schema.js
+++ b/app/view/netcreate/template-schema.js
@@ -287,7 +287,7 @@ MOD.TEMPLATE = {
     },
     "edgeDefaultTransparency": {
       type: 'number',
-      description: 'Default transparency for edges (0 - 1.',
+      description: 'Default transparency for edges (0 - 1).',
       default: 0.7
     },
     "searchColor": {


### PR DESCRIPTION
Replicates [netcreate-2018 #296](https://github.com/netcreateorg/netcreate-2018/issues/296)

Edges that were faded by the "Fade" filter would remain faded when switching filters rather than reverting to the default edge transparency as defined in the Template. The easiest test:

1. Open a graph with two edge types
2. Select Fade Edge > Type > First Edge Type
3. Select Reduce
4. Select Reduce Edge > Type > Second Edge Type
5. Because the First Edge Type was faded by the Fade filter, they were not being restored to the default transparency. Now with this fix, the Second Edge Type should be visible.

A side effect of this fix is that edge transparency as defined in the Template is now properly and immediately applied before any filters are activated. Prior to this we were not applying the template-defined transparency when filters were activated.

See [netcreate-2018 #296](https://github.com/netcreateorg/netcreate-2018/issues/296) for testing instructions.