### PR TITLE
Skip import of blank lines for nodes and edges

### DIFF
--- a/app/view/netcreate/importexport-mgr.js
+++ b/app/view/netcreate/importexport-mgr.js
@@ -528,6 +528,7 @@ function m_NodefileLoadNodes(headers, lines) {
   let isValid = true;
   let messageJsx = '';
   const nodes = lines.map(l => {
+    if (l === "") return undefined; // skip blank lines
     const node = { meta: {} };
     const subcategories = new Map();
     const importFields = l.split(REGEXMatchCommasNotInQuotes); // ?=" needed to match commas in strings
@@ -591,7 +592,7 @@ function m_NodefileLoadNodes(headers, lines) {
     if (isNaN(node.meta.revision)) node.meta.revision = 0;
 
     return node;
-  });
+  }).filter(n => n !== undefined);
   return { isValid, messageJsx, nodes };
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -783,6 +784,7 @@ function m_EdgefileLoadEdges(headers, lines) {
   let isValid = true;
   let messageJsx = '';
   const edges = lines.map(l => {
+    if (l === "") return undefined; // skip blank lines
     const edge = { meta: {} };
     const subcategories = new Map();
     const importFields = l.split(REGEXMatchCommasNotInQuotes); // ?=" needed to match commas in strings
@@ -846,7 +848,8 @@ function m_EdgefileLoadEdges(headers, lines) {
     if (isNaN(edge.meta.revision)) edge.meta.revision = 0;
 
     return edge;
-  });
+  }).filter(e => e !== undefined);;
+  console.log('result edges', edges)
   return { isValid, messageJsx, edges };
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Windows Excel seems to export an extra blank line when exporting to CSV.  Mac Excel does not do this.

When importing a node or edge file with a blank line, the app will choke with a `Node in row xxx does not have a valid id. Found 'NaN'` error.

The simple fix is to ignore any blank lines.  This will also help with inadvertent blank lines in the middle of the csv export.

Fixes #136.