### PR TITLE
Feature: Filter edges by source and target labels, Part 2

### DIFF
--- a/app/init-appshell.jsx
+++ b/app/init-appshell.jsx
@@ -118,7 +118,7 @@ class AppShell extends UNISYS.Component {
           </Collapse>
         </Navbar>
         {/* <div style={{ height: '3.5em' }}> */}
-          {/*/ add space underneath the fixed navbar /*/}
+        {/*/ add space underneath the fixed navbar /*/}
         {/* </div> */}
         <NetCreate />
       </div>

--- a/app/system/util/enum.js
+++ b/app/system/util/enum.js
@@ -32,7 +32,9 @@ ENUM.BUILTIN_FIELDS_EDGE = [
   'degrees',
   'created',
   'updated',
-  'revision'
+  'revision',
+  'sourceLabel', // used internally for filters
+  'targetLabel' // used internally for filters
 ];
 
 /// MODULE EXPORTS ////////////////////////////////////////////////////////////

--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -633,7 +633,7 @@ class EdgeTable extends UNISYS.Component {
                 key={i}
                 style={{
                   color: edge.isFiltered ? 'red' : 'black',
-                  opacity: edge.isFiltered ? edge.filteredTransparency : 1
+                  opacity: edge.filteredTransparency
                 }}
               >
                 <td hidden={!DBG}>{edge.id}</td>

--- a/app/view/netcreate/components/filter/README.md
+++ b/app/view/netcreate/components/filter/README.md
@@ -68,18 +68,16 @@ A few notes:
 
 #### How are Nodes/Edges hidden?
 
-Programmatically, any node or edge that is filtered is marked with a `isFilteredOut` flag.  If `isFilteredOut` is true, the object is hidden.  If `isFilteredOut` is absent or is false, the object is displayed.
+There are three types of filtering:
+* Fade -- Show matches, fade others
+* Reduce -- Show matches, remove others and recalculate sizes
+* Focus -- Show only nodes connected to the selected node within a designated range
 
-Hiding is simply done by setting the opacity of the node or edge.  Nodes and edges are not actually removed from the graph.
+Programmatically, how a node or edge is filtered depends on the filter type.
 
-
-
-### Storyboard
-
-With the Filtering system, we introduce a new development toolkit [storybook.js](https://storybook.js.org/).  This is primarily used for the basic component development and data architecture design.  
-
-* It is not yet fully integrated with the UNISYS architecture.
-* It is not yet fully integrated with bootstrap/css, so components are not displayed using the site's settings.
-
-To run storybook, use `npm run storybook`.
+* Faded nodes/edges have their `.filteredTransparency` value set to either:
+  a. the default transparency level defined in the template (usually 1.0 for nodes, and 0.7 for edges), or
+  b. the transparency level set in the FiltersPane (usually 0.2)
+* Reduced nodes/edges are completely removed the visible data in the table and graph (FILTEREDD3DATA)
+* Focused nodes are also completely removed.
 

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -222,7 +222,7 @@ function m_ImportFilters() {
       group: 'edges', // this needs to be passed to StringFilter
       label: 'Edge Filters',
       filters: m_ReplaceSourceTargetIdsWithStrings(m_ImportPrompts(edgeDefs)),
-      transparency: 0.03 // Default transparency form for Highlight should be 0.03, not template default which is usu 0.3
+      transparency: 0.2 // Default transparency form for Highlight should be 0.2, not template default which is usu 0.7
     },
     focus: {
       source: undefined, // nothing focused by default

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -519,10 +519,7 @@ function m_MatchNumber(operator, filterVal, objVal) {
 
 /// NODE FILTERS //////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/** Side effect:
- *  FILTEREDNCDATA.nodes are updated with `isFilteredOut` flags.
- * @param {Array} filters
- */
+/** Side effect: FILTEREDNCDATA.nodes are updated with a new `filterTransparency`. */
 function m_FiltersApplyToNodes(FILTERDEFS, FILTEREDNCDATA) {
   RemovedNodes = [];
 
@@ -554,7 +551,6 @@ function m_NodeIsFiltered(node, FILTERDEFS) {
   });
 
   // 2. Decide based on filterAction
-  node.isFiltered = false; // always reset if not HIGHLIGHT
   node.filteredTransparency = NODE_DEFAULT_TRANSPARENCY; // always reset if not HIGHLIGHT
   if (filterAction === FILTER.ACTION.FILTER) {
     // not using highlight, so restore transparency
@@ -639,7 +635,8 @@ function m_FiltersApplyToEdges(FILTERDEFS, FILTEREDNCDATA) {
   });
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/** Side effect: Sets `isFiltered`
+/**
+ *  Side effect: FILTEREDNCDATA.edges are updated with a new `filterTransparency`.
  */
 function m_EdgeIsFiltered(edge, filters, transparency, filterAction, FILTEREDNCDATA) {
   // let all_no_op = true; // all filters are no_op


### PR DESCRIPTION
Additional Fixes
* Use filteredTransparency for edge table -- not the old `isFiltered` tag.  Restores correct transparency in edge table view.
* Set default edge transparency to 0.2 to match node fading transparency
* Hide 'sourceLabel' and 'targetLabel' fields in EdgeTable.