### PR TITLE
Dev jd/image scaling

### DIFF
--- a/app/init-appshell.jsx
+++ b/app/init-appshell.jsx
@@ -117,9 +117,9 @@ class AppShell extends UNISYS.Component {
             </Nav>
           </Collapse>
         </Navbar>
-        <div style={{ height: '3.5em' }}>
+        {/* <div style={{ height: '3.5em' }}> */}
           {/*/ add space underneath the fixed navbar /*/}
-        </div>
+        {/* </div> */}
         <NetCreate />
       </div>
     );

--- a/app/view/netcreate/NetCreate.jsx
+++ b/app/view/netcreate/NetCreate.jsx
@@ -162,7 +162,10 @@ class NetCreate extends UNISYS.Component {
 
     // note: the navbar is in init-appshell.jsx
     return (
-      <div className="--NetCreate">
+      <div
+        className="--NetCreate"
+        style={{ display: 'flex', flexFlow: 'column', height: '100%' }}
+      >
         <div
           className="--NetCreate_Fixed_Top"
           hidden={this.state.isConnected}
@@ -195,7 +198,7 @@ class NetCreate extends UNISYS.Component {
             display: 'flex',
             flexFlow: 'row nowrap',
             width: '100%',
-            height: '100vh',
+            height: '100%',
             overflow: 'hidden',
             visibility: hideGraph
           }}
@@ -208,7 +211,8 @@ class NetCreate extends UNISYS.Component {
               flex: '1 1 25%',
               maxWidth: '400px',
               padding: '10px',
-              overflow: 'scroll',
+              overflowY: 'scroll',
+              overflowX: 'auto',
               marginTop: '38px'
             }}
           >
@@ -227,29 +231,16 @@ class NetCreate extends UNISYS.Component {
           <div
             className="--NetCreate_Column_NetView"
             id="middle"
-            style={{ backgroundColor: '#fcfcfc', flex: '3 0 60%', marginTop: '38px' }}
+            style={{
+              backgroundColor: '#fcfcfc',
+              flex: '3 0 60%',
+              marginTop: '38px',
+              display: 'flex',
+              flexDirection: 'column'
+            }}
           >
             <InfoPanel />
             <NCGraph />
-            <div
-              className="--NetCreate_Column_Break_Info"
-              style={{
-                fontSize: '10px',
-                position: 'fixed',
-                left: '0px',
-                bottom: '0px',
-                right: '0px',
-                zIndex: '1500',
-                color: '#aaa',
-                backgroundColor: '#eee',
-                padding: '5px 10px'
-              }}
-            >
-              Please contact Professor Kalani Craig, Institute for Digital Arts &
-              Humanities at (812) 856-5721 (BH) or craigkl@indiana.edu with questions
-              or concerns and/or to request information contained on this website in
-              an accessible format.
-            </div>
           </div>
           {/*** RIGHT VIEW COLUMN ***************/}
           {layoutFiltersOpen ? (
@@ -301,6 +292,25 @@ class NetCreate extends UNISYS.Component {
               </Button>
             </div>
           )}
+        </div>
+        <div
+          className="--NetCreate_Column_Break_Info"
+          style={{
+            fontSize: '10px',
+            // position: 'fixed',
+            left: '0px',
+            bottom: '0px',
+            right: '0px',
+            zIndex: '1500',
+            color: '#aaa',
+            backgroundColor: '#eee',
+            padding: '5px 10px'
+          }}
+        >
+          Please contact Professor Kalani Craig, Institute for Digital Arts &
+          Humanities at (812) 856-5721 (BH) or craigkl@indiana.edu with questions or
+          concerns and/or to request information contained on this website in an
+          accessible format.
         </div>
       </div>
     ); // end return

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -410,6 +410,7 @@ class NCEdge extends UNISYS.Component {
    * already locked, so we can't edit.
    */
   EditEdge() {
+    if (!this.IsLoggedIn()) return;
     this.LockEdge(lockSuccess => {
       this.setState({ uIsLockedByDB: !lockSuccess }, () => {
         if (lockSuccess) this.EnableEditMode();

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -624,7 +624,7 @@ class NCEdge extends UNISYS.Component {
    */
   SetBackgroundColor() {
     const { attributes } = this.state;
-    const type = attributes && attributes.type;
+    const type = (attributes && attributes.type) || ''; // COLORMAP uses "" for undefined
     const COLORMAP = UDATA.AppState('COLORMAP');
     const uBackgroundColor = COLORMAP.edgeColorMap[type] || '#555555';
     this.setState({ uBackgroundColor });

--- a/app/view/netcreate/components/NCGraph.jsx
+++ b/app/view/netcreate/components/NCGraph.jsx
@@ -249,9 +249,9 @@ class NCGraph extends UNISYS.Component {
         <div
           style={{
             position: 'absolute',
-            bottom: '40px',
+            bottom: '5px',
             marginLeft: '10px',
-            marginBottom: '15px',
+            marginBottom: '0px',
             fontSize: '10px'
           }}
         >

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -194,7 +194,7 @@
   overflow-wrap: anywhere; /* prevents form extending into graph */
 }
 .nccomponent .formview .viewvalue img {
-  max-height: 100px;
+  max-width: 225px;
 }
 .nccomponent .formview div.targetarrow {
   margin-top: -5px;

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -480,7 +480,7 @@ class NCNode extends UNISYS.Component {
    */
   SetBackgroundColor() {
     const { attributes } = this.state;
-    const type = attributes && attributes.type;
+    const type = (attributes && attributes.type) || ''; // COLORMAP uses "" for undefined
     const COLORMAP = UDATA.AppState('COLORMAP');
     const uBackgroundColor = COLORMAP.nodeColorMap[type] || '#555555';
     this.setState({ uBackgroundColor });

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -499,6 +499,8 @@ class NCNode extends UNISYS.Component {
    * already locked, so we can't edit.
    */
   UIRequestEditNode() {
+    const { isLoggedIn } = this.state;
+    if (!isLoggedIn) return;
     this.LockNode(lockSuccess => {
       this.setState({ uIsLockedByDB: !lockSuccess }, () => {
         if (lockSuccess) this.EnableEditMode();

--- a/app/view/netcreate/components/NodeSelector.css
+++ b/app/view/netcreate/components/NodeSelector.css
@@ -7,7 +7,8 @@
 /* Applies to both NodeSelector, EdgeEditor, NodeTable, and EdgeTable */
 .nodeEntry img,
 .table img {
-  max-width: 100%;
+  max-width: 250px;
+  max-height: 200px;
 }
 
 .nodeEntry textarea[readonly] {

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -188,6 +188,29 @@ function m_ImportFilters() {
   NODE_DEFAULT_TRANSPARENCY = TEMPLATE.nodeDefaultTransparency;
   EDGE_DEFAULT_TRANSPARENCY = TEMPLATE.edgeDefaultTransparency;
 
+  /** HACK Source / Target Filter Definitions
+      Source and Target are normally built-in numeric id fields.
+      But for filtering we want to use the corresponding source/target labels as strings.
+      In m_FiltersDefine we are already injecting `sourceLabel` and `targetLabel` into the edge objects
+      to facilitate filtering (saves an extra lookup).  So we can just repurpose the filter definitions
+      to use sourceLabel and targetLabel.  The tricky part is hiding and re-ordering the numeric id filters.
+  */
+  edgeDefs.sourceLabel = {
+    displayLabel: 'Source',
+    exportLabel: 'Source Label',
+    help: 'Source label',
+    hidden: false,
+    type: 'string'
+  };
+  edgeDefs.targetLabel = {
+    displayLabel: 'Target',
+    exportLabel: 'Target Label',
+    help: 'Target label',
+    hidden: false,
+    type: 'string'
+  };
+  /* END HACK */
+
   let fdefs = {
     nodes: {
       group: 'nodes', // this needs to be passed to StringFilter
@@ -199,6 +222,7 @@ function m_ImportFilters() {
       group: 'edges', // this needs to be passed to StringFilter
       label: 'Edge Filters',
       filters: m_ImportPrompts(edgeDefs),
+      filters: m_ReplaceSourceTargetIdsWithStrings(m_ImportPrompts(edgeDefs)),
       transparency: 0.03 // Default transparency form for Highlight should be 0.03, not template default which is usu 0.3
     },
     focus: {
@@ -270,6 +294,29 @@ function m_ImportPrompts(prompts) {
   }
   return filters;
 }
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** Used to replace the `source` and `target` numeric id filter definitions
+ *  with `sourceLabel` and `targetLabel` string defintions.
+ *  m_ImportPrompts converts the edgeDefs object to an array
+ *  We then insert sourceLabel and targetLabel in place of source and target
+ *  and then remove the now extraneous sourceLabel and targetLabel definitions.
+ *  This is a hacky brute force solution but it gives us better control over
+ *  the field order.
+ */
+function m_ReplaceSourceTargetIdsWithStrings(filters) {
+  const reorderedFilters = [...filters];
+  // Replace `source` with 'sourceLabel'
+  const sourceIndex = 1; // force seccond item // reorderedFilters.findIndex(f => f.key === 'source');
+  const sourceLabelIndex = reorderedFilters.findIndex(f => f.key === 'sourceLabel');
+  reorderedFilters.splice(sourceIndex, 1, reorderedFilters[sourceLabelIndex]);
+  reorderedFilters.splice(sourceLabelIndex, 1);
+  // and 'target' with 'targetLabel'
+  const targetIndex = 2; // force third item // reorderedFilters.findIndex(f => f.key === 'target');
+  const targetLabelIndex = reorderedFilters.findIndex(f => f.key === 'targetLabel');
+  reorderedFilters.splice(targetIndex, 1, reorderedFilters[targetLabelIndex]);
+  reorderedFilters.splice(targetLabelIndex, 1);
+  return reorderedFilters;
+}
 
 /// UDATA HANDLERS ////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -317,6 +364,7 @@ function m_FiltersApply() {
   // skip if FILTERDEFS has not been defined yet
   if (Object.keys(FILTERDEFS).length < 1) return;
 
+  // sourceLabel, targetLabel are available
   // stuff 'sourceLabel' and 'targetLabel' into edges for quicker filtering
   // otherwise we have to constantly look up the node label
   FILTEREDNCDATA.edges = NCDATA.edges.map(e => {

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -221,7 +221,6 @@ function m_ImportFilters() {
     edges: {
       group: 'edges', // this needs to be passed to StringFilter
       label: 'Edge Filters',
-      filters: m_ImportPrompts(edgeDefs),
       filters: m_ReplaceSourceTargetIdsWithStrings(m_ImportPrompts(edgeDefs)),
       transparency: 0.03 // Default transparency form for Highlight should be 0.03, not template default which is usu 0.3
     },

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -64,7 +64,9 @@ function Markdownify(str = '') {
  *  @param {function} cb Callback function
  */
 function m_UIMarkdownInputUpdate(event, cb) {
-  console.warn("WARNNIG: Markdown text is not being error checked!  Use with caution!")
+  console.warn(
+    'WARNNIG: Markdown text is not being error checked!  Use with caution!'
+  );
   const key = event.target.id;
   const value = event.target.value;
   if (typeof cb === 'function') cb(key, value);
@@ -121,11 +123,12 @@ function m_UIInsertImageURL(url, parentId, cb) {
   const event = {
     target: {
       id: parentId,
-      value: currentValue.substring(0, selectionStart)
-        + `![image](${url})`
-        + currentValue.substring(selectionStart)
+      value:
+        currentValue.substring(0, selectionStart) +
+        `![image](${url})` +
+        currentValue.substring(selectionStart)
     }
-  }
+  };
   m_UIMarkdownInputUpdate(event, cb);
 }
 function m_UICancelInsertImageURL() {
@@ -204,10 +207,10 @@ function RenderAttributesTabEdit(state, defs, onchange) {
         items.push(RenderStringInput(k, value, onchange, helpText));
         break;
       case 'number':
-        items.push(m_RenderNumberInput(k, value, onchange));
+        items.push(m_RenderNumberInput(k, value, onchange, helpText));
         break;
       case 'select':
-        items.push(m_RenderOptionsInput(k, value, defs, onchange));
+        items.push(m_RenderOptionsInput(k, value, defs, onchange, helpText));
         break;
       default:
         items.push(RenderStringValue(k, value, onchange)); // display unsupported type
@@ -303,8 +306,10 @@ function RenderMarkdownInput(key, value, cb, helpText) {
       <div className="help">{helpText}</div>
       <button
         className="stylebutton"
-        onClick={() => UDATA.LocalCall("IMAGE_URL_DIALOG_OPEN", { id: key })}
-      >Insert Image URL...</button>
+        onClick={() => UDATA.LocalCall('IMAGE_URL_DIALOG_OPEN', { id: key })}
+      >
+        Insert Image URL...
+      </button>
       <textarea
         id={key}
         key={`${key}input`}


### PR DESCRIPTION
Fixes:
* adjusts scaling tied to markdown-it and builds on #97 
* Only allow node/edge edit if logged in. #96
* Reflow flex layout to account for footer. #98 
* Fix undefined node and edge types properly use the "" (blank) node color
* Fixed help text rendering for selection and number types - the code was there to render but the helpText wasn't passed in