### PR TITLE
Feature: Add filters using `&&` or `||` in strings.

### DIFF
--- a/app/view/netcreate/NetCreate.jsx
+++ b/app/view/netcreate/NetCreate.jsx
@@ -197,6 +197,7 @@ class NetCreate extends UNISYS.Component {
           style={{
             display: 'flex',
             flexFlow: 'row nowrap',
+            backgroundColor: '#EEE',
             width: '100%',
             height: '100%',
             overflow: 'hidden',
@@ -243,55 +244,46 @@ class NetCreate extends UNISYS.Component {
             <NCGraph />
           </div>
           {/*** RIGHT VIEW COLUMN ***************/}
-          {layoutFiltersOpen ? (
-            // OPEN
+          <div
+            className="--NetCreate_Column_Filters_Open"
+            id="right"
+            style={{
+              marginTop: '38px',
+              padding: '0 5px',
+              backgroundColor: '#6c757d',
+              borderTopLeftRadius: layoutFiltersOpen ? '10px' : '0',
+              paddingBottom: '25px' // avoid footer
+            }}
+          >
             <div
-              className="--NetCreate_Column_Filters_Open"
-              id="right"
               style={{
-                marginTop: '38px',
-                padding: '0 5px',
-                backgroundColor: '#6c757d',
-                borderTopLeftRadius: '10px',
-                paddingBottom: '25px' // avoid footer
-              }}
-            >
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'end',
-                  height: '100%',
-                  overflow: 'hidden'
-                }}
-              >
-                <Button onClick={this.onFilterBtnClick} style={{ width: '90px' }}>
-                  {FILTER.PANEL_LABEL} &gt;
-                </Button>
-                <FiltersPanel />
-              </div>
-            </div>
-          ) : (
-            // CLOSED
-            <div
-              className="--NetCreate_Column_Filters_Closed"
-              id="right"
-              style={{
-                marginTop: '38px',
-                paddingTop: '0px',
-                backgroundColor: '#6c757d',
-                width: '10px',
-                height: '100%'
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'end',
+                width: layoutFiltersOpen ? '100%' : '0',
+                height: layoutFiltersOpen ? '100%' : 'inherit',
+                overflow: 'hidden'
               }}
             >
               <Button
                 onClick={this.onFilterBtnClick}
-                style={{ width: '90px', float: 'right' }}
+                style={{
+                  width: '90px',
+                  borderTopLeftRadius: '10px',
+                  paddingBottom: '10px',
+                  backgroundColor: '#6c757d',
+                  border: 'none',
+                  boxShadow: 'none',
+                  position: layoutFiltersOpen ? 'inherit' : 'absolute'
+                }}
               >
-                &lt; {FILTER.PANEL_LABEL}
+                {!layoutFiltersOpen && `< `}
+                {FILTER.PANEL_LABEL}
+                {layoutFiltersOpen && ` >`}
               </Button>
+              <FiltersPanel hidden={!layoutFiltersOpen} />
             </div>
-          )}
+          </div>
         </div>
         <div
           className="--NetCreate_Column_Break_Info"

--- a/app/view/netcreate/components/NCAutoSuggest.jsx
+++ b/app/view/netcreate/components/NCAutoSuggest.jsx
@@ -181,7 +181,7 @@ class NCAutoSuggest extends UNISYS.Component {
           ))
         : undefined;
     return (
-      <div style={{ position: 'relative' }}>
+      <div style={{ position: 'relative', flexGrow: '1' }}>
         <div className="helptop">Click on a node, or type a node name</div>
         <input
           id={statekey}

--- a/app/view/netcreate/components/NCSearch.css
+++ b/app/view/netcreate/components/NCSearch.css
@@ -1,9 +1,6 @@
 .ncsearch {
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-auto-columns: 100px;
-  grid-auto-flow: column;
-  column-gap: 10px;
+  display: flex;
+  flex-wrap: wrap;
   margin-top: 38px; /* match navbar height */
   margin-bottom: 20px;
 }

--- a/app/view/netcreate/components/filter/FilterEnums.js
+++ b/app/view/netcreate/components/filter/FilterEnums.js
@@ -60,12 +60,12 @@ FILTER.OPERATORS.CONTAINS = { key: 'CONTAINS', label: 'contains' };
 FILTER.OPERATORS.NOT_CONTAINS = { key: 'NOT_CONTAINS', label: 'does not contain' };
 FILTER.OPERATORS.IS_EMPTY = { key: 'IS_EMPTY', label: 'is empty' };
 FILTER.OPERATORS.IS_NOT_EMPTY = { key: 'IS_NOT_EMPTY', label: 'is not empty' };
+FILTER.OPERATORS.EQ = { key: 'EQ', label: '=' };
+FILTER.OPERATORS.NOT_EQ = { key: 'NOT_EQ', label: `\u2260` };
 FILTER.OPERATORS.GT = { key: 'GT', label: '>' };
 FILTER.OPERATORS.GT_EQ = { key: 'GT_EQ', label: '>=' };
 FILTER.OPERATORS.LT = { key: 'LT', label: '<' };
 FILTER.OPERATORS.LT_EQ = { key: 'LT_EQ', label: '<=' };
-FILTER.OPERATORS.EQ = { key: 'EQ', label: '=' };
-FILTER.OPERATORS.NOT_EQ = { key: 'NOT_EQ', label: `\u2260` };
 
 /// MODULE EXPORTS ////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/view/netcreate/components/filter/FilterEnums.js
+++ b/app/view/netcreate/components/filter/FilterEnums.js
@@ -45,6 +45,7 @@ FILTER.TYPES.NUMBER = 'number';
 FILTER.TYPES.SELECT = 'select';
 FILTER.TYPES.NODE = 'node'; // edge source / target
 FILTER.TYPES.DATE = 'date';
+FILTER.TYPES.MARKDOWN = 'markdown';
 FILTER.TYPES.HIDDEN = 'hidden';
 // Special Edge Keys mapped to node objects
 // Used by m_IsEdgeMatchedByFilter to find node labels

--- a/app/view/netcreate/components/filter/FilterGroup.jsx
+++ b/app/view/netcreate/components/filter/FilterGroup.jsx
@@ -37,8 +37,9 @@ function FilterGroup({ group, label, filters, filterAction, transparency }) {
       </div>
       {filters.map(filter => {
         switch (filter.type) {
-          case FILTER.TYPES.STRING:
+          case FILTER.TYPES.MARKDOWN:
           case FILTER.TYPES.NODE:
+          case FILTER.TYPES.STRING:
             return (
               <StringFilter
                 key={filter.id}

--- a/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -109,6 +109,7 @@ class FiltersPanel extends UNISYS.Component {
   }
 
   render() {
+    const { hidden } = this.props;
     const { filterAction, focusRange, focusSourceLabel, statsSummary } = this.state;
     const defs = [this.state.nodes, this.state.edges];
 
@@ -148,10 +149,10 @@ class FiltersPanel extends UNISYS.Component {
       <div
         className="filterPanel"
         style={{
+          display: hidden ? 'none' : 'flex',
           overflow: 'hidden',
           margin: '6px 0',
           padding: '5px',
-          display: 'flex',
           flexDirection: 'column',
           backgroundColor: '#EEE',
           zIndex: '2000'

--- a/app/view/netcreate/components/filter/NumberFilter.js
+++ b/app/view/netcreate/components/filter/NumberFilter.js
@@ -57,12 +57,12 @@ var UDATA = null;
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const OPERATORS = [
   FILTER.OPERATORS.NO_OP,
-  FILTER.OPERATORS.GT,
-  FILTER.OPERATORS.GT_EQ,
+  FILTER.OPERATORS.EQ,
+  FILTER.OPERATORS.NOT_EQ,
   FILTER.OPERATORS.LT,
   FILTER.OPERATORS.LT_EQ,
-  FILTER.OPERATORS.EQ,
-  FILTER.OPERATORS.NOT_EQ
+  FILTER.OPERATORS.GT,
+  FILTER.OPERATORS.GT_EQ
 ];
 
 /// CLASS DECLARATION /////////////////////////////////////////////////////////

--- a/app/view/netcreate/components/filter/NumberFilter.js
+++ b/app/view/netcreate/components/filter/NumberFilter.js
@@ -39,6 +39,10 @@
   The `id` variable allows us to potentially support multiple search filters
   using the same key, e.g. we could have two 'Label' filters.
 
+  In order to retain the input selection cursor between state updates, we use
+  a secondary state `inputval` that retains the cursor position.
+
+
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
 
 const FILTER = require('./FilterEnums');
@@ -77,7 +81,8 @@ class NumberFilter extends React.Component {
 
     this.state = {
       operator: FILTER.OPERATORS.NO_OP, // Used locally to define result
-      value: '' // Used locally to define result
+      inputval: '', // Used to maintain input caret position
+      value: '' // Used to define the final result
     };
 
     /// Initialize UNISYS DATA LINK for REACT
@@ -91,13 +96,14 @@ class NumberFilter extends React.Component {
     this.setState(newstate, this.TriggerChangeHandler);
   }
 
-  OnChangeValue(e) {
-    this.setState(
-      {
-        value: Number(e.target.value)
-      },
-      this.TriggerChangeHandler
-    );
+  OnChangeValue(event) {
+    const value = Number(event.target.value);
+    // First update the input field, retaining cursor position
+    this.setState({ inputval: value }, () => {
+      // Then send the result
+      this.setState({ value }, this.TriggerChangeHandler);
+    });
+
   }
 
   TriggerChangeHandler() {
@@ -126,6 +132,7 @@ class NumberFilter extends React.Component {
   }
 
   render() {
+    const { inputval } = this.state;
     const { filterAction } = this.props;
     const { id, key, keylabel, operator, value } = this.props.filter;
     return (
@@ -160,8 +167,8 @@ class NumberFilter extends React.Component {
             ))}
           </Input>
           <Input
-            type="text"
-            value={value}
+            type="number"
+            value={inputval}
             placeholder="..."
             style={{ maxWidth: '12em', height: '1.5em', padding: '0' }}
             onChange={this.OnChangeValue}

--- a/app/view/netcreate/components/filter/NumberFilter.js
+++ b/app/view/netcreate/components/filter/NumberFilter.js
@@ -74,6 +74,7 @@ class NumberFilter extends React.Component {
     onChangeHandler
   }) {
     super();
+    this.m_ClearFilters = this.m_ClearFilters.bind(this);
     this.OnChangeOperator = this.OnChangeOperator.bind(this);
     this.OnChangeValue = this.OnChangeValue.bind(this);
     this.TriggerChangeHandler = this.TriggerChangeHandler.bind(this);
@@ -87,12 +88,24 @@ class NumberFilter extends React.Component {
 
     /// Initialize UNISYS DATA LINK for REACT
     UDATA = UNISYS.NewDataLink(this);
+    UDATA.HandleMessage('FILTER_CLEAR', this.m_ClearFilters);
+  }
+
+  componentWillUnmount() {
+    UDATA.UnhandleMessage('FILTER_CLEAR', this.m_ClearFilters);
+  }
+
+  m_ClearFilters() {
+    this.setState({ inputval: '' });
   }
 
   OnChangeOperator(e) {
     const newstate = { operator: e.target.value };
     // clear value if NO_OP
-    if (e.target.value === FILTER.OPERATORS.NO_OP.key) newstate.value = '';
+    if (e.target.value === FILTER.OPERATORS.NO_OP.key) {
+      newstate.inputval = '';
+      newstate.value = '';
+    }
     this.setState(newstate, this.TriggerChangeHandler);
   }
 

--- a/app/view/netcreate/components/filter/README.md
+++ b/app/view/netcreate/components/filter/README.md
@@ -35,6 +35,7 @@ The available types are:
 * "number"
 * "select" -- Drop down menu
 * "node" -- Special type for edge "source" and "target" setting.
+* "markdown" -- Special string subtype that renders markdown as "string" in view mode
 
 Each type has specific operations associated with it, e.g. "string" supports "contains" and "not contains", whereas "number" supports ">" and "!=" etc. 
 

--- a/app/view/netcreate/components/filter/StringFilter.jsx
+++ b/app/view/netcreate/components/filter/StringFilter.jsx
@@ -93,7 +93,6 @@ class StringFilter extends React.Component {
     // First update the input field, retaining cursor position
     this.setState({ inputval: value }, () => {
       // Then send the result
-      // this.setState({ value }, () => this.TriggerChangeHandler());
       this.setState({ value }, this.TriggerChangeHandler);
     });
   }

--- a/app/view/netcreate/components/filter/StringFilter.jsx
+++ b/app/view/netcreate/components/filter/StringFilter.jsx
@@ -34,6 +34,9 @@
   The `id` variable allows us to potentially support multiple search filters
   using the same key, e.g. we could have two 'Label' filters.
 
+  In order to retain the input selection cursor between state updates, we use
+  a secondary state `inputval` that retains the cursor position.
+
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
 
 const FILTER = require('./FilterEnums');
@@ -70,7 +73,8 @@ class StringFilter extends React.Component {
 
     this.state = {
       operator: FILTER.OPERATORS.NO_OP, // Used locally to define result
-      value: '' // Used locally to define result
+      inputval: '', // Used to maintain input caret position
+      value: '' // Used to define the final result
     };
 
     /// Initialize UNISYS DATA LINK for REACT
@@ -84,13 +88,14 @@ class StringFilter extends React.Component {
     this.setState(newstate, this.TriggerChangeHandler);
   }
 
-  OnChangeValue(e) {
-    this.setState(
-      {
-        value: e.target.value
-      },
-      this.TriggerChangeHandler
-    );
+  OnChangeValue(event) {
+    const value = event.target.value;
+    // First update the input field, retaining cursor position
+    this.setState({ inputval: value }, () => {
+      // Then send the result
+      // this.setState({ value }, () => this.TriggerChangeHandler());
+      this.setState({ value }, this.TriggerChangeHandler);
+    });
   }
 
   TriggerChangeHandler() {
@@ -119,6 +124,7 @@ class StringFilter extends React.Component {
   }
 
   render() {
+    const { inputval } = this.state;
     const { filterAction } = this.props;
     const { id, key, keylabel, operator, value } = this.props.filter;
     return (
@@ -154,7 +160,7 @@ class StringFilter extends React.Component {
           </Input>
           <Input
             type="text"
-            value={value}
+            value={inputval}
             placeholder="..."
             style={{ maxWidth: '12em', height: '1.5em' }}
             onChange={this.OnChangeValue}

--- a/app/view/netcreate/components/filter/StringFilter.jsx
+++ b/app/view/netcreate/components/filter/StringFilter.jsx
@@ -66,6 +66,7 @@ class StringFilter extends React.Component {
     onChangeHandler
   }) {
     super();
+    this.m_ClearFilters = this.m_ClearFilters.bind(this);
     this.OnChangeOperator = this.OnChangeOperator.bind(this);
     this.OnChangeValue = this.OnChangeValue.bind(this);
     this.TriggerChangeHandler = this.TriggerChangeHandler.bind(this);
@@ -79,12 +80,24 @@ class StringFilter extends React.Component {
 
     /// Initialize UNISYS DATA LINK for REACT
     UDATA = UNISYS.NewDataLink(this);
+    UDATA.HandleMessage('FILTER_CLEAR', this.m_ClearFilters);
+  }
+
+  componentWillUnmount() {
+    UDATA.UnhandleMessage('FILTER_CLEAR', this.m_ClearFilters);
+  }
+
+  m_ClearFilters() {
+    this.setState({ inputval: '' });
   }
 
   OnChangeOperator(e) {
     const newstate = { operator: e.target.value };
     // clear value if NO_OP
-    if (e.target.value === FILTER.OPERATORS.NO_OP.key) newstate.value = '';
+    if (e.target.value === FILTER.OPERATORS.NO_OP.key) {
+      newstate.inputval = '';
+      newstate.value = '';
+    }
     this.setState(newstate, this.TriggerChangeHandler);
   }
 
@@ -126,6 +139,7 @@ class StringFilter extends React.Component {
     const { inputval } = this.state;
     const { filterAction } = this.props;
     const { id, key, keylabel, operator, value } = this.props.filter;
+
     return (
       <Form inline className="filter-item" key={id} onSubmit={this.OnSubmit}>
         {/* FormGroup needs to unset flexFlow or fields will overflow

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -470,11 +470,31 @@ function m_OperatorToString(operator) {
 
 /// UTILITY FUNCTIONS /////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-function m_MatchString(pin, haystack, contains = true) {
-  pin = NCLOGIC.EscapeRegexChars(pin.trim());
-  const regex = new RegExp(/*'^'+*/ pin, 'i');
+/**
+ *  Match strings, allowing use of `&&` and `||`
+ *  * Matches strings in a flat list of pairs, starting with ORs
+ *  * Does not support grouping
+ *  * Operator precedence: ORs are evaluated first, follwed by ANDs.
+ *  * Extra spaces will be trimmed.
+ *  @param {string} needle aka "needle" in the haystack
+ *  @param {*} haystack
+ *  @param {*} contains
+ *  @returns booleean
+ */
+function m_MatchString(needle, haystack, contains = true) {
+
+  function clean(str) { return NCLOGIC.EscapeRegexChars(String(str).trim()); };
+
+  const ANDNeedles = String(needle).split('&&');
+  const ORNeedleArrs = ANDNeedles.map(ands => String(ands).split(/\|\|/).map(str => String(str).trim()));
+  // For each set of OR Array matches, evaluate the pair
+  const ORResults = ORNeedleArrs.map(pair => pair.reduce((a, b) => a || m_MatchStringSnippet(clean(b), haystack, contains), false));
+  return ORResults.reduce((a, b) => a && b, true)
+}
+function m_MatchStringSnippet(needle, haystack, contains = true) {
+  const regex = new RegExp(/*'^'+*/ needle, 'i');
   let matches;
-  if (pin === '') {
+  if (needle === '') {
     // empty string matches everything
     matches = true;
   } else if (contains) {

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -470,6 +470,8 @@ function m_OperatorToString(operator) {
 
 /// UTILITY FUNCTIONS /////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function clean(str) { return NCLOGIC.EscapeRegexChars(String(str).trim()); };
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /**
  *  Match strings, allowing use of `&&` and `||`
  *  * Matches strings in a flat list of pairs, starting with ORs
@@ -482,14 +484,12 @@ function m_OperatorToString(operator) {
  *  @returns booleean
  */
 function m_MatchString(needle, haystack, contains = true) {
-
-  function clean(str) { return NCLOGIC.EscapeRegexChars(String(str).trim()); };
-
   const ANDNeedles = String(needle).split('&&');
   const ORNeedleArrs = ANDNeedles.map(ands => String(ands).split(/\|\|/).map(str => String(str).trim()));
   // For each set of OR Array matches, evaluate the pair
-  const ORResults = ORNeedleArrs.map(pair => pair.reduce((a, b) => a || m_MatchStringSnippet(clean(b), haystack, contains), false));
-  return ORResults.reduce((a, b) => a && b, true)
+  const ResultsOR = ORNeedleArrs.map(pair => pair.reduce((a, b) => a || m_MatchStringSnippet(clean(b), haystack, true), false));
+  const ResultsAND = ResultsOR.reduce((a, b) => a && b, true);
+  return contains ? ResultsAND : !ResultsAND;
 }
 function m_MatchStringSnippet(needle, haystack, contains = true) {
   const regex = new RegExp(/*'^'+*/ needle, 'i');

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -244,6 +244,7 @@ function m_ImportPrompts(prompts) {
   for (const [key, prompt] of Object.entries(prompts)) {
     let operator;
     switch (prompt.type) {
+      case FILTER.TYPES.MARKDOWN:
       case FILTER.TYPES.STRING:
         operator = FILTER.OPERATORS.NO_OP.key; // default to no_op
         break;


### PR DESCRIPTION
See #83 

Adds ability to define string filters that use `&&` or `||` in strings.

For example:
```
label [ contains ] "Ben || Joshua"     // matches "ben" or "joshua"
label [ contains ] "scuba && diving"   // matches "likes scuba diving in the Maldives"
label [ contains ] "scuba || swim"     // matches "likes scuba" and "likes swimming"
label [ contains ] "scuba || swim && diving"     // matches "likes scuba diving" but not "likes swimming" because it's missing "diving"
```

A few notes:

* The logic with "does not contain" gets a little screwy.  I think it's correct, but you might check on it.  It evaluates the expression, then returns the negative of the whole expression.
* While typing, a blank will evaluate as true, e.g. while typing `scuba &&` will return true for any nodes that have "scuba", but typing `scuba ||` will match ALL nodes since the blank is always true.