### PR TITLE
Feature: Citation Dialog

### DIFF
--- a/app/view/netcreate/components/NCDialog.jsx
+++ b/app/view/netcreate/components/NCDialog.jsx
@@ -11,8 +11,6 @@
       onSelect={this.handleSelection}
     />
 
-  This will look up matching nodes via FIND_MATCHING_NODES nc-logic request.
-
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
 
 const React = require('react');

--- a/app/view/netcreate/components/NCDialogCitation.jsx
+++ b/app/view/netcreate/components/NCDialogCitation.jsx
@@ -1,0 +1,85 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  Citation Dialog
+
+  USE:
+
+    <NCDialogCitation
+      message={message}
+      copymessage={'Copy to Clipboard"}
+      onClose={this.UIHandleClose}
+    />
+
+  This display citation text with a "Copy to Clipboard" button.
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+const React = require('react');
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const DBG = false;
+const PR = 'NCDialogCitation';
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+class NCDialogCitation extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { copiedMessage: '' };
+    this.m_UIOnCopy = this.m_UIOnCopy.bind(this);
+  }
+
+  m_UIOnCopy() {
+    const { onClose } = this.props;
+    const messageEl = document.querySelector('#citationMessage');
+    messageEl.select();
+    document.execCommand('copy'); // deprecated, but other techniques require HTTPS
+    if (typeof onClose === 'function') {
+      this.setState({ copiedMessage: 'Copied to Clipboard!' }, () =>
+        setTimeout(onClose, 500)
+      );
+    }
+  }
+
+  render() {
+    const { copiedMessage } = this.state;
+    const {
+      message = 'message',
+      copymessage = 'Copy to Clipboard',
+      onClose
+    } = this.props;
+    const CopyBtn = <button onClick={this.m_UIOnCopy}>{copymessage}</button>;
+    return (
+      <div className="dialog">
+        <div className="screen"></div>
+        <div className="dialogwindow">
+          <div className="dialogmessage">
+            <textarea
+              id="citationMessage"
+              defaultValue={message}
+              rows="5"
+              cols="60"
+              readOnly
+              style={{
+                fontSize: '12px',
+                fontStyle: 'italic',
+                padding: '5px 10px',
+                border: 'none',
+                color: '#333',
+                background: '#eef'
+              }}
+            />
+          </div>
+          <div className="dialogcontrolbar">
+            {copiedMessage} {CopyBtn}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = NCDialogCitation;

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -815,12 +815,17 @@ class NCEdge extends UNISYS.Component {
       dTargetNode = { label: undefined }
     } = this.state;
     const bgcolor = uBackgroundColor + '66'; // hack opacity
-    const defs = UDATA.AppState('TEMPLATE').edgeDefs;
+    const TEMPLATE = UDATA.AppState('TEMPLATE');
+    const defs = TEMPLATE.edgeDefs;
+    const uShowCitationButton = TEMPLATE.citation && !TEMPLATE.citation.hidden;
     const disableSourceTargetInView = true;
     const citation =
-      `NetCreate ${this.AppState('TEMPLATE').name} network, ` +
+      `NetCreate ${TEMPLATE.name} network, ` +
       `Edge: (ID ${id}), ` +
       `from "${dSourceNode.label}" to "${dTargetNode.label}". ` +
+      (TEMPLATE.citation && TEMPLATE.citation.text
+        ? `${TEMPLATE.citation.text}. `
+        : '') +
       `Last accessed at ${NCUI.DateFormatted()}.`;
 
     return (
@@ -859,13 +864,16 @@ class NCEdge extends UNISYS.Component {
           </div>
           {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
           <div className="controlbar">
-            <button
-              id="citationbtn"
-              className="citationbutton"
-              onClick={this.UICitationShow}
-            >
-              Cite Edge
-            </button>
+            {uShowCitationButton && (
+              <button
+                id="citationbtn"
+                className="citationbutton"
+                onClick={this.UICitationShow}
+              >
+                Cite Edge
+              </button>
+            )}
+            <div style={{ flexGrow: 1 }}></div>
             {!uEditBtnHide && uSelectedTab !== TABS.EDGES && (
               <button
                 id="editbtn"

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -28,6 +28,7 @@ const { EDITORTYPE, BUILTIN_FIELDS_EDGE } = require('system/util/enum');
 const NCUI = require('../nc-ui');
 const NCAutoSuggest = require('./NCAutoSuggest');
 const NCDialog = require('./NCDialog');
+const NCDialogCitation = require('./NCDialogCitation');
 const SETTINGS = require('settings');
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
@@ -106,6 +107,8 @@ class NCEdge extends UNISYS.Component {
     this.UIEnableSourceTargetSelect = this.UIEnableSourceTargetSelect.bind(this);
     this.UISourceTargetInputUpdate = this.UISourceTargetInputUpdate.bind(this);
     this.UISourceTargetInputSelect = this.UISourceTargetInputSelect.bind(this);
+    this.UICitationShow = this.UICitationShow.bind(this);
+    this.UICitationClose = this.UICitationClose.bind(this);
     // RENDERERS -- Main
     this.RenderView = this.RenderView.bind(this);
     this.RenderEdit = this.RenderEdit.bind(this);
@@ -181,6 +184,7 @@ class NCEdge extends UNISYS.Component {
       uEditLockMessage: '',
       uNewNodeKey: undefined,
       uNewNodeLabel: undefined,
+      uShowCitationDialog: false,
 
       // DERIVED VALUES 'd'
       dSourceNode: undefined,
@@ -787,6 +791,14 @@ class NCEdge extends UNISYS.Component {
     this.ValidateSourceTarget(key, value, id);
   }
 
+  UICitationShow(event) {
+    event.stopPropagation();
+    this.setState({ uShowCitationDialog: true });
+  }
+  UICitationClose() {
+    this.setState({ uShowCitationDialog: false });
+  }
+
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// RENDER METHODS
   RenderView() {
@@ -797,12 +809,20 @@ class NCEdge extends UNISYS.Component {
       uEditBtnDisable,
       uEditBtnHide,
       uEditLockMessage,
+      uShowCitationDialog,
+      id,
       dSourceNode = { label: undefined },
       dTargetNode = { label: undefined }
     } = this.state;
     const bgcolor = uBackgroundColor + '66'; // hack opacity
     const defs = UDATA.AppState('TEMPLATE').edgeDefs;
     const disableSourceTargetInView = true;
+    const citation =
+      `NetCreate ${this.AppState('TEMPLATE').name} network, ` +
+      `Edge: (ID ${id}), ` +
+      `from "${dSourceNode.label}" to "${dTargetNode.label}". ` +
+      `Last accessed at ${NCUI.DateFormatted()}.`;
+
     return (
       <div className={`nccomponent ncedge ${animateHeight}`}>
         <div
@@ -839,6 +859,13 @@ class NCEdge extends UNISYS.Component {
           </div>
           {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
           <div className="controlbar">
+            <button
+              id="citationbtn"
+              className="citationbutton"
+              onClick={this.UICitationShow}
+            >
+              Cite Edge
+            </button>
             {!uEditBtnHide && uSelectedTab !== TABS.EDGES && (
               <button
                 id="editbtn"
@@ -862,6 +889,9 @@ class NCEdge extends UNISYS.Component {
             </div>
           )}
         </div>
+        {uShowCitationDialog && (
+          <NCDialogCitation message={citation} onClose={this.UICitationClose} />
+        )}
       </div>
     );
   }

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -259,7 +259,7 @@
 
 .nccomponent .controlbar {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: baseline;
   padding: 10px 0 0 0;
 }

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -259,8 +259,8 @@
 
 .nccomponent .controlbar {
   display: flex;
-  justify-content: flex-end;
-  align-items: top;
+  justify-content: space-between;
+  align-items: baseline;
   padding: 10px 0 0 0;
 }
 
@@ -285,4 +285,10 @@
   font-size: 10px;
   background-color: transparent;
   margin-left: 0;
+}
+.nccomponent .citationbutton {
+  align-self: flex-start;
+  margin-left: 0;
+  border-color: #0002;
+  color: #0006;
 }

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -291,4 +291,5 @@
   margin-left: 0;
   border-color: #0002;
   color: #0006;
+  background-color: transparent;
 }

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -91,7 +91,7 @@ class NCNode extends UNISYS.Component {
     this.ClearSelection = this.ClearSelection.bind(this);
     this.UpdateSelection = this.UpdateSelection.bind(this);
     this.SelectEdgeAndEdit = this.SelectEdgeAndEdit.bind(this);
-    this.SeselectEdge = this.SeselectEdge.bind(this);
+    this.SelectEdge = this.SelectEdge.bind(this);
     // DATA LOADING
     this.LoadNode = this.LoadNode.bind(this);
     this.LoadEdges = this.LoadEdges.bind(this);
@@ -133,7 +133,7 @@ class NCNode extends UNISYS.Component {
     UDATA.HandleMessage('EDIT_PERMISSIONS_UPDATE', this.SetPermissions);
     UDATA.HandleMessage('NODE_EDIT', this.UIRequestEditNode); // Node Table request
     UDATA.HandleMessage('EDGE_SELECT_AND_EDIT', this.SelectEdgeAndEdit);
-    UDATA.HandleMessage('EDGE_DESELECT', this.SeselectEdge);
+    UDATA.HandleMessage('EDGE_DESELECT', this.SelectEdge);
   }
 
   componentDidMount() {
@@ -288,7 +288,7 @@ class NCNode extends UNISYS.Component {
       });
     });
   }
-  SeselectEdge() {
+  SelectEdge() {
     this.setState({ selectedEdgeId: null });
   }
 

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -642,11 +642,16 @@ class NCNode extends UNISYS.Component {
       id,
       label
     } = this.state;
-    const defs = UDATA.AppState('TEMPLATE').nodeDefs;
+    const TEMPLATE = UDATA.AppState('TEMPLATE');
+    const defs = TEMPLATE.nodeDefs;
+    const uShowCitationButton = TEMPLATE.citation && !TEMPLATE.citation.hidden;
     const bgcolor = uBackgroundColor + '44'; // hack opacity
     const citation =
-      `NetCreate ${this.AppState('TEMPLATE').name} network, ` +
+      `NetCreate ${TEMPLATE.name} network, ` +
       `Node: "${label}" (ID ${id}). ` +
+      (TEMPLATE.citation && TEMPLATE.citation.text
+        ? `${TEMPLATE.citation.text}. `
+        : '') +
       `Last accessed at ${NCUI.DateFormatted()}.`;
 
     return (
@@ -682,13 +687,16 @@ class NCNode extends UNISYS.Component {
             </div>
           )}
           <div className="--NCNode_View_Controls controlbar">
-            <button
-              id="citationbtn"
-              className="citationbutton"
-              onClick={this.UICitationShow}
-            >
-              Cite Node
-            </button>
+            {uShowCitationButton && (
+              <button
+                id="citationbtn"
+                className="citationbutton"
+                onClick={this.UICitationShow}
+              >
+                Cite Node
+              </button>
+            )}
+            <div style={{ flexGrow: 1 }}></div>
             {!uEditBtnHide && uSelectedTab !== TABS.EDGES && (
               <button
                 id="editbtn"

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -43,6 +43,7 @@ const EDGEMGR = require('../edge-mgr'); // handles edge synthesis
 const { EDITORTYPE, BUILTIN_FIELDS_NODE } = require('system/util/enum');
 const NCUI = require('../nc-ui');
 const NCEdge = require('./NCEdge');
+const NCDialogCitation = require('./NCDialogCitation');
 const SETTINGS = require('settings');
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
@@ -116,6 +117,8 @@ class NCNode extends UNISYS.Component {
     this.UILabelInputUpdate = this.UILabelInputUpdate.bind(this);
     this.UIViewEdge = this.UIViewEdge.bind(this);
     this.UIEditEdge = this.UIEditEdge.bind(this);
+    this.UICitationShow = this.UICitationShow.bind(this);
+    this.UICitationClose = this.UICitationClose.bind(this);
     // RENDERERS -- Main
     this.RenderView = this.RenderView.bind(this);
     this.RenderEdit = this.RenderEdit.bind(this);
@@ -175,6 +178,7 @@ class NCNode extends UNISYS.Component {
       uHideDeleteNodeButton: TEMPLATE.hideDeleteNodeButton,
       uReplacementNodeId: '',
       uIsValidReplacementNodeID: true,
+      uShowCitationDialog: false,
       // NODE DEFS
       id: null,
       label: '',
@@ -494,6 +498,7 @@ class NCNode extends UNISYS.Component {
     this.setState({ uSelectedTab });
     if (event.target.value !== TABS.EDGES) UDATA.LocalCall('EDGE_DESELECT');
   }
+
   /**
    * If `lockNode` is not successful, then that means the node was
    * already locked, so we can't edit.
@@ -614,6 +619,13 @@ class NCNode extends UNISYS.Component {
     );
   }
 
+  UICitationShow() {
+    this.setState({ uShowCitationDialog: true });
+  }
+  UICitationClose() {
+    this.setState({ uShowCitationDialog: false });
+  }
+
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// RENDER METHODS
   RenderView() {
@@ -626,11 +638,17 @@ class NCNode extends UNISYS.Component {
       uHideDeleteNodeButton,
       uReplacementNodeId,
       uIsValidReplacementNodeID,
+      uShowCitationDialog,
       id,
       label
     } = this.state;
     const defs = UDATA.AppState('TEMPLATE').nodeDefs;
     const bgcolor = uBackgroundColor + '44'; // hack opacity
+    const citation =
+      `NetCreate ${this.AppState('TEMPLATE').name} network, ` +
+      `Node: "${label}" (ID ${id}). ` +
+      `Last accessed at ${NCUI.DateFormatted()}.`;
+
     return (
       <div className="--NCNode_View nccomponent">
         <div className="view" style={{ background: bgcolor }}>
@@ -664,6 +682,13 @@ class NCNode extends UNISYS.Component {
             </div>
           )}
           <div className="--NCNode_View_Controls controlbar">
+            <button
+              id="citationbtn"
+              className="citationbutton"
+              onClick={this.UICitationShow}
+            >
+              Cite Node
+            </button>
             {!uEditBtnHide && uSelectedTab !== TABS.EDGES && (
               <button
                 id="editbtn"
@@ -697,6 +722,9 @@ class NCNode extends UNISYS.Component {
             </div>
           )}
         </div>
+        {uShowCitationDialog && (
+          <NCDialogCitation message={citation} onClose={this.UICitationClose} />
+        )}
       </div>
     );
   }

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -35,8 +35,8 @@ const UDATA = UNISYS.NewDataLink(MOD);
 function DateFormatted() {
   var today = new Date();
   var year = String(today.getFullYear());
-  var date = today.getMonth() + 1 + '/' + today.getDate() + '/' + year.substr(2, 4);
-  var time = today.toTimeString().substr(0, 5);
+  var date = today.getMonth() + 1 + '/' + today.getDate() + '/' + year.substring(2, 4);
+  var time = today.toTimeString().substring(0, 5);
   var dateTime = time + ' on ' + date;
   return dateTime;
 }


### PR DESCRIPTION
Addresses #86 

This re-implements the ability to cite nodes and edges. Clicking the "Cite Node" and "Cite Edge" buttons will show a dialog with the citation text with a "Copy to Clipboard" button.  Clicking the button will close the window and copy the text to the clipboard.  

This works on most browsers.  Tested on:
* Chrome
* FireFox
* Safari
* DuckDuckGo
* Edge (Windows)

e.g.
![screenshot_1362](https://github.com/netcreateorg/netcreate-itest/assets/1403057/4b0f4ee7-4eef-41b9-9bac-7ec8f3b017f9)

```
NetCreate Tacitus network, Node: "Nero" (ID 5). Last accessed at 09:26 on 11/29/23.
```
```
NetCreate Tacitus network, Edge: (ID 8), from "Nero" to "Tacitus". Last accessed at 09:27 on 11/29/23.
```

#### NOTES
* Edge definitions (and Node too?) used to have a `Citation` field that would show bibliographic references.  Clicking on the "Cite Edge" field would reference that field.  With the changeover to built-in fields (source, target) and arbitrary attributes fields (everything else), we no longer have the ability to do that, since a `citation` field may or may not exist.  So currently we do not reference the `citation` field.  One possible workaround is to add support that will automatically add any field named `citation` (if it exists) to the citation text, and to ignore the text otherwise.  Should we add that?  Do you want to call it `citation`?  Something else?
For reference, this is what the citation used to look like:
```
                NetCreate {this.AppState('TEMPLATE').name} network, Edge:{' '}
                {this.state.formData.label} (ID {this.state.formData.id}), from &quot;
                {sourceNode.label}&quot; to &quot;{targetNode.label}&quot;.{' '}
                {citation.text}. Last accessed at {this.dateFormatted()}.
```