### PR TITLE
Created, Updated, Revision Handling and Table Filter Fixes

### DIFF
--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -164,7 +164,7 @@ class EdgeTable extends UNISYS.Component {
       ) {
         edges = edges.filter(edge => {
           const filteredEdge = filteredEdges.find(n => n.id === edge.id);
-          return edge;
+          return filteredEdge; // keep if it's in the list of filtered edges
         });
       } else {
         edges = edges.map(edge => {

--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -607,6 +607,16 @@ class EdgeTable extends UNISYS.Component {
                   </Button>
                 </th>
               ))}
+              <th width="10%" hidden={edgeDefs.provenance.hidden}>
+                <Button
+                  size="sm"
+                  onClick={() =>
+                    this.setSortKey('provenance', edgeDefs.provenance.type)
+                  }
+                >
+                  {edgeDefs.provenance.displayLabel} {this.sortSymbol('provenance')}
+                </Button>
+              </th>
               {/*
               <th width="7%" hidden={!isAdmin}>
                 <Button
@@ -678,6 +688,7 @@ class EdgeTable extends UNISYS.Component {
                       : edge[a]}
                   </td>
                 ))}
+                <td hidden={edgeDefs.provenance.hidden}>{edge.provenance}</td>
                 {/*
                 <td hidden={!isAdmin} style={{ fontSize: '9px' }}>
                   {this.displayUpdated(edge)}

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -1006,7 +1006,7 @@ class NCEdge extends UNISYS.Component {
                 {uSelectedTab === TABS.ATTRIBUTES &&
                   NCUI.RenderAttributesTabEdit(this.state, defs, this.UIInputUpdate)}
                 {uSelectedTab === TABS.PROVENANCE &&
-                  NCUI.RenderProvenanceTabEdit(this.state, defs)}
+                  NCUI.RenderProvenanceTabEdit(this.state, defs, this.UIInputUpdate)}
               </div>
             </div>
             {/* CONTROL BAR - - - - - - - - - - - - - - - - */}

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -724,7 +724,7 @@ class NCEdge extends UNISYS.Component {
     const { revision, previousState } = this.state;
 
     // if user is cancelling a newly created unsaved edge, delete the edge instead
-    if (revision < 0) {
+    if (revision < 1) {
       this.UIDisableEditMode();
       this.DeleteEdge();
       return;
@@ -999,7 +999,7 @@ class NCEdge extends UNISYS.Component {
             </div>
             {/* CONTROL BAR - - - - - - - - - - - - - - - - */}
             <div className="controlbar" style={{ justifyContent: 'space-between' }}>
-              {revision > -1 && (
+              {revision > 0 && (
                 <button className="cancelbtn" onClick={this.UIDeleteEdge}>
                   Delete
                 </button>

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -322,9 +322,9 @@ class NCEdge extends UNISYS.Component {
         targetId: edge.target,
         attributes: attributes,
         provenance: edge.provenance,
-        created: edge.created,
-        updated: edge.updated,
-        revision: edge.revision
+        created: edge.meta ? new Date(edge.meta.created).toLocaleString() : '',
+        updated: edge.meta ? new Date(edge.meta.updated).toLocaleString() : '',
+        revision: edge.meta ? edge.meta.revision : ''
       },
       () => this.UpdateDerivedValues()
     );
@@ -594,32 +594,21 @@ class NCEdge extends UNISYS.Component {
   /// DATA SAVING
   ///
   SaveEdge() {
-    const {
-      id,
-      sourceId,
-      targetId,
-      attributes,
-      provenance,
-      created,
-      updated,
-      revision
-    } = this.state;
-
-    // update revision number
-    const updatedRevision = revision + 1;
-    // update time stamp
-    const timestamp = new Date().toLocaleString('en-US');
+    const { id, sourceId, targetId, attributes, provenance } = this.state;
 
     const edge = {
       id,
       source: sourceId,
       target: targetId,
-      provenance,
-      created,
-      updated: timestamp,
-      revision: updatedRevision
+      provenance
     };
     Object.keys(attributes).forEach(k => (edge[k] = attributes[k]));
+
+    this.setState(
+      {
+        uViewMode: NCUI.VIEWMODE.VIEW
+      },
+      () => {
     this.AppCall('DB_UPDATE', { edge }).then(() => {
       this.UnlockEdge(() => {
         // Clear the secondary selection
@@ -627,14 +616,13 @@ class NCEdge extends UNISYS.Component {
 
         UDATA.LocalCall('SELECTMGR_SET_MODE', { mode: 'normal' });
         this.setState({
-          uViewMode: NCUI.VIEWMODE.VIEW,
           uIsLockedByDB: false,
-          uSelectSourceTarget: undefined,
-          updated: edge.updated,
-          revision: edge.revision
+              uSelectSourceTarget: undefined
         });
       });
     });
+  }
+    );
   }
   DeleteEdge() {
     const { id } = this.state;

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -53,10 +53,6 @@ const PR = 'NCNode';
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const isAdmin = SETTINGS.IsAdmin();
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const VIEWMODE = {
-  EDIT: 'edit',
-  VIEW: 'view'
-};
 const TABS = {
   // Also used as labels
   ATTRIBUTES: 'ATTRIBUTES',
@@ -179,7 +175,7 @@ class NCNode extends UNISYS.Component {
       // UI State
       uEditBtnDisable: false,
       uEditBtnHide: false,
-      uViewMode: VIEWMODE.VIEW,
+      uViewMode: NCUI.VIEWMODE.VIEW,
       uSelectedTab: TABS.ATTRIBUTES,
       selectedEdgeId: null,
       uBackgroundColor: 'transparent',
@@ -200,7 +196,7 @@ class NCNode extends UNISYS.Component {
   ///
   CheckUnload(event) {
     event.preventDefault();
-    if (this.state.uViewMode === VIEWMODE.EDIT) {
+    if (this.state.uViewMode === NCUI.VIEWMODE.EDIT) {
       (event || window.event).returnValue = null;
     } else {
       Reflect.deleteProperty(event, 'returnValue');
@@ -208,7 +204,7 @@ class NCNode extends UNISYS.Component {
     return event;
   }
   DoUnload(event) {
-    if (this.state.uViewMode === VIEWMODE.EDIT) {
+    if (this.state.uViewMode === NCUI.VIEWMODE.EDIT) {
       UDATA.NetCall('SRV_DBUNLOCKNODE', { nodeID: this.state.id });
       UDATA.NetCall('SRV_RELEASE_EDIT_LOCK', { editor: EDITORTYPE.NODE });
     }
@@ -308,7 +304,7 @@ class NCNode extends UNISYS.Component {
     const { id, uViewMode } = this.state;
 
     // If we're editing, ignore the select!
-    if (uViewMode === VIEWMODE.EDIT) return;
+    if (uViewMode === NCUI.VIEWMODE.EDIT) return;
 
     // If no node was selected, deselect
     if (!node) {
@@ -464,7 +460,7 @@ class NCNode extends UNISYS.Component {
     // it's still in edit mode)
     this.setState(
       {
-        uViewMode: VIEWMODE.VIEW
+        uViewMode: NCUI.VIEWMODE.VIEW
       },
       () => {
     // write data to database
@@ -576,7 +572,7 @@ class NCNode extends UNISYS.Component {
       // provenance: Object.assign({}, provenance) // uncomment after provenence is implemented
     };
     this.setState({
-      uViewMode: VIEWMODE.EDIT,
+      uViewMode: NCUI.VIEWMODE.EDIT,
       uSelectedTab: editableTab,
       previousState
     });
@@ -606,7 +602,7 @@ class NCNode extends UNISYS.Component {
   UIDisableEditMode() {
     this.UnlockNode(() => {
       this.setState({
-        uViewMode: VIEWMODE.VIEW,
+        uViewMode: NCUI.VIEWMODE.VIEW,
         uIsLockedByDB: false
       });
       UDATA.NetCall('SRV_RELEASE_EDIT_LOCK', { editor: EDITORTYPE.NODE });
@@ -897,7 +893,7 @@ class NCNode extends UNISYS.Component {
   render() {
     const { id, uViewMode } = this.state;
     if (!id) return ''; // nothing selected
-    if (uViewMode === VIEWMODE.VIEW) {
+    if (uViewMode === NCUI.VIEWMODE.VIEW) {
       return this.RenderView();
     } else {
       return this.RenderEdit();

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -582,7 +582,8 @@ class NCNode extends UNISYS.Component {
     const { revision, previousState } = this.state;
 
     // if user is cancelling a newly created unsaved node, delete the node instead
-    if (revision < 0) {
+    // Initial Node creation is rev 0, saving it for the first time bumps it to rev 1
+    if (revision < 1) {
       this.UIDisableEditMode();
       this.DeleteNode();
       return;

--- a/app/view/netcreate/components/NodeTable.jsx
+++ b/app/view/netcreate/components/NodeTable.jsx
@@ -501,6 +501,16 @@ class NodeTable extends UNISYS.Component {
                   </Button>
                 </th>
               ))}
+              <th width="10%" hidden={nodeDefs.provenance.hidden}>
+                <Button
+                  size="sm"
+                  onClick={() =>
+                    this.setSortKey('provenance', nodeDefs.provenance.type)
+                  }
+                >
+                  {nodeDefs.provenance.displayLabel} {this.sortSymbol('provenance')}
+                </Button>
+              </th>
               {/*
               <th width="10%" hidden={!isLocalHost}>
                 <Button
@@ -547,6 +557,7 @@ class NodeTable extends UNISYS.Component {
                       : node[a]}
                   </td>
                 ))}
+                <td hidden={nodeDefs.provenance.hidden}>{node.provenance}</td>
                 {/*
                 <td hidden={!isLocalHost} style={{ fontSize: '9px' }}>
                   {this.displayUpdated(node)}

--- a/app/view/netcreate/importexport-mgr.js
+++ b/app/view/netcreate/importexport-mgr.js
@@ -528,7 +528,7 @@ function m_NodefileLoadNodes(headers, lines) {
   let isValid = true;
   let messageJsx = '';
   const nodes = lines.map(l => {
-    const node = {};
+    const node = { meta: {} };
     const subcategories = new Map();
     const importFields = l.split(REGEXMatchCommasNotInQuotes); // ?=" needed to match commas in strings
     importFields.forEach((f, index) => {
@@ -567,20 +567,29 @@ function m_NodefileLoadNodes(headers, lines) {
           // We don't want empty ids to be converted to id 0
           // so we explicitly replace it with NaN
           node[internalLabel] = field === '' ? NaN : field; // ids are numbers
-        } else if (['created', 'updated', 'revision'].includes(internalLabel)) {
-          // meta fields
-          if (node.meta === undefined) node.meta = {};
+        } else if (['created', 'updated'].includes(internalLabel)) {
+          // meta fields: date
+          node.meta[internalLabel] = new Date(field).getTime();
+        } else if (['revision'].includes(internalLabel)) {
+          // meta fields: revision
           node.meta[internalLabel] = field;
         } else {
           node[internalLabel] = m_decode(field); // convert double quotes
         }
       }
     });
+
     // DEPRECATED
     // collapse 'attributes' and 'meta' into objects
     // subcategories.forEach((val, key) => {
     //   node[key] = val
     // });
+
+
+    // Add meta data if missing
+    if (isNaN(node.meta.created)) node.meta.created = new Date().getTime();
+    if (isNaN(node.meta.revision)) node.meta.revision = 0;
+
     return node;
   });
   return { isValid, messageJsx, nodes };
@@ -774,7 +783,7 @@ function m_EdgefileLoadEdges(headers, lines) {
   let isValid = true;
   let messageJsx = '';
   const edges = lines.map(l => {
-    const edge = {};
+    const edge = { meta: {} };
     const subcategories = new Map();
     const importFields = l.split(REGEXMatchCommasNotInQuotes); // ?=" needed to match commas in strings
     importFields.forEach((f, index) => {
@@ -814,20 +823,28 @@ function m_EdgefileLoadEdges(headers, lines) {
           // We don't want empty ids to be converted to id 0
           // so we explicitly replace it with NaN
           edge[internalLabel] = field === '' ? NaN : field; // ids are numbers
-        } else if (['created', 'updated', 'revision'].includes(internalLabel)) {
-          // meta fields
-          if (edge.meta === undefined) edge.meta = {};
+        } else if (['created', 'updated'].includes(internalLabel)) {
+          // meta fields: date
+          edge.meta[internalLabel] = new Date(field).getTime();
+        } else if (['revision'].includes(internalLabel)) {
+          // meta fields: revision
           edge.meta[internalLabel] = field;
         } else {
           edge[internalLabel] = m_decode(field); // convert double quotes
         }
       }
     });
+
     // DEPRECATED
     // collapse 'attributes' and 'meta' into objects
     // subcategories.forEach((val, key) => {
     //   node[key] = val
     // });
+
+    // Add meta data if missing
+    if (isNaN(edge.meta.created)) edge.meta.created = new Date().getTime();
+    if (isNaN(edge.meta.revision)) edge.meta.revision = 0;
+
     return edge;
   });
   return { isValid, messageJsx, edges };

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -491,7 +491,7 @@ MOD.Hook('INITIALIZE', () => {
       throw Error('SOURCE_UPDATE: found duplicate IDs');
     } else if (updatedNodes.length === 1) {
       // if one matched, update NCDATA with the refreshed node from the db
-      const index = NCDATA.nodes.find(n => n.id === node.id);
+      const index = NCDATA.nodes.findIndex(n => n.id === node.id);
       NCDATA.nodes.splice(index, 1, node);
     } else if (updatedNodes.length === 0) {
       // if no nodes had matched, then add a new node!

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -696,20 +696,20 @@ MOD.Hook('INITIALIZE', () => {
     let updatedEdges = m_SetMatchingEdgesByProp({ id: edge.id }, edge);
     if (DBG) console.log('nc-logic.EDGE_UPDATE: updated', updatedEdges);
 
-    // if no edges had matched, then add a new edge!
     if (updatedEdges.length === 0) {
+      // if no edges had matched, then add a new edge!
       if (DBG) console.log('nc-logic.EDGE_UPDATE: adding new edge', edge);
       // created edges should have a default size
       edge.size = 1;
       NCDATA.edges.push(edge);
-    }
-    // if there was one edge
-    if (updatedEdges.length === 1) {
+    } else if (updatedEdges.length === 1) {
+      // if there was one edge, update it
+      const index = NCDATA.edges.findIndex(e => e.id === edge.id);
+      NCDATA.edges.splice(index, 1, edge);
       if (DBG)
         console.log('nc-logic.EDGE_UPDATE: updating existing edge', updatedEdges);
-    }
+    } else if (updatedEdges.length > 1) {
     // if there were more edges than expected
-    if (updatedEdges.length > 1) {
       throw Error('EdgeUpdate found duplicate IDs');
     }
 

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -486,12 +486,17 @@ MOD.Hook('INITIALIZE', () => {
     // try updating existing nodes with this id?
     let updatedNodes = m_SetMatchingNodesByProp({ id: node.id }, node);
     if (DBG) console.log('SOURCE_UPDATE: updated', updatedNodes);
-    // if no nodes had matched, then add a new node!
     if (updatedNodes.length > 1) {
-      console.error('SOURCE_UPDATE: duplicate ids in', updatedNodes);
+      // if more than one matched, then there are duplicate ids
       throw Error('SOURCE_UPDATE: found duplicate IDs');
+    } else if (updatedNodes.length === 1) {
+      // if one matched, update NCDATA with the refreshed node from the db
+      const index = NCDATA.nodes.find(n => n.id === node.id);
+      NCDATA.nodes.splice(index, 1, node);
+    } else if (updatedNodes.length === 0) {
+      // if no nodes had matched, then add a new node!
+      NCDATA.nodes.push(node);
     }
-    if (updatedNodes.length === 0) NCDATA.nodes.push(node);
     UDATA.SetAppState('NCDATA', NCDATA);
   });
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -508,9 +508,7 @@ MOD.Hook('INITIALIZE', () => {
 
     return DATASTORE.PromiseNewNodeID().then(newNodeID => {
       const node = {
-        id: newNodeID, label: data.label, provenance,
-        created: timestamp,
-        revision: -1
+        id: newNodeID, label: data.label, provenance
       };
       return UDATA.LocalCall('DB_UPDATE', { node }).then(() => {
         NCDATA.nodes.push(node);
@@ -635,9 +633,7 @@ MOD.Hook('INITIALIZE', () => {
         source: data.nodeId,
         target: undefined,
         attributes: {},
-        provenance,
-        created: timestamp,
-        revision: -1
+        provenance
       };
       return UDATA.LocalCall('DB_UPDATE', { edge }).then(() => {
         console.log('...DB_UPDATE node is now', edge);


### PR DESCRIPTION
This PR includes one major change and two minor changes.

## Minor: Edge Table Filter Fixes
Fixes a minor bug with Edge Tables and focus filters: the Edge Table does not re-run the focus filter when you switch to the Edge Table.  See #126.

## Minor: Show Provenance in Tables
Provenance is now displayed in the Node Table and Edge Table.  You can hide Provenance in tables by setting the template node/edge Provenance field's `hidden` property.  Provenance will always be shown in the NCNode/NCEdge editors regardless of the `hidden` property.

## Major: Created, Updated, Revision Fields Handling

See #127 for details.

### Improved meta fields
The meta fields Created, Updated, and Revision fields were not being consistently handled by the new v1.5+ UI.  This should now be fixed.  Of note is exporting and importing of those fields are now correct.

* To skip exporting meta fields, set their `hidden` value to `true` in the template.  
* Importing without meta fields will now correctly set the Creation, Updated, and Revision values.

### Fixes Edge `Provenance` field 
A bug was preventing the `Provenance` field from being edited.  Fixed with d3e8221d6f870dd9de5e845edf49e3588443a1f2


# IMPORTANT

Project files and exports created between June 2023 and January 2024 (v1.5.0 - v1.5.1) might not have accurate Created, Updated, and Revision values. The project files should read and function properly, but the dates and revision numbers may not be accurate (you might see "Invalid date" on some records).