### PR TITLE
Comment edit lock

### DIFF
--- a/_ur_addons/comment/ac-comment.ts
+++ b/_ur_addons/comment/ac-comment.ts
@@ -488,6 +488,12 @@ function GetUserName(uid) {
 function GetCommentTypes() {
   return DCCOMMENTS.GetCommentTypes();
 }
+function GetCommentType(typeid) {
+  return DCCOMMENTS.GetCommentType(typeid);
+}
+function GetDefaultCommentType() {
+  return DCCOMMENTS.GetDefaultCommentType();
+}
 function GetComment(cid) {
   return DCCOMMENTS.GetComment(cid);
 }
@@ -538,6 +544,8 @@ export {
   // PASS THROUGH
   GetUserName,
   GetCommentTypes,
+  GetCommentType,
+  GetDefaultCommentType,
   GetComment,
   GetReadby,
   GetCrefs

--- a/_ur_addons/comment/dc-comment.ts
+++ b/_ur_addons/comment/dc-comment.ts
@@ -186,6 +186,12 @@ function GetCommentTypes() {
 function GetCommentType(typeid) {
   return COMMENTTYPES.get(typeid);
 }
+function GetDefaultCommentType() {
+  // returns the first comment type object
+  if (DEFAULT_CommentTypes.length < 1)
+    throw new Error('dc-comments: No comment types defined!');
+  return GetCommentType(DEFAULT_CommentTypes[0].id);
+}
 
 function GetComments() {
   return COMMENTS;
@@ -661,6 +667,7 @@ export default {
   // COMMENT TYPES
   GetCommentTypes,
   GetCommentType,
+  GetDefaultCommentType,
   // COMMENTS
   GetComments,
   GetComment,

--- a/app/system/util/enum.js
+++ b/app/system/util/enum.js
@@ -12,7 +12,8 @@ ENUM.EDITORTYPE = {
   TEMPLATE: 'template',
   IMPORTER: 'importer',
   NODE: 'node', // parameter sent with packet, listed here for coverage
-  EDGE: 'edge' // parameter sent with packet, listed here for coverage
+  EDGE: 'edge', // parameter sent with packet, listed here for coverage
+  COMMENT: 'comment'
 };
 // BUILT-IN FIELDS
 ENUM.BUILTIN_FIELDS_NODE = [

--- a/app/unisys/component/SessionShell.jsx
+++ b/app/unisys/component/SessionShell.jsx
@@ -95,9 +95,7 @@ const LABEL_STYLE = {
 };
 /// Move login to navbar
 const NAV_LOGIN_STYLE = {
-  position: 'fixed',
-  top: '7px',
-  right: '20px',
+  margin: '8px 10px 0 20px',
   zIndex: '2000'
 };
 const NAV_LOGIN_FEEDBACK_STYLE = {

--- a/app/unisys/server.js
+++ b/app/unisys/server.js
@@ -203,6 +203,21 @@ UNISYS.RegisterHandlers = () => {
     return UDB.PKT_IsEdgeLocked(pkt);
   });
 
+  UNET.HandleMessage('SRV_DBLOCKCOMMENT', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_RequestLockComment(pkt);
+  });
+
+  UNET.HandleMessage('SRV_DBUNLOCKCOMMENT', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_RequestUnlockComment(pkt);
+  });
+
+  UNET.HandleMessage('SRV_DBISCOMMENTLOCKED', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_IsCommentLocked(pkt);
+  });
+
   UNET.HandleMessage('SRV_DBUNLOCKALLNODES', function (pkt) {
     if (DBG) console.log(PR, sprint_message(pkt));
     return UDB.PKT_RequestUnlockAllNodes(pkt);
@@ -211,11 +226,15 @@ UNISYS.RegisterHandlers = () => {
     if (DBG) console.log(PR, sprint_message(pkt));
     return UDB.PKT_RequestUnlockAllEdges(pkt);
   });
+  UNET.HandleMessage('SRV_DBUNLOCKALLCOMMENTS', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return UDB.PKT_RequestUnlockAllComments(pkt);
+  });
   UNET.HandleMessage('SRV_DBUNLOCKALL', function (pkt) {
     if (DBG) console.log(PR, sprint_message(pkt));
     const res = UDB.PKT_RequestUnlockAll(pkt);
     // Broadcast Lock State
-    const data = UDB.GetEditStatus();
+    const data = UDB.GetEditStatus(pkt);
     UNET.NetCall('EDIT_PERMISSIONS_UPDATE', data);
     return res;
   });

--- a/app/view/netcreate/NetCreate.css
+++ b/app/view/netcreate/NetCreate.css
@@ -1,3 +1,34 @@
+/* Base App: NetCrate.jsx */
+.nc-base {
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+}
+.nc-savealert {
+  position: fixed;
+  top: 0px;
+  flex-grow: 1;
+  background-color: rgba(256, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+  z-index: 3000;
+}
+.nc-savealert > div {
+  color: #fff;
+  width: 100%;
+  text-align: center;
+}
+.nc-navbar {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: 38px;
+  display: flex;
+  flex-flow: row-reverse;
+  z-index: 2000;
+}
 /* Bootstrap override */
 .nav-item {
   cursor: pointer;

--- a/app/view/netcreate/NetCreate.jsx
+++ b/app/view/netcreate/NetCreate.jsx
@@ -179,35 +179,24 @@ class NetCreate extends UNISYS.Component {
 
     // note: the navbar is in init-appshell.jsx
     return (
-      <div
-        className="--NetCreate"
-        style={{ display: 'flex', flexFlow: 'column', height: '100%' }}
-      >
+      <div className="--NetCreate nc-base">
         <div
-          className="--NetCreate_Fixed_Top"
+          className="--NetCreate_Fixed_Top_SaveAlert nc-savealert"
           hidden={this.state.isConnected}
-          style={{
-            width: '100%',
-            height: '38px',
-            position: 'fixed',
-            backgroundColor: 'rgba(256,0,0,0.5',
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'space-evenly',
-            alignItems: 'center',
-            zIndex: '3000'
-          }}
         >
-          <div
-            className="--NetCreate_Fixed_Top_SaveAlert"
-            style={{ color: '#fff', width: '100%', textAlign: 'center' }}
-          >
+          <div>
             <b>{disconnectMsg}!</b> Your changes will not be saved! Please report
             &quot;
             {disconnectMsg}&quot; to your administrator to restart the graph.
           </div>
         </div>
-        <SessionShell />
+        <div className="--NetCreate_Fixed_Top nc-navbar">
+          <SessionShell />
+          <NCCommentStatus
+            message={commentStatusMessage}
+            handleMessageUpdate={handleMessageUpdate}
+          />
+        </div>
 
         <div
           className="--NetCreate_Rows"
@@ -322,10 +311,6 @@ class NetCreate extends UNISYS.Component {
           accessible format.
         </div>
         <div id="dialog-container"></div>
-        <NCCommentStatus
-          message={commentStatusMessage}
-          handleMessageUpdate={handleMessageUpdate}
-        />
       </div>
     ); // end return
   } // end render()

--- a/app/view/netcreate/comment-mgr.js
+++ b/app/view/netcreate/comment-mgr.js
@@ -230,6 +230,12 @@ MOD.GetUserName = (uid) => {
 MOD.GetCommentTypes = () => {
   return COMMENT.GetCommentTypes();
 }
+MOD.GetCommentType = typeid => {
+  return COMMENT.GetCommentType(typeid);
+}
+MOD.GetDefaultCommentType = () => {
+  return COMMENT.GetDefaultCommentType();
+}
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// Global Operations

--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -260,7 +260,10 @@ class EdgeTable extends UNISYS.Component {
     UDATA.NetCall('SRV_GET_EDIT_STATUS').then(data => {
       // someone else might be editing a template or importing or editing node or edge
       disableEdit =
-        data.templateBeingEdited || data.importActive || data.nodeOrEdgeBeingEdited;
+        data.templateBeingEdited ||
+        data.importActive ||
+        data.nodeOrEdgeBeingEdited ||
+        data.commentBeingEditedByMe; // only lock out if this user is the one editing comments, allow network commen edits
       this.setState({ disableEdit });
     });
   }

--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -58,6 +58,7 @@ class EdgeTable extends UNISYS.Component {
       edges: [],
       filteredEdges: [],
       nodes: [], // needed for dereferencing source/target
+      disableEdit: false,
       isLocked: false,
       isExpanded: true,
       sortkey: 'Relationship'
@@ -67,6 +68,7 @@ class EdgeTable extends UNISYS.Component {
     this.updateEdgeFilterState = this.updateEdgeFilterState.bind(this);
     this.handleDataUpdate = this.handleDataUpdate.bind(this);
     this.handleFilterDataUpdate = this.handleFilterDataUpdate.bind(this);
+    this.updateEditState = this.updateEditState.bind(this);
     this.OnTemplateUpdate = this.OnTemplateUpdate.bind(this);
     this.onViewButtonClick = this.onViewButtonClick.bind(this);
     this.onEditButtonClick = this.onEditButtonClick.bind(this);
@@ -83,6 +85,8 @@ class EdgeTable extends UNISYS.Component {
 
     /// Initialize UNISYS DATA LINK for REACT
     UDATA = UNISYS.NewDataLink(this);
+
+    UDATA.HandleMessage('EDIT_PERMISSIONS_UPDATE', this.updateEditState);
 
     // SESSION is called by SessionSHell when the ID changes
     //  set system-wide. data: { classId, projId, hashedId, groupId, isValid }
@@ -113,9 +117,14 @@ class EdgeTable extends UNISYS.Component {
       let NCDATA = this.AppState('NCDATA');
       this.handleDataUpdate(NCDATA);
     });
+
+    // Request edit state too because the update may have come
+    // while we were hidden
+    this.updateEditState();
   }
 
   componentWillUnmount() {
+    UDATA.UnhandleMessage('EDIT_PERMISSIONS_UPDATE', this.updateEditState);
     this.AppStateChangeOff('SESSION', this.onStateChange_SESSION);
     this.AppStateChangeOff('NCDATA', this.handleDataUpdate);
     this.AppStateChangeOff('FILTEREDNCDATA', this.handleFilterDataUpdate);
@@ -242,6 +251,18 @@ class EdgeTable extends UNISYS.Component {
         );
       }
     }
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  updateEditState() {
+    // disable edit if someone else is editing a template, node, or edge
+    let disableEdit = false;
+    UDATA.NetCall('SRV_GET_EDIT_STATUS').then(data => {
+      // someone else might be editing a template or importing or editing node or edge
+      disableEdit =
+        data.templateBeingEdited || data.importActive || data.nodeOrEdgeBeingEdited;
+      this.setState({ disableEdit });
+    });
   }
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -536,7 +557,7 @@ class EdgeTable extends UNISYS.Component {
   /**
    */
   render() {
-    let { edgeDefs, isLocked } = this.state;
+    let { edgeDefs, disableEdit, isLocked } = this.state;
     if (edgeDefs.category === undefined) {
       // for backwards compatability
       edgeDefs.category = {};
@@ -699,13 +720,15 @@ class EdgeTable extends UNISYS.Component {
                 <td hidden={!DBG}>{edge.id}</td>
                 <td hidden={!DBG}>{edge.size}</td>
                 <td>
-                  <button
-                    className="small outline"
-                    onClick={event => this.onViewButtonClick(event, edge.id)}
-                  >
-                    {ICON_VIEW}
-                  </button>
-                  {!isLocked && (
+                  {!disableEdit && (
+                    <button
+                      className="small outline"
+                      onClick={event => this.onViewButtonClick(event, edge.id)}
+                    >
+                      {ICON_VIEW}
+                    </button>
+                  )}
+                  {!disableEdit && !isLocked && (
                     <button
                       className="small outline"
                       onClick={event => this.onEditButtonClick(event, edge.id)}
@@ -717,25 +740,33 @@ class EdgeTable extends UNISYS.Component {
                 {/* Cast to string for edge.target where target is undefined */}
                 <td hidden={!DBG}>{String(edge.source)}</td>
                 <td>
-                  <a
-                    href="#"
-                    onClick={e => this.selectNode(edge.source, e)}
-                    onMouseOver={() => this.onHighlightNode(edge.source)}
-                  >
-                    {edge.sourceLabel}
-                  </a>
+                  {!disableEdit ? (
+                    <a
+                      href="#"
+                      onClick={e => this.selectNode(edge.source, e)}
+                      onMouseOver={() => this.onHighlightNode(edge.source)}
+                    >
+                      {edge.sourceLabel}
+                    </a>
+                  ) : (
+                    edge.sourceLabel
+                  )}
                 </td>
                 {hasTypeField && <td hidden={edgeDefs.type.hidden}>{edge.type}</td>}
                 {/* Cast to string for edge.target where target is undefined */}
                 <td hidden={!DBG}>{String(edge.target)}</td>
                 <td>
-                  <a
-                    href="#"
-                    onClick={e => this.selectNode(edge.target, e)}
-                    onMouseOver={() => this.onHighlightNode(edge.target)}
-                  >
-                    {edge.targetLabel}
-                  </a>
+                  {!disableEdit ? (
+                    <a
+                      href="#"
+                      onClick={e => this.selectNode(edge.target, e)}
+                      onMouseOver={() => this.onHighlightNode(edge.target)}
+                    >
+                      {edge.targetLabel}
+                    </a>
+                  ) : (
+                    edge.targetLabel
+                  )}
                 </td>
                 {attributes.map(a => (
                   <td hidden={edgeDefs[a].hidden} key={`${edge.id}${a}`}>

--- a/app/view/netcreate/components/NCComment.css
+++ b/app/view/netcreate/components/NCComment.css
@@ -321,8 +321,10 @@ svg#comment-icon {
 }
 .commentThread .comment .help {
   /* override nccomponent */
-  font-size: 10px;
   font-style: italic; /* emulate nccomponent */
+  font-size: 12px;
+  line-height: 14px;
+  padding-bottom: 3px;
   opacity: 0.7;
 }
 
@@ -336,7 +338,8 @@ svg#comment-icon {
 .comment .feedback {
   color: #0007; /* emulate nccomponent help */
   opacity: 0.8;
-  font-size: 10px;
+  font-size: 12px;
+  line-height: 14px;
 }
 .comment .commenttext {
   background-color: #fff5;

--- a/app/view/netcreate/components/NCComment.css
+++ b/app/view/netcreate/components/NCComment.css
@@ -359,8 +359,11 @@ svg#comment-icon {
 /* control bars */
 .commentThread .topbar {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   padding-bottom: 2px;
+}
+.commentThread .topbar .commentTitle {
+  color: var(--comment-system-font-color);
 }
 .commentThread .topbar .closeBtn {
   /* content: 'X'; */

--- a/app/view/netcreate/components/NCComment.css
+++ b/app/view/netcreate/components/NCComment.css
@@ -8,11 +8,7 @@
 
 /* Comment Bar ------------------------------------------------------------- */
 #comment-bar {
-  position: absolute;
-  top: 0px;
-  right: 200px;
   display: flex;
-  align-items: center;
   margin-top: 6px;
   font-size: 0.8rem;
   z-index: 2000;

--- a/app/view/netcreate/components/NCComment.css
+++ b/app/view/netcreate/components/NCComment.css
@@ -2,7 +2,7 @@
   --comment-bg: #ffd700;
   --comment-bg-light: #f1e9c5ee;
   --comment-bg-new: #d84a00;
-  --comment-statust-font-color: #d84a0088;
+  --comment-status-font-color: #d84a0088;
   --comment-system-font-color: #0003;
 }
 
@@ -15,7 +15,7 @@
 }
 #comment-bar h3 {
   display: inline-block;
-  color: var(--comment-statust-font-color);
+  color: var(--comment-status-font-color);
   margin: 3px 0 5px 0;
   font-size: 10px;
   width: 1px;
@@ -71,7 +71,7 @@
 /* Comment Summary */
 #comment-summary {
   display: flex;
-  color: var(--comment-statust-font-color);
+  color: var(--comment-status-font-color);
   background-color: var(--comment-bg-light);
   border-radius: 15px;
   height: 1.8rem;
@@ -331,15 +331,22 @@ svg#comment-icon {
 .comment .comment-item {
   margin-bottom: 5px;
 }
-.comment .feedback {
-  color: #0007; /* emulate nccomponent help */
+.comment .feedback,
+.comment .error {
   opacity: 0.8;
   font-size: 12px;
   line-height: 14px;
 }
+.comment .feedback {
+  color: #0007; /* emulate nccomponent help */
+}
+.comment .error {
+  color: var(--comment-status-font-color);
+}
 .comment .commenttext {
   background-color: #fff5;
   padding-left: 3px;
+  margin-bottom: 3px;
 }
 
 .comment .commentId {

--- a/app/view/netcreate/components/NCComment.jsx
+++ b/app/view/netcreate/components/NCComment.jsx
@@ -370,7 +370,7 @@ class NCComment extends React.Component {
       CommentComponent = (
         <div
           id={cid}
-          className={`comment ${comment.comment_isMarkedDeleted && 'deleted'}`}
+          className={`comment ${comment.comment_isMarkedDeleted ? 'deleted' : ''}`}
         >
           <div>
             <div className="commenter">{commenter}</div>

--- a/app/view/netcreate/components/NCCommentBtn.jsx
+++ b/app/view/netcreate/components/NCCommentBtn.jsx
@@ -219,7 +219,7 @@ class NCCommentBtn extends React.Component {
     let css = 'commentbtn ';
     if (ccol.hasUnreadComments) css += 'hasUnreadComments ';
     else if (ccol.hasReadComments) css += 'hasReadComments ';
-    css += ccol.isOpen ? 'isOpen ' : '';
+    css += isOpen ? 'isOpen ' : '';
 
     const label = count > 0 ? count : '';
 

--- a/app/view/netcreate/components/NCCommentBtn.jsx
+++ b/app/view/netcreate/components/NCCommentBtn.jsx
@@ -198,6 +198,8 @@ class NCCommentBtn extends React.Component {
     const updatedIsOpen = !this.state.isOpen;
     this.UIOpenComment(updatedIsOpen);
   }
+  }
+
 
   UIOnResize(event) {
     const position = this.GetCommentThreadPosition();

--- a/app/view/netcreate/components/NCCommentBtn.jsx
+++ b/app/view/netcreate/components/NCCommentBtn.jsx
@@ -14,6 +14,15 @@
   * has unread comments (gold color)
   * all comments are read (gray color)
 
+  During Edit
+  While a comment is being edited, we need to catch events to prevent
+  the comment from inadvertently being closed:
+  * prevent NodeTable or EdgeTable view/edit actions from triggering
+    (handled by selection-mgr)
+  * prevent NCNode from being able to click "Edit"
+  * prevent NCCommentBtn close toggles (handled by NCCommentBtn)
+  * prevent NCGraphRenderer events from selecting another node
+    (handled by selection-mgr)
 
   USE:
 
@@ -69,15 +78,18 @@ class NCCommentBtn extends React.Component {
 
     const uid = CMTMGR.GetCurrentUserId();
 
+    const btnid = `${props.cref}${props.isTable ? `-isTable` : ''}`;
     this.state = {
       uid, // empty uid is allowed for non-logged in users
       isOpen: false,
+      isDisabled: false,
       x: '300px',
       y: '120px',
-      commentButtonId: `comment-button-${props.cref}-${props.isTable}`
+      commentButtonId: `comment-button-${btnid}`
     };
 
     // EVENT HANDLERS
+    this.UpdatePermissions = this.UpdatePermissions.bind(this);
     this.GetCommentThreadPosition = this.GetCommentThreadPosition.bind(this);
     this.UpdateCommentCollection = this.UpdateCommentCollection.bind(this);
     this.UpdateCommentVObjs = this.UpdateCommentVObjs.bind(this);
@@ -94,6 +106,7 @@ class NCCommentBtn extends React.Component {
     /// REGISTER LISTENERS
     UDATA.OnAppStateChange('COMMENTCOLLECTION', this.UpdateCommentCollection);
     UDATA.OnAppStateChange('COMMENTVOBJS', this.UpdateCommentVObjs);
+    UDATA.HandleMessage('COMMENT_UPDATE_PERMISSIONS', this.UpdatePermissions);
     UDATA.HandleMessage('COMMENT_SELECT', this.HandleCOMMENT_SELECT);
     window.addEventListener('resize', this.UIOnResize);
   }
@@ -105,7 +118,13 @@ class NCCommentBtn extends React.Component {
   componentWillUnmount() {
     UDATA.AppStateChangeOff('COMMENTCOLLECTION', this.UpdateCommentCollection);
     UDATA.AppStateChangeOff('COMMENTVOBJS', this.UpdateCommentVObjs);
+    UDATA.UnhandleMessage('COMMENT_UPDATE_PERMISSIONS', this.UpdatePermissions);
+    UDATA.UnhandleMessage('COMMENT_SELECT', this.HandleCOMMENT_SELECT);
     window.removeEventListener('resize', this.UIOnResize);
+  }
+
+  UpdatePermissions(data) {
+    this.setState({ isDisabled: data.commentBeingEditedByMe });
   }
 
   GetCommentThreadPosition() {
@@ -173,6 +192,9 @@ class NCCommentBtn extends React.Component {
 
   UIOnClick(event) {
     event.stopPropagation(); // prevent Edge deselect
+    const { isDisabled } = this.state;
+    // disable open toggle if comment is being edited
+    if (!isDisabled) {
     const updatedIsOpen = !this.state.isOpen;
     this.UIOpenComment(updatedIsOpen);
   }

--- a/app/view/netcreate/components/NCCommentThread.jsx
+++ b/app/view/netcreate/components/NCCommentThread.jsx
@@ -104,6 +104,8 @@ class NCCommentThread extends React.Component {
     const windowHeight = Math.min(screen.height, window.innerHeight); // handle Safari and FireFox differences
     const commentMaxHeight = `${windowHeight - y - 100}px`;
 
+    const { typeLabel, sourceLabel } = CMTMGR.GetCREFSourceLabel(cref);
+
     return (
       <Draggable>
         <div
@@ -112,6 +114,9 @@ class NCCommentThread extends React.Component {
           onClick={e => e.stopPropagation()} // prevent edge deselect
         >
           <div className="topbar">
+            <div className="commentTitle">
+              Comments on {typeLabel} {sourceLabel}
+            </div>
             <div className="closeBtn" onClick={this.UIOnClose}>
               X
             </div>

--- a/app/view/netcreate/components/NodeTable.jsx
+++ b/app/view/netcreate/components/NodeTable.jsx
@@ -200,7 +200,10 @@ class NodeTable extends UNISYS.Component {
     UDATA.NetCall('SRV_GET_EDIT_STATUS').then(data => {
       // someone else might be editing a template or importing or editing node or edge
       disableEdit =
-        data.templateBeingEdited || data.importActive || data.nodeOrEdgeBeingEdited;
+        data.templateBeingEdited ||
+        data.importActive ||
+        data.nodeOrEdgeBeingEdited ||
+        data.commentBeingEditedByMe; // only lock out if this user is the one editing comments, allow network commen edits
       this.setState({ disableEdit });
     });
   }

--- a/app/view/netcreate/selection-mgr.js
+++ b/app/view/netcreate/selection-mgr.js
@@ -38,7 +38,8 @@ const SELECTION_MODE = {
   NORMAL: 'normal', // graph is selectable
   EDGE_EDIT: 'edge_edit', // edge is being edited
   // NODE_EDIT is not necessary b/c the transparent screen prevents clicks
-  SOURCETARGET: 'sourcetarget' // waiting for a source or target
+  SOURCETARGET: 'sourcetarget', // waiting for a source or target
+  COMMENT_EDIT: 'comment_edit' // disable node selection during comment edit
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 let m_SelectionMode = SELECTION_MODE.NORMAL; // default
@@ -90,6 +91,9 @@ function m_D3SelectNode(data) {
       console.log(PR, 'm_D3SelectNode: ignoring selection during edge edit mode');
   } else if (m_SelectionMode === SELECTION_MODE.SOURCETARGET) {
     m_SendSourceTargetSelectionUpdate(node);
+  } else if (m_SelectionMode === SELECTION_MODE.COMMENT_EDIT) {
+    // ignore selection during COMMENT edit so that selecting
+    // another node closes the comment
   } else {
     throw `Unknown SELECTION Mode ${m_SelectionMode}`;
   }


### PR DESCRIPTION
 While a comment is being edited, we need to catch events to prevent
  the comment from inadvertently being closed:

  * prevent NodeTable or EdgeTable view/edit actions from triggering
    (handled by selection-mgr)
  * prevent NCNode from being able to click "Edit"
  * prevent NCCommentBtn close toggles (handled by NCCommentBtn)
  * prevent NCGraphRenderer events from selecting another node
    (handled by selection-mgr)

#### To Test

1. Open a node that already has a comment
2. Click the comment button to open the window (but don't edit or hit reply)
3. Try:
   - open NodeTable or EdgeTable and view or edit another node/edge -- you should be able to do it
   - in the selected node, click edit -- you should be able to edit the node
   - click the comment button -- you should be able to close the comment window
   - in the graph, click to select a node -- you should be able to select it (and close the prior comment)
4. Now add a new comment
   - open NodeTable or EdgeTable -- the view and edit buttons in the table should be hidden
   - in the selected node, the "Edit" button should be disabled so you can't click it
   - click the comment button -- nothing should happen -- you can't click the comment button to close the comment
   - in the graph, click to select a node -- nothing should happen -- you can't select another node
5. Save the comment -- everything should work again.
6. Add a reply -- everything should be locked again.

We probably want to add some messaging so that the caught clicks don't just quietly fail.  e.g. add an alert message informing the user to "Please finish editing the comment before selecting another comment" or something like that.