### PR TITLE
Minor UI fixes

### DIFF
--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -506,23 +506,29 @@ class EdgeTable extends UNISYS.Component {
     }
     const { tableHeight } = this.props;
     const styles = `thead, tbody { font-size: 0.8em }
-                      .table {
-                        display: table; /* override bootstrap for fixed header */
-                        border-spacing: 0;
-                      }
-                      .table th {
-                        position: -webkit-sticky;
-                        position: sticky;
-                        top: 0;
-                        background-color: #eafcff;
-                        border-top: none;
-                      }
-                      xtbody { overflow: auto; }
-                      .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }
-                      `;
-    const attributes = Object.keys(edgeDefs).filter(
+                    .table {
+                      display: table; /* override bootstrap for fixed header */
+                      border-spacing: 0;
+                    }
+                    .table th {
+                      position: -webkit-sticky;
+                      position: sticky;
+                      top: 0;
+                      background-color: #eafcff;
+                      border-top: none;
+                    }
+                    xtbody { overflow: auto; }
+                    .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }
+                    `;
+    let attributes = Object.keys(edgeDefs).filter(
       k => !BUILTIN_FIELDS_EDGE.includes(k)
     );
+
+    // show 'type' between 'source' and 'target' if `type` has been defined
+    // if it isn't defined, just show attribute fields after `source` and 'target`
+    const hasTypeField = edgeDefs['type'];
+    if (hasTypeField) attributes = attributes.filter(a => a !== 'type');
+
     return (
       <div
         onMouseLeave={() => this.onHighlightNode(undefined)}
@@ -570,14 +576,18 @@ class EdgeTable extends UNISYS.Component {
                   {edgeDefs.source.displayLabel} {this.sortSymbol('source')}
                 </Button>
               </th>
-              {/* <th hidden={edgeDefs.type.hidden} width="10%">
-                <Button
-                  size="sm"
-                  onClick={() => this.setSortKey('Relationship', edgeDefs.type.type)}
-                >
-                  {edgeDefs.type.displayLabel} {this.sortSymbol('Relationship')}
-                </Button>
-              </th> */}
+              {hasTypeField && (
+                <th hidden={edgeDefs.type.hidden} width="10%">
+                  <Button
+                    size="sm"
+                    onClick={() =>
+                      this.setSortKey('Relationship', edgeDefs.type.type)
+                    }
+                  >
+                    {edgeDefs.type.displayLabel} {this.sortSymbol('Relationship')}
+                  </Button>
+                </th>
+              )}
               <th hidden={!DBG}>Target ID</th>
               <th width="10%">
                 <Button
@@ -649,7 +659,7 @@ class EdgeTable extends UNISYS.Component {
                     {edge.sourceLabel}
                   </a>
                 </td>
-                {/* <td hidden={edgeDefs.type.hidden}>{edge.type}</td> */}
+                {hasTypeField && <td hidden={edgeDefs.type.hidden}>{edge.type}</td>}
                 {/* Cast to string for edge.target where target is undefined */}
                 <td hidden={!DBG}>{String(edge.target)}</td>
                 <td>

--- a/app/view/netcreate/components/NCAutoSuggest.jsx
+++ b/app/view/netcreate/components/NCAutoSuggest.jsx
@@ -79,6 +79,11 @@ class NCAutoSuggest extends UNISYS.Component {
     const { onChange } = this.props;
     const key = event.target.id;
     const value = event.target.value;
+
+    // save the selection cursor position
+    const selstart = event.target.selectionStart;
+    const inputEl = event.target;
+
     let isValidNode = false;
     UDATA.LocalCall('FIND_MATCHING_NODES', { searchString: value }).then(data => {
       const matches =
@@ -89,7 +94,12 @@ class NCAutoSuggest extends UNISYS.Component {
             })
           : undefined;
       this.setState({ matches, isValidNode });
-      if (typeof onChange === 'function') onChange(key, value);
+      if (typeof onChange === 'function')
+        onChange(key, value, () => {
+          // restore  selection cursor position
+          inputEl.selectionStart = selstart;
+          inputEl.selectionEnd = selstart;
+        });
     });
   }
   /**

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -28,11 +28,15 @@ const { EDITORTYPE, BUILTIN_FIELDS_EDGE } = require('system/util/enum');
 const NCUI = require('../nc-ui');
 const NCAutoSuggest = require('./NCAutoSuggest');
 const NCDialog = require('./NCDialog');
+const SETTINGS = require('settings');
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const DBG = false;
 const PR = 'NCEdge';
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const isAdmin = SETTINGS.IsAdmin();
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const TABS = {
   // Also used as labels
   ATTRIBUTES: 'ATTRIBUTES',
@@ -844,8 +848,17 @@ class NCEdge extends UNISYS.Component {
               </button>
             )}
           </div>
-          {uEditLockMessage && (
-            <div className="message warning">{uEditLockMessage}</div>
+          {!uEditBtnHide && uEditLockMessage && (
+            <div className="message warning" style={{ marginTop: '1em' }}>
+              <p>{uEditLockMessage}</p>
+              <p hidden={!isAdmin}>
+                <b>ADMINISTRATOR ONLY</b>: If you are absolutely sure this is an
+                error, you can force the unlock.
+                <button onClick={this.UIDisableEditMode} style={{ marginLeft: 0 }}>
+                  Force Unlock
+                </button>
+              </p>
+            </div>
           )}
         </div>
       </div>

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -78,8 +78,8 @@
 /* HTML Component Subtypes */
 .nccomponent button.cancelbtn {
   background-color: transparent;
-  border-color: #999;
-  color: #666;
+  border-color: #0004;
+  color: #0006;
 }
 .nccomponent button.sourcetargetbtn {
   border-radius: 15px;

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -649,6 +649,18 @@ class NCNode extends UNISYS.Component {
             </div>
           </div>
           {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
+          {!editBtnHide && editLockMessage && (
+            <div className="message warning" style={{ marginTop: '1em' }}>
+              <p>{editLockMessage}</p>
+              <p hidden={!isAdmin}>
+                <b>ADMINISTRATOR ONLY</b>: If you are absolutely sure this is an
+                error, you can force the unlock.
+                <button onClick={this.UIDisableEditMode} style={{ marginLeft: 0 }}>
+                  Force Unlock
+                </button>
+              </p>
+            </div>
+          )}
           <div className="--NCNode_View_Controls controlbar">
             {!editBtnHide && uSelectedTab !== TABS.EDGES && (
               <button
@@ -660,9 +672,6 @@ class NCNode extends UNISYS.Component {
               </button>
             )}
           </div>
-          {editLockMessage && (
-            <div className="message warning">{editLockMessage}</div>
-          )}
           {isAdmin && !editBtnDisable && !uHideDeleteNodeButton && (
             <div className="controlbar deletenode">
               <div className="message">

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -162,16 +162,16 @@ class NCNode extends UNISYS.Component {
       // isAdmin: false,
       previousState: {},
       // UI State
-      editBtnDisable: false,
-      editBtnHide: false,
+      uEditBtnDisable: false,
+      uEditBtnHide: false,
       uViewMode: VIEWMODE.VIEW,
       uSelectedTab: TABS.ATTRIBUTES,
       selectedEdgeId: null,
-      backgroundColor: 'transparent',
-      isLockedByDB: false, // shows db lock message next to Edit Node button
-      isLockedByTemplate: false,
-      isLockedByImport: false,
-      editLockMessage: '',
+      uBackgroundColor: 'transparent',
+      uIsLockedByDB: false, // shows db lock message next to Edit Node button
+      uIsLockedByTemplate: false,
+      uIsLockedByImport: false,
+      uEditLockMessage: '',
       uHideDeleteNodeButton: TEMPLATE.hideDeleteNodeButton,
       uReplacementNodeId: '',
       uIsValidReplacementNodeID: true,
@@ -231,34 +231,34 @@ class NCNode extends UNISYS.Component {
     const nodeIsLocked = data.lockedNodes.includes(id);
     this.setState(
       {
-        isLockedByDB: nodeIsLocked,
-        isLockedByTemplate: data.templateBeingEdited,
-        isLockedByImport: data.importActive
+        uIsLockedByDB: nodeIsLocked,
+        uIsLockedByTemplate: data.templateBeingEdited,
+        uIsLockedByImport: data.importActive
       },
       () => this.UpdatePermissions()
     );
   }
   UpdatePermissions() {
-    const { isLoggedIn, isLockedByDB, isLockedByTemplate, isLockedByImport } =
+    const { isLoggedIn, uIsLockedByDB, uIsLockedByTemplate, uIsLockedByImport } =
       this.state;
     const TEMPLATE = UDATA.AppState('TEMPLATE');
-    let editLockMessage = '';
-    let editBtnDisable = false;
-    let editBtnHide = true;
-    if (isLoggedIn) editBtnHide = false;
-    if (isLockedByDB) {
-      editBtnDisable = true;
-      editLockMessage += TEMPLATE.nodeIsLockedMessage;
+    let uEditLockMessage = '';
+    let uEditBtnDisable = false;
+    let uEditBtnHide = true;
+    if (isLoggedIn) uEditBtnHide = false;
+    if (uIsLockedByDB) {
+      uEditBtnDisable = true;
+      uEditLockMessage += TEMPLATE.nodeIsLockedMessage;
     }
-    if (isLockedByTemplate) {
-      editBtnDisable = true;
-      editLockMessage += TEMPLATE.templateIsLockedMessage;
+    if (uIsLockedByTemplate) {
+      uEditBtnDisable = true;
+      uEditLockMessage += TEMPLATE.templateIsLockedMessage;
     }
-    if (isLockedByImport) {
-      editBtnDisable = true;
-      editLockMessage += TEMPLATE.importIsLockedMessage;
+    if (uIsLockedByImport) {
+      uEditBtnDisable = true;
+      uEditLockMessage += TEMPLATE.importIsLockedMessage;
     }
-    this.setState({ editBtnDisable, editBtnHide, editLockMessage });
+    this.setState({ uEditBtnDisable, uEditBtnHide, uEditLockMessage });
   }
   ClearSelection() {
     this.ResetState();
@@ -329,7 +329,7 @@ class NCNode extends UNISYS.Component {
         this.IsNodeLocked(nodeIsLocked => {
           this.setState(
             {
-              isLockedByDB: nodeIsLocked
+              uIsLockedByDB: nodeIsLocked
             },
             () => this.UpdatePermissions()
           );
@@ -451,7 +451,7 @@ class NCNode extends UNISYS.Component {
       this.UnlockNode(() => {
         this.setState({
           uViewMode: VIEWMODE.VIEW,
-          isLockedByDB: false
+          uIsLockedByDB: false
         });
       });
     });
@@ -474,7 +474,7 @@ class NCNode extends UNISYS.Component {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// HELPER METHODS
   /**
-   * Sets the background color of the node editor via `backgroundColor` state.
+   * Sets the background color of the node editor via `uBackgroundColor` state.
    * Currently the background color is determined by the template node type
    * color mapping.  This will eventually be replaced with a color manager.
    */
@@ -482,8 +482,8 @@ class NCNode extends UNISYS.Component {
     const { attributes } = this.state;
     const type = attributes && attributes.type;
     const COLORMAP = UDATA.AppState('COLORMAP');
-    const backgroundColor = COLORMAP.nodeColorMap[type] || '#555555';
-    this.setState({ backgroundColor });
+    const uBackgroundColor = COLORMAP.nodeColorMap[type] || '#555555';
+    this.setState({ uBackgroundColor });
   }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -500,7 +500,7 @@ class NCNode extends UNISYS.Component {
    */
   UIRequestEditNode() {
     this.LockNode(lockSuccess => {
-      this.setState({ isLockedByDB: !lockSuccess }, () => {
+      this.setState({ uIsLockedByDB: !lockSuccess }, () => {
         if (lockSuccess) this.EnableEditMode();
       });
     });
@@ -566,7 +566,7 @@ class NCNode extends UNISYS.Component {
     this.UnlockNode(() => {
       this.setState({
         uViewMode: VIEWMODE.VIEW,
-        isLockedByDB: false
+        uIsLockedByDB: false
       });
       UDATA.NetCall('SRV_RELEASE_EDIT_LOCK', { editor: EDITORTYPE.NODE });
     });
@@ -617,10 +617,10 @@ class NCNode extends UNISYS.Component {
   RenderView() {
     const {
       uSelectedTab,
-      backgroundColor,
-      editBtnDisable,
-      editBtnHide,
-      editLockMessage,
+      uBackgroundColor,
+      uEditBtnDisable,
+      uEditBtnHide,
+      uEditLockMessage,
       uHideDeleteNodeButton,
       uReplacementNodeId,
       uIsValidReplacementNodeID,
@@ -628,7 +628,7 @@ class NCNode extends UNISYS.Component {
       label
     } = this.state;
     const defs = UDATA.AppState('TEMPLATE').nodeDefs;
-    const bgcolor = backgroundColor + '44'; // hack opacity
+    const bgcolor = uBackgroundColor + '44'; // hack opacity
     return (
       <div className="--NCNode_View nccomponent">
         <div className="view" style={{ background: bgcolor }}>
@@ -649,9 +649,9 @@ class NCNode extends UNISYS.Component {
             </div>
           </div>
           {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
-          {!editBtnHide && editLockMessage && (
+          {!uEditBtnHide && uEditLockMessage && (
             <div className="message warning" style={{ marginTop: '1em' }}>
-              <p>{editLockMessage}</p>
+              <p>{uEditLockMessage}</p>
               <p hidden={!isAdmin}>
                 <b>ADMINISTRATOR ONLY</b>: If you are absolutely sure this is an
                 error, you can force the unlock.
@@ -662,17 +662,17 @@ class NCNode extends UNISYS.Component {
             </div>
           )}
           <div className="--NCNode_View_Controls controlbar">
-            {!editBtnHide && uSelectedTab !== TABS.EDGES && (
+            {!uEditBtnHide && uSelectedTab !== TABS.EDGES && (
               <button
                 id="editbtn"
                 onClick={this.UIRequestEditNode}
-                disabled={editBtnDisable}
+                disabled={uEditBtnDisable}
               >
                 Edit
               </button>
             )}
           </div>
-          {isAdmin && !editBtnDisable && !uHideDeleteNodeButton && (
+          {isAdmin && !uEditBtnDisable && !uHideDeleteNodeButton && (
             <div className="controlbar deletenode">
               <div className="message">
                 Re-link edges to this Node ID (leave blank to delete edge)
@@ -700,9 +700,9 @@ class NCNode extends UNISYS.Component {
   }
 
   RenderEdit() {
-    const { uSelectedTab, backgroundColor, matchingNodeLabels, label } = this.state;
+    const { uSelectedTab, uBackgroundColor, matchingNodeLabels, label } = this.state;
     const defs = UDATA.AppState('TEMPLATE').nodeDefs;
-    const bgcolor = backgroundColor + '66'; // hack opacity
+    const bgcolor = uBackgroundColor + '66'; // hack opacity
     const matchList = matchingNodeLabels
       ? matchingNodeLabels.map(l => <div key={l}>{l}</div>)
       : undefined;
@@ -716,7 +716,7 @@ class NCNode extends UNISYS.Component {
             className="edit"
             style={{
               background: bgcolor,
-              borderColor: backgroundColor
+              borderColor: uBackgroundColor
             }}
           >
             {/* BUILT-IN - - - - - - - - - - - - - - - - - */}
@@ -763,8 +763,8 @@ class NCNode extends UNISYS.Component {
     const {
       uSelectedTab,
       selectedEdgeId,
-      editBtnDisable,
-      editBtnHide,
+      uEditBtnDisable,
+      uEditBtnHide,
       id,
       label,
       edges
@@ -793,7 +793,7 @@ class NCNode extends UNISYS.Component {
                 <button
                   className="edgebutton"
                   onClick={() => this.UIViewEdge(e.id)}
-                  style={{ backgroundColor: bgcolor }}
+                  style={{ uBackgroundColor: bgcolor }}
                 >
                   {id === e.source ? me : sourceNode.label}
                   &nbsp;<span title={e.type}>{ARROW_RIGHT}</span>&nbsp;
@@ -803,11 +803,11 @@ class NCNode extends UNISYS.Component {
             );
           }
         })}
-        {!editBtnHide && uSelectedTab === TABS.EDGES && (
+        {!uEditBtnHide && uSelectedTab === TABS.EDGES && (
           <button
             className="addedgebutton"
             onClick={this.UIAddEdge}
-            disabled={editBtnDisable}
+            disabled={uEditBtnDisable}
           >
             New Edge
           </button>

--- a/app/view/netcreate/components/NCSearch.jsx
+++ b/app/view/netcreate/components/NCSearch.jsx
@@ -67,14 +67,20 @@ class NCSearch extends UNISYS.Component {
     this.setState({ isLoggedIn: decoded.isValid });
   }
 
-  UIOnChange(key, value) {
+  /**
+   * The callback function (cb) is used to restore the selection point
+   * otherwise the `value` state update will leave the cursor at the end of the field.
+   */
+  UIOnChange(key, value, cb) {
     // Pass the input value (node label search string) to UDATA
     // which will in turn pass the searchLabel back to the SEARCH
     // state handler in the constructor, which will in turn set the state
     // of the input value to be passed on to AutoSuggest
     this.AppCall('SOURCE_SEARCH', { searchString: value });
-    // Update current input value
-    this.setState({ value });
+    // Update current input value and restore the cursor position
+    this.setState({ value }, () => {
+      if (typeof cb === 'function') cb();
+    });
   }
 
   UIOnSelect(key, value, id) {


### PR DESCRIPTION
Numerous minor fixes

## #64 Show "type" column between "source" and "Target"

## #66 "Force Unlock" functionality has been restored.

## #77 Increase contrast of "Cancel" button

## #87 Fix NCSearch cursor
Any edits to the NCSearch field would result in the cursor moving to the end of the field.  This includes:
* Deleting a single letter from the middle of the text
* Inserting a new character in the middle of the text
* Selecting and replacing multiple characters by inserting new characters in the middle of the text.

React state updates were clobbering the whole text input field.  This saves and restores the cursor position.
