### PR TITLE
Re-implement Edge Delete button

### DIFF
--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -97,6 +97,7 @@ class NCEdge extends UNISYS.Component {
     this.UIDeselectEdge = this.UIDeselectEdge.bind(this);
     this.UICancelEditMode = this.UICancelEditMode.bind(this);
     this.UIDisableEditMode = this.UIDisableEditMode.bind(this);
+    this.UIDeleteEdge = this.UIDeleteEdge.bind(this);
     this.UIInputUpdate = this.UIInputUpdate.bind(this);
     this.UIEnableSourceTargetSelect = this.UIEnableSourceTargetSelect.bind(this);
     this.UISourceTargetInputUpdate = this.UISourceTargetInputUpdate.bind(this);
@@ -731,6 +732,12 @@ class NCEdge extends UNISYS.Component {
     });
   }
 
+  UIDeleteEdge() {
+    const { id } = this.state;
+    this.UIDisableEditMode();
+    this.AppCall('DB_UPDATE', { edgeID: id }); // Calling DB_UPDATE with `edgeID` will remove the edge
+  }
+
   UIInputUpdate(key, value) {
     if (BUILTIN_FIELDS_EDGE.includes(key)) {
       const data = {};
@@ -919,7 +926,10 @@ class NCEdge extends UNISYS.Component {
               </div>
             </div>
             {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
-            <div className="controlbar">
+            <div className="controlbar" style={{ justifyContent: 'space-between' }}>
+              <button className="cancelbtn" onClick={this.UIDeleteEdge}>
+                Delete
+              </button>
               <button className="cancelbtn" onClick={this.UICancelEditMode}>
                 Cancel
               </button>

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -25,6 +25,17 @@ const VIEWMODE = {
 const MOD = UNISYS.NewModule(module.id);
 const UDATA = UNISYS.NewDataLink(MOD);
 
+/// UTILITIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function DateFormatted() {
+  var today = new Date();
+  var year = String(today.getFullYear());
+  var date = today.getMonth() + 1 + '/' + today.getDate() + '/' + year.substr(2, 4);
+  var time = today.toTimeString().substr(0, 5);
+  var dateTime = time + ' on ' + date;
+  return dateTime;
+}
+
 /// INPUT FORM CHANGE HANDLERS ////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** This processes the form data before passing it on to the parent handler.
@@ -281,6 +292,7 @@ function m_RenderOptionsInput(key, value, defs, cb, helpText) {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 module.exports = {
   VIEWMODE,
+  DateFormatted,
   RenderTabSelectors,
   RenderAttributesTabView,
   RenderAttributesTabEdit,


### PR DESCRIPTION
In the revamp of `NCEdge.jsx` (from `EdgeEditor.jsx`), we did not implement the "DELETE" button.  This adds it back in.

The new "DELETE" button is only visible in EDIT mode.  I figure hiding the button behind edit makes it less likely to end up with a careless deletion.

NOTE: The "Cite Edge" button has not been implemented either.

# To Test
1. Open a Graph
2. Click on a Node with an edge
3. Click on the "EDGES" tab
4. Select an edge
5. Click "EDIT" to edit the edge
6. Click "DELETE" to remove the edge
7. The edge should immediately be removed, and you will automatically exit EDIT mode.
8. You should be able to continue working, selecting other nodes, selecting ATTRIBUTES, working with edges etc.