### PR TITLE
Feature: "Cancel" newly-created unsaved node/edge removes it

### DIFF
--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -974,7 +974,7 @@ class NCEdge extends UNISYS.Component {
             </div>
             {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
             <div className="controlbar" style={{ justifyContent: 'space-between' }}>
-              {revision > 0 && (
+              {revision > -1 && (
                 <button className="cancelbtn" onClick={this.UIDeleteEdge}>
                   Delete
                 </button>

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -75,6 +75,7 @@ class NCEdge extends UNISYS.Component {
     this.ReqLoadEdge = this.ReqLoadEdge.bind(this);
     // DATA LOADING
     this.LoadEdge = this.LoadEdge.bind(this);
+    this.DeleteEdge = this.DeleteEdge.bind(this);
     this.LoadAttributes = this.LoadAttributes.bind(this);
     this.LockEdge = this.LockEdge.bind(this);
     this.UnlockEdge = this.UnlockEdge.bind(this);
@@ -160,9 +161,9 @@ class NCEdge extends UNISYS.Component {
       targetId: null,
       attributes: [],
       provenance: [],
-      // created: undefined,
-      // updated: undefined,
-      // revision: 0
+      created: undefined,
+      updated: undefined,
+      revision: 0,
 
       // SYSTEM STATE
       // isLoggedIn: false, // don't clear session state!
@@ -313,11 +314,11 @@ class NCEdge extends UNISYS.Component {
         id: edge.id,
         sourceId: edge.source,
         targetId: edge.target,
-        attributes: attributes
-        // provenance: edge.provenance,
-        // created: edge.created,
-        // updated: edge.updated,
-        // revision: edge.revision
+        attributes: attributes,
+        provenance: edge.provenance,
+        created: edge.created,
+        updated: edge.updated,
+        revision: edge.revision
       },
       () => this.UpdateDerivedValues()
     );
@@ -591,12 +592,30 @@ class NCEdge extends UNISYS.Component {
   /// DATA SAVING
   ///
   SaveEdge() {
-    const { id, sourceId, targetId, attributes, provenance } = this.state;
+    const {
+      id,
+      sourceId,
+      targetId,
+      attributes,
+      provenance,
+      created,
+      updated,
+      revision
+    } = this.state;
+
+    // update revision number
+    const updatedRevision = revision + 1;
+    // update time stamp
+    const timestamp = new Date().toLocaleString('en-US');
+
     const edge = {
       id,
       source: sourceId,
       target: targetId,
-      provenance
+      provenance,
+      created,
+      updated: timestamp,
+      revision: updatedRevision
     };
     Object.keys(attributes).forEach(k => (edge[k] = attributes[k]));
     this.AppCall('DB_UPDATE', { edge }).then(() => {
@@ -608,10 +627,16 @@ class NCEdge extends UNISYS.Component {
         this.setState({
           uViewMode: NCUI.VIEWMODE.VIEW,
           uIsLockedByDB: false,
-          uSelectSourceTarget: undefined
+          uSelectSourceTarget: undefined,
+          updated: edge.updated,
+          revision: edge.revision
         });
       });
     });
+  }
+  DeleteEdge() {
+    const { id } = this.state;
+    this.AppCall('DB_UPDATE', { edgeID: id }); // Calling DB_UPDATE with `edgeID` will remove the edge
   }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -706,7 +731,15 @@ class NCEdge extends UNISYS.Component {
   }
 
   UICancelEditMode() {
-    const { previousState } = this.state;
+    const { revision, previousState } = this.state;
+
+    // if user is cancelling a newly created unsaved edge, delete the edge instead
+    if (revision < 0) {
+      this.UIDisableEditMode();
+      this.DeleteEdge();
+      return;
+    }
+
     // restore previous state
     this.setState(
       {
@@ -738,9 +771,8 @@ class NCEdge extends UNISYS.Component {
   }
 
   UIDeleteEdge() {
-    const { id } = this.state;
     this.UIDisableEditMode();
-    this.AppCall('DB_UPDATE', { edgeID: id }); // Calling DB_UPDATE with `edgeID` will remove the edge
+    this.DeleteEdge();
   }
 
   UIInputUpdate(key, value) {
@@ -871,6 +903,7 @@ class NCEdge extends UNISYS.Component {
     const {
       sourceId,
       targetId,
+      revision,
       uSelectedTab,
       uSelectSourceTarget,
       uBackgroundColor,
@@ -941,9 +974,11 @@ class NCEdge extends UNISYS.Component {
             </div>
             {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
             <div className="controlbar" style={{ justifyContent: 'space-between' }}>
-              <button className="cancelbtn" onClick={this.UIDeleteEdge}>
-                Delete
-              </button>
+              {revision > 0 && (
+                <button className="cancelbtn" onClick={this.UIDeleteEdge}>
+                  Delete
+                </button>
+              )}
               <button className="cancelbtn" onClick={this.UICancelEditMode}>
                 Cancel
               </button>

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -109,7 +109,7 @@ class NCNode extends UNISYS.Component {
     this.UIRequestEditNode = this.UIRequestEditNode.bind(this);
     this.UIReplacementNodeIdUpdate = this.UIReplacementNodeIdUpdate.bind(this);
     this.UIAddEdge = this.UIAddEdge.bind(this);
-    this.EnableEditMode = this.EnableEditMode.bind(this);
+    this.UIEnableEditMode = this.UIEnableEditMode.bind(this);
     this.UICancelEditMode = this.UICancelEditMode.bind(this);
     this.UIDisableEditMode = this.UIDisableEditMode.bind(this);
     this.UIInputUpdate = this.UIInputUpdate.bind(this);
@@ -157,6 +157,17 @@ class NCNode extends UNISYS.Component {
   ResetState() {
     const TEMPLATE = this.AppState('TEMPLATE');
     this.setState({
+      // NODE DEFS
+      id: null,
+      label: '',
+      degrees: null,
+      attributes: [],
+      provenance: [],
+      created: undefined,
+      updated: undefined,
+      revision: 0,
+      // EDGES
+      edges: [], // selected nodes' edges not ALL edges
       // SYSTEM STATE
       // isLoggedIn: false, // don't clear session state!
       // isAdmin: false,
@@ -174,18 +185,7 @@ class NCNode extends UNISYS.Component {
       uEditLockMessage: '',
       uHideDeleteNodeButton: TEMPLATE.hideDeleteNodeButton,
       uReplacementNodeId: '',
-      uIsValidReplacementNodeID: true,
-      // NODE DEFS
-      id: null,
-      label: '',
-      degrees: null,
-      attributes: [],
-      provenance: [],
-      created: undefined,
-      updated: undefined,
-      revision: 0,
-      // EDGES
-      edges: [] // selected nodes' edges not ALL edges
+      uIsValidReplacementNodeID: true
     });
   }
 
@@ -517,7 +517,7 @@ class NCNode extends UNISYS.Component {
     if (!isLoggedIn) return;
     this.LockNode(lockSuccess => {
       this.setState({ uIsLockedByDB: !lockSuccess }, () => {
-        if (lockSuccess) this.EnableEditMode();
+        if (lockSuccess) this.UIEnableEditMode();
       });
     });
   }
@@ -548,7 +548,7 @@ class NCNode extends UNISYS.Component {
     });
   }
 
-  EnableEditMode() {
+  UIEnableEditMode() {
     const { uSelectedTab, label, attributes, provenance } = this.state;
     // If user was on Edges tab while requesting edit (e.g. from Node Table), then
     // switch to Attributes tab first.

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -188,7 +188,7 @@ class NCNode extends UNISYS.Component {
       uEditLockMessage: '',
       uHideDeleteNodeButton: TEMPLATE.hideDeleteNodeButton,
       uReplacementNodeId: '',
-      uIsValidReplacementNodeID: true
+      uIsValidReplacementNodeID: true,
       uShowCitationDialog: false
     });
   }

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -441,7 +441,19 @@ class NCNode extends UNISYS.Component {
     const { id, label, attributes, provenance, created, updated, revision } =
       this.state;
 
-    const node = { id, label, provenance, created, updated, revision };
+    // update revision number
+    const updatedRevision = revision + 1;
+    // update time stamp
+    const timestamp = new Date().toLocaleString('en-US');
+
+    const node = {
+      id,
+      label,
+      provenance,
+      created,
+      updated: timestamp,
+      revision: updatedRevision
+    };
     Object.keys(attributes).forEach(k => (node[k] = attributes[k]));
 
     // write data to database
@@ -451,7 +463,9 @@ class NCNode extends UNISYS.Component {
       this.UnlockNode(() => {
         this.setState({
           uViewMode: VIEWMODE.VIEW,
-          uIsLockedByDB: false
+          uIsLockedByDB: false,
+          updated: node.updated,
+          revision: node.revision
         });
       });
     });

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -566,7 +566,14 @@ class NCNode extends UNISYS.Component {
   }
 
   UICancelEditMode() {
-    const { previousState } = this.state;
+    const { revision, previousState } = this.state;
+
+    // if user is cancelling a newly created unsaved node, delete the node instead
+    if (revision < 0) {
+      this.DeleteNode();
+      return;
+    }
+
     // restore previous state
     this.setState(
       {

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -570,6 +570,7 @@ class NCNode extends UNISYS.Component {
 
     // if user is cancelling a newly created unsaved node, delete the node instead
     if (revision < 0) {
+      this.UIDisableEditMode();
       this.DeleteNode();
       return;
     }

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -502,7 +502,11 @@ MOD.Hook('INITIALIZE', () => {
     const provenance_str = `Added by ${session.token} on ${timestamp}`;
 
     return DATASTORE.PromiseNewNodeID().then(newNodeID => {
-      const node = { id: newNodeID, label: data.label, provenance: provenance_str };
+      const node = {
+        id: newNodeID, label: data.label, provenance: provenance_str,
+        created: timestamp,
+        revision: -1
+      };
       return UDATA.LocalCall('DB_UPDATE', { node }).then(() => {
         NCDATA.nodes.push(node);
         UDATA.SetAppState('NCDATA', NCDATA);

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -498,7 +498,7 @@ MOD.Hook('INITIALIZE', () => {
   UDATA.HandleMessage('NODE_CREATE', data => {
     // provenance
     const session = UDATA.AppState('SESSION');
-    const timestamp = new Date().toLocaleDateString('en-US');
+    const timestamp = new Date().toLocaleString('en-US');
     const provenance_str = `Added by ${session.token} on ${timestamp}`;
 
     return DATASTORE.PromiseNewNodeID().then(newNodeID => {

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -617,6 +617,11 @@ MOD.Hook('INITIALIZE', () => {
    *  @param {string} data.nodeId
    */
   UDATA.HandleMessage('EDGE_CREATE', data => {
+    // provenance
+    const session = UDATA.AppState('SESSION');
+    const timestamp = new Date().toLocaleString('en-US');
+    const provenance = `Added by ${session.token} on ${timestamp}`;
+
     // call server to retrieve an unused edge ID
     return DATASTORE.PromiseNewEdgeID().then(newEdgeID => {
       // Add it to local state for now
@@ -624,7 +629,10 @@ MOD.Hook('INITIALIZE', () => {
         id: newEdgeID,
         source: data.nodeId,
         target: undefined,
-        attributes: {}
+        attributes: {},
+        provenance,
+        created: timestamp,
+        revision: -1
       };
       return UDATA.LocalCall('DB_UPDATE', { edge }).then(() => {
         console.log('...DB_UPDATE node is now', edge);

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -499,11 +499,11 @@ MOD.Hook('INITIALIZE', () => {
     // provenance
     const session = UDATA.AppState('SESSION');
     const timestamp = new Date().toLocaleString('en-US');
-    const provenance_str = `Added by ${session.token} on ${timestamp}`;
+    const provenance = `Added by ${session.token} on ${timestamp}`;
 
     return DATASTORE.PromiseNewNodeID().then(newNodeID => {
       const node = {
-        id: newNodeID, label: data.label, provenance: provenance_str,
+        id: newNodeID, label: data.label, provenance,
         created: timestamp,
         revision: -1
       };


### PR DESCRIPTION
Addresses #53 

If you create a new node, then change your mind and decide to cancel the creation, the new node will be deleted.  (When the user clicks "New Node", a node is immediately created and saved.  Prior to this, clicking "Cancel" would leave the newly created node in place).

Similarly, if you create a new edge, then change your mind and decide to cancel the creation, the new edge will be deleted.

ADDITIONAL NOTES:
* We re-added support for the `Revision` field.  We make use of this to decide whether to delete a "Canceled" node/edge.  Upon creation, a new node/edge has a revision value of `-1`.  When you save the node/edge the revision is incremented to 0.  If you "Cancel" a node or edge edit and the revision is still at `-1`, we delete the node or edge.
* The "Delete" button in Edge Edit mode is now only shown if the edge has been previously saved.  Otherwise it only shows "Cancel".  This makes it clearer that when you click "Cancel" on an newly-created unsaved edge, the edge will be removed, matching the node behavior.
* We re-added support for the `Created` and `Updated` fields.  Prior to this they were left blank.