### PR TITLE
Add Descriptive ClassNames for Key GUI Areas

### DIFF
--- a/app/init-appshell.jsx
+++ b/app/init-appshell.jsx
@@ -62,6 +62,7 @@ class AppShell extends UNISYS.Component {
     const isLocalHost = SETTINGS.IsLocalHost();
     return (
       <div
+        className="--AppShell"
         style={{
           display: 'flex',
           flexFlow: 'column nowrap',
@@ -70,6 +71,7 @@ class AppShell extends UNISYS.Component {
         }}
       >
         <Navbar
+          className="--AppShell_Navbar"
           fixed="top"
           light
           expand="md"

--- a/app/unisys/component/SessionShell.jsx
+++ b/app/unisys/component/SessionShell.jsx
@@ -262,7 +262,11 @@ class SessionShell extends UNISYS.Component {
     }
 
     return (
-      <Form onSubmit={this.onSubmit} style={NAV_LOGIN_STYLE}>
+      <Form
+        className="--SessionShell_Login"
+        onSubmit={this.onSubmit}
+        style={NAV_LOGIN_STYLE}
+      >
         <FormGroup row>
           <InputGroup>
             <InputGroupAddon addonType="prepend">

--- a/app/view/netcreate/NetCreate.jsx
+++ b/app/view/netcreate/NetCreate.jsx
@@ -163,9 +163,11 @@ class NetCreate extends UNISYS.Component {
     let hideGraph = 'visible';
     if (this.state.requireLogin && !isLoggedIn) hideGraph = 'hidden';
 
+    // note: the navbar is in init-appshell.jsx
     return (
-      <div>
+      <div className="--NetCreate">
         <div
+          className="--NetCreate_Fixed_Top"
           hidden={this.state.isConnected}
           style={{
             width: '100%',
@@ -179,14 +181,19 @@ class NetCreate extends UNISYS.Component {
             zIndex: '3000'
           }}
         >
-          <div style={{ color: '#fff', width: '100%', textAlign: 'center' }}>
+          <div
+            className="--NetCreate_Fixed_Top_SaveAlert"
+            style={{ color: '#fff', width: '100%', textAlign: 'center' }}
+          >
             <b>{disconnectMsg}!</b> Your changes will not be saved! Please report
             &quot;
             {disconnectMsg}&quot; to your administrator to restart the graph.
           </div>
         </div>
         <SessionShell />
+
         <div
+          className="--NetCreate_Rows"
           style={{
             display: 'flex',
             flexFlow: 'row nowrap',
@@ -197,6 +204,7 @@ class NetCreate extends UNISYS.Component {
           }}
         >
           <div
+            className="--NetCreate_Columns"
             id="left"
             style={{
               backgroundColor: '#EEE',
@@ -207,21 +215,27 @@ class NetCreate extends UNISYS.Component {
               marginTop: '38px'
             }}
           >
-            <div style={{ display: 'flex', flexFlow: 'column nowrap' }}>
+            {/*** LEFT EDITOR COLUMN ***************/}
+            <div
+              className="--NetCreate_Column_Left"
+              style={{ display: 'flex', flexFlow: 'column nowrap' }}
+            >
               <NCSearch />
               <NCNode />
               {/* <Search /> */}
               {/* <NodeSelector /> */}
             </div>
           </div>
+          {/*** CENTER NETVIEW COLUMN***************/}
           <div
+            className="--NetCreate_Column_NetView"
             id="middle"
             style={{ backgroundColor: '#fcfcfc', flex: '3 0 60%', marginTop: '38px' }}
           >
             <InfoPanel />
-            {/* Deprecated d3simplenetgraph: <NetGraph /> */}
             <NCGraph />
             <div
+              className="--NetCreate_Column_Break_Info"
               style={{
                 fontSize: '10px',
                 position: 'fixed',
@@ -240,9 +254,11 @@ class NetCreate extends UNISYS.Component {
               an accessible format.
             </div>
           </div>
+          {/*** RIGHT VIEW COLUMN ***************/}
           {layoutFiltersOpen ? (
             // OPEN
             <div
+              className="--NetCreate_Column_Filters_Open"
               id="right"
               style={{
                 marginTop: '38px',
@@ -270,6 +286,7 @@ class NetCreate extends UNISYS.Component {
           ) : (
             // CLOSED
             <div
+              className="--NetCreate_Column_Filters_Closed"
               id="right"
               style={{
                 marginTop: '38px',

--- a/app/view/netcreate/components/InfoPanel.jsx
+++ b/app/view/netcreate/components/InfoPanel.jsx
@@ -64,6 +64,28 @@ class InfoPanel extends UNISYS.Component {
     UDATA.HandleMessage('UI_CLOSE_MORE', this.CloseMore);
   } // constructor
 
+  /// GOOGLE ANALYTICS EVENT LOGGING ////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** legacy google analytics event logging method inserted by Joshua. This
+   *  method of google analytics that may no longer work in 2023 because the
+   *  "universal analytics" api has been deprecated for GA4. See the code
+   *  inserted into index.ejs to see how the googlea property was injected
+   *  through the use of the nc.js CLI configurator */
+  sendGA(actionType, url) {
+    if (window.ga === undefined) return;
+    if (window.NC_CONFIG && window.NC_CONFIG.googlea) {
+      const googlea = window.NC_CONFIG.googlea;
+      if (googlea != '0') {
+        window.ga('send', {
+          hitType: 'event',
+          eventCategory: 'Tab',
+          eventAction: actionType,
+          eventLabel: '' + url
+        });
+      }
+    }
+  }
+
   /// UI EVENT HANDLERS /////////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /**

--- a/app/view/netcreate/components/InfoPanel.jsx
+++ b/app/view/netcreate/components/InfoPanel.jsx
@@ -173,7 +173,7 @@ class InfoPanel extends UNISYS.Component {
     } = this.state;
     //send flag in with tableheight
     return (
-      <div>
+      <div className="--InfoPanel">
         <div
           id="tabpanel"
           style={{
@@ -299,18 +299,6 @@ class InfoPanel extends UNISYS.Component {
         </div>
       </div>
     );
-  }
-
-  sendGA(actionType, url) {
-    let googlea = NC_CONFIG.googlea;
-    if (googlea != '0') {
-      ga('send', {
-        hitType: 'event',
-        eventCategory: 'Tab',
-        eventAction: actionType,
-        eventLabel: '' + url
-      });
-    }
   }
 } // class InfoPanel
 

--- a/app/view/netcreate/components/NCGraph.jsx
+++ b/app/view/netcreate/components/NCGraph.jsx
@@ -203,7 +203,11 @@ class NCGraph extends UNISYS.Component {
   render() {
     const { nodeTypes, edgeTypes } = this.state;
     return (
-      <div ref={dom => (this.dom = dom)} style={{ height: '100%' }}>
+      <div
+        className="--NCGraph"
+        ref={dom => (this.dom = dom)}
+        style={{ height: '100%' }}
+      >
         <div style={{ margin: '10px 0 0 10px' }}>
           <div className="tooltipAnchor">
             <span style={{ fontSize: '9px' }}>

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -630,7 +630,7 @@ class NCNode extends UNISYS.Component {
     const defs = UDATA.AppState('TEMPLATE').nodeDefs;
     const bgcolor = backgroundColor + '44'; // hack opacity
     return (
-      <div className="nccomponent">
+      <div className="--NCNode_View nccomponent">
         <div className="view" style={{ background: bgcolor }}>
           {/* BUILT-IN - - - - - - - - - - - - - - - - - */}
           <div className="titlebar">
@@ -638,7 +638,7 @@ class NCNode extends UNISYS.Component {
             <div className="nodenumber">#{id}</div>
           </div>
           {/* TABS - - - - - - - - - - - - - - - - - - - */}
-          <div className="tabcontainer">
+          <div className="--NCNode_View_Tabs tabcontainer">
             {NCUI.RenderTabSelectors(TABS, this.state, this.UISelectTab)}
             <div className="tabview">
               {uSelectedTab === TABS.ATTRIBUTES &&
@@ -649,7 +649,7 @@ class NCNode extends UNISYS.Component {
             </div>
           </div>
           {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
-          <div className="controlbar">
+          <div className="--NCNode_View_Controls controlbar">
             {!editBtnHide && uSelectedTab !== TABS.EDGES && (
               <button
                 id="editbtn"
@@ -700,7 +700,7 @@ class NCNode extends UNISYS.Component {
     const duplicateWarning = UDATA.AppState('TEMPLATE').duplicateWarning;
     const isDuplicate = matchingNodeLabels && matchingNodeLabels.includes(label);
     return (
-      <div>
+      <div className="--NCNode_Edit">
         <div className="screen"></div>
         <div className="nccomponent">
           <div

--- a/app/view/netcreate/components/NCSearch.jsx
+++ b/app/view/netcreate/components/NCSearch.jsx
@@ -109,7 +109,7 @@ class NCSearch extends UNISYS.Component {
     const newNodeBtnDisabled = !isLoggedIn || value === '';
     const key = 'search'; // used for source/target, placeholder for search
     return (
-      <div className="ncsearch">
+      <div className="--NCSearch ncsearch">
         <NCAutoSuggest
           statekey={key}
           value={value}


### PR DESCRIPTION
The `NetCreate.jsx` main `render()` function is somewhat convoluted due to `position:fixed` dev elements and other layout chrome obscuring other elements, making it difficult to discern what is a "panel" in what column. This pull request adds `className` properties of the form `--Element_Subelement` so using Chrome's **Inspect Element** is easier to place within the GUI structure. 

These are the top-level control areas in NetCreate
```
--AppShell
--AppShell_NavBar
--SessionShell_Login
--NetCreate
--NetCreate_Fixed_Top
--NetCreate_Fixed_Top_SaveAlert
--NetCreate_Rows
--NetCreate_Columns
--NetCreate_Column_Left
--NetCreate_Column_NetView
--NetCreate_Column_Break_Info
--NetCreate_Column_Filters_Open
--NetCreate_Column_Filters_Closed
--InfoPanel
--NCGraph
--NCNode_View
--NCNode_View_Tabs
--NCNode_View_Controls
--NCNode_Edit
--NCSearch
```

## TO TEST

These are only classNames and some additional comments that do not change function, so there should be no effect on code operation.

You can use **Inspect Element** and find the containing DIV that has one of the classnames, then in VSCode use **Find in Files** to quickly find the file from which to start looking deeper.
