### PR TITLE
Feature: Filtered Node/Edge Statistics Summary

### DIFF
--- a/app/view/netcreate/components/NCGraph.jsx
+++ b/app/view/netcreate/components/NCGraph.jsx
@@ -206,7 +206,7 @@ class NCGraph extends UNISYS.Component {
       <div
         className="--NCGraph"
         ref={dom => (this.dom = dom)}
-        style={{ height: '100%' }}
+        style={{ height: '100%', position: 'relative' }}
       >
         <div style={{ margin: '10px 0 0 10px' }}>
           <div className="tooltipAnchor">

--- a/app/view/netcreate/components/filter/FiltersPanel.css
+++ b/app/view/netcreate/components/filter/FiltersPanel.css
@@ -1,0 +1,3 @@
+.filter-group hr {
+  margin: 0.5rem 0 0 0;
+}

--- a/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -33,6 +33,7 @@ class FiltersPanel extends UNISYS.Component {
     super();
 
     this.UpdateFilterDefs = this.UpdateFilterDefs.bind(this);
+    this.UpdateFilteredNCData = this.UpdateFilteredNCData.bind(this);
     this.LookupFilterHelp = this.LookupFilterHelp.bind(this);
     this.OnClearBtnClick = this.OnClearBtnClick.bind(this);
     this.SelectFilterAction = this.SelectFilterAction.bind(this);
@@ -50,14 +51,22 @@ class FiltersPanel extends UNISYS.Component {
       edges: FILTERDEFS.edges,
       filterAction: FILTER.ACTION.FADE,
       focusSourceLabel: undefined,
-      focusRange: undefined
+      focusRange: undefined,
+      statsSummary: ''
     };
     UDATA.OnAppStateChange('FILTERDEFS', this.UpdateFilterDefs);
+    UDATA.OnAppStateChange('FILTEREDNCDATA', this.UpdateFilteredNCData);
   } // constructor
 
+  componentDidMount() {
+    // update filter stats on load
+    const FILTEREDNCDATA = UDATA.AppState('FILTEREDNCDATA');
+    this.UpdateFilteredNCData(FILTEREDNCDATA);
+  }
+
   componentWillUnmount() {
-    // console.error('TBD: gracefully unsubscribe!')
     UDATA.AppStateChangeOff('FILTERDEFS', this.UpdateFilterDefs);
+    UDATA.AppStateChangeOff('FILTEREDNCDATA', this.UpdateFilteredNCData);
   }
 
   UpdateFilterDefs(data) {
@@ -74,6 +83,10 @@ class FiltersPanel extends UNISYS.Component {
         focusRange: data.focus && data.focus.range ? data.focus.range : undefined
       };
     });
+  }
+
+  UpdateFilteredNCData(data = { stats: {} }) {
+    this.setState({ statsSummary: data.stats.statsSummary });
   }
 
   LookupFilterHelp(filterAction) {
@@ -96,7 +109,7 @@ class FiltersPanel extends UNISYS.Component {
   }
 
   render() {
-    const { filterAction, focusRange, focusSourceLabel } = this.state;
+    const { filterAction, focusRange, focusSourceLabel, statsSummary } = this.state;
     const defs = [this.state.nodes, this.state.edges];
 
     // Can we assume TEMPLATE is already loaded by the time we render?
@@ -219,6 +232,16 @@ class FiltersPanel extends UNISYS.Component {
             Clear Filters
           </Button>
         </div>
+        <Label
+          className="small text-muted"
+          style={{
+            fontStyle: 'italic',
+            padding: '0.5em 0 0 0.5em',
+            marginBottom: '0'
+          }}
+        >
+          {statsSummary}
+        </Label>
       </div>
     );
   }

--- a/app/view/netcreate/components/filter/NumberFilter.js
+++ b/app/view/netcreate/components/filter/NumberFilter.js
@@ -85,12 +85,10 @@ class NumberFilter extends React.Component {
   }
 
   OnChangeOperator(e) {
-    this.setState(
-      {
-        operator: e.target.value
-      },
-      this.TriggerChangeHandler
-    );
+    const newstate = { operator: e.target.value };
+    // clear value if NO_OP
+    if (e.target.value === FILTER.OPERATORS.NO_OP.key) newstate.value = '';
+    this.setState(newstate, this.TriggerChangeHandler);
   }
 
   OnChangeValue(e) {

--- a/app/view/netcreate/components/filter/NumberFilter.js
+++ b/app/view/netcreate/components/filter/NumberFilter.js
@@ -96,7 +96,7 @@ class NumberFilter extends React.Component {
   OnChangeValue(e) {
     this.setState(
       {
-        value: e.target.value
+        value: Number(e.target.value)
       },
       this.TriggerChangeHandler
     );

--- a/app/view/netcreate/components/filter/StringFilter.jsx
+++ b/app/view/netcreate/components/filter/StringFilter.jsx
@@ -78,12 +78,10 @@ class StringFilter extends React.Component {
   }
 
   OnChangeOperator(e) {
-    this.setState(
-      {
-        operator: e.target.value
-      },
-      this.TriggerChangeHandler
-    );
+    const newstate = { operator: e.target.value };
+    // clear value if NO_OP
+    if (e.target.value === FILTER.OPERATORS.NO_OP.key) newstate.value = '';
+    this.setState(newstate, this.TriggerChangeHandler);
   }
 
   OnChangeValue(e) {

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -356,12 +356,15 @@ function m_ClearFilters() {
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function m_UpdateFilterStats(NCDATA, FILTEREDNCDATA, filterAction) {
+  const FILTERDEFS = UDATA.AppState('FILTERDEFS');
+  const { transparency } = FILTERDEFS.edges;
+
   const nodeCount = NCDATA.nodes.length;
   const edgeCount = NCDATA.edges.length;
   let filteredNodeCount, filteredEdgeCount;
   if (filterAction === FILTER.ACTION.FADE) {
-    filteredNodeCount = nodeCount - FILTEREDNCDATA.nodes.filter(n => !n.filteredTransparency > 0).length
-    filteredEdgeCount = edgeCount - FILTEREDNCDATA.edges.filter(e => !e.filteredTransparency > 0).length
+    filteredNodeCount = nodeCount - FILTEREDNCDATA.nodes.filter(n => n.filteredTransparency <= transparency).length
+    filteredEdgeCount = edgeCount - FILTEREDNCDATA.edges.filter(e => e.filteredTransparency <= transparency).length
   } else {
     filteredNodeCount = FILTEREDNCDATA.nodes.length;
     filteredEdgeCount = FILTEREDNCDATA.edges.length;
@@ -511,9 +514,7 @@ function m_NodeIsFiltered(node, FILTERDEFS) {
     return false; // remove from array
   } else if (filterAction === FILTER.ACTION.FADE) {
     if (!keepNode) {
-      // for filtering fades, we actually want to set it to 0 not default filtered value
-      // because we're REMOVING the filtered item
-      node.filteredTransparency = 0;
+      node.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
     }
     return true; // don't filter out
   } else if (filterAction === FILTER.ACTION.REDUCE) {
@@ -653,9 +654,7 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDNCD
     return false; // remove from array
   } else if (filterAction === FILTER.ACTION.FADE) {
     if (!keepEdge) {
-      // for filtering fades, we actually want to set it to 0 not default filtered value
-      // because we're REMOVING the filtered item
-      edge.filteredTransparency = 0;
+      edge.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
     }
     return true; // always keep in array
   } else if (filterAction === FILTER.ACTION.REDUCE) {

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -357,14 +357,15 @@ function m_ClearFilters() {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function m_UpdateFilterStats(NCDATA, FILTEREDNCDATA, filterAction) {
   const FILTERDEFS = UDATA.AppState('FILTERDEFS');
-  const { transparency } = FILTERDEFS.edges;
+  const { transparency: transparencyNode } = FILTERDEFS.nodes;
+  const { transparency: transparencyEdge } = FILTERDEFS.edges;
 
   const nodeCount = NCDATA.nodes.length;
   const edgeCount = NCDATA.edges.length;
   let filteredNodeCount, filteredEdgeCount;
   if (filterAction === FILTER.ACTION.FADE) {
-    filteredNodeCount = nodeCount - FILTEREDNCDATA.nodes.filter(n => n.filteredTransparency <= transparency).length
-    filteredEdgeCount = edgeCount - FILTEREDNCDATA.edges.filter(e => e.filteredTransparency <= transparency).length
+    filteredNodeCount = nodeCount - FILTEREDNCDATA.nodes.filter(n => n.filteredTransparency <= transparencyNode).length
+    filteredEdgeCount = edgeCount - FILTEREDNCDATA.edges.filter(e => e.filteredTransparency <= transparencyEdge).length
   } else {
     filteredNodeCount = FILTEREDNCDATA.nodes.length;
     filteredEdgeCount = FILTEREDNCDATA.edges.length;

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -488,7 +488,9 @@ function m_NodeIsFiltered(node, FILTERDEFS) {
     return false; // remove from array
   } else if (filterAction === FILTER.ACTION.FADE) {
     if (!keepNode) {
-      node.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
+      // for filtering fades, we actually want to set it to 0 not default filtered value
+      // because we're REMOVING the filtered item
+      node.filteredTransparency = 0;
     }
     return true; // don't filter out
   } else if (filterAction === FILTER.ACTION.REDUCE) {
@@ -628,7 +630,9 @@ function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDNCD
     return false; // remove from array
   } else if (filterAction === FILTER.ACTION.FADE) {
     if (!keepEdge) {
-      edge.filteredTransparency = transparency; // set the transparency value ... right now it is inefficient to set this at the node / edge level, but that's more flexible
+      // for filtering fades, we actually want to set it to 0 not default filtered value
+      // because we're REMOVING the filtered item
+      edge.filteredTransparency = 0;
     }
     return true; // always keep in array
   } else if (filterAction === FILTER.ACTION.REDUCE) {

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -46,7 +46,7 @@ function DateFormatted() {
  *  -- Supports emojis
  *  -- add `_blank` to `a` tags.
  */
-function Markdownify(str) {
+function Markdownify(str = '') {
   const htmlString = MD.render(str);
   // HACK!!! MDPARSE does not give us direct access to the dom elements, so just
   // hack it by adding to the parsed html string
@@ -269,7 +269,7 @@ function RenderLabel(key, label, helpText) {
   );
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-function RenderMarkdownValue(key, value) {
+function RenderMarkdownValue(key, value = '') {
   const val = String(value);
   return (
     <div id={key} key={`${key}value`} className="viewvalue">


### PR DESCRIPTION
Addresses #84 

## Summary Statistics

* When the FIlter panel is shown, "Showing x/x nodes, y/y edges" is shown immediately at the bottom of the window.
* Defining a filter will update the "Showing..." summary in real time.
* The Filter Summary (gray bar above the graph) will also show the summary statistics even when the Filter panel is collapsed.


## Additional Fixes

* Numeric filters were using string values in the input field, so filters using "id=1" were not working.
* Non-Faded nodes and edges were using default filter transparency levels rather than removing them.
* De-selecting a filter operator now properly clears the value field.  This fixes a bug where deselecting the filter operator would leave the value in the value field, sometimes resultiing in JS errors.
