### PR TITLE
Feature: Additional Comment Prop Types

### DIFF
--- a/_ur_addons/comment/ac-comment.ts
+++ b/_ur_addons/comment/ac-comment.ts
@@ -432,11 +432,6 @@ function AddComment(data: {
   );
   COMMENTVOBJS.set(data.cref, commentVObjs);
 
-  // Mark it Open
-  let ccol = GetCommentCollection(data.cref);
-  ccol.isOpen = true;
-  COMMENTCOLLECTION.set(data.cref, ccol);
-
   return comment;
 }
 

--- a/_ur_addons/comment/ac-comment.ts
+++ b/_ur_addons/comment/ac-comment.ts
@@ -532,8 +532,8 @@ function GetUserName(uid: TCommentID): string {
 function GetCommentTypes(): TCommentTypeMap {
   return DCCOMMENTS.GetCommentTypes();
 }
-function GetCommentType(typeid: CType): TCommentType {
-  return DCCOMMENTS.GetCommentType(typeid);
+function GetCommentType(slug: CType): TCommentType {
+  return DCCOMMENTS.GetCommentType(slug);
 }
 function GetDefaultCommentType(): TCommentType {
   return DCCOMMENTS.GetDefaultCommentType();

--- a/_ur_addons/comment/dc-comment.ts
+++ b/_ur_addons/comment/dc-comment.ts
@@ -63,7 +63,7 @@
 
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
 
-const DBG = true;
+const DBG = false;
 const PR = 'dc-comments';
 
 /// TYPE DEFINITIONS //////////////////////////////////////////////////////////
@@ -164,6 +164,58 @@ const NEXT: Map<TCommentID, TCommentID> = new Map(); // Map<comment_id_previous,
 
 const DEFAULT_CommentTypes: Array<TCommentType> = [
   {
+    id: 'demo',
+    label: 'Demo',
+    prompts: [
+      {
+        format: 'text',
+        prompt: 'Comment', // prompt label
+        help: 'Use this for any general comment.',
+        feedback: 'Just enter text'
+      },
+      {
+        format: 'dropdown',
+        prompt: 'How often did you use "Dropdown"', // prompt label
+        options: ['🥲 No', '🤔 A little', '😀 A lot'],
+        help: 'Select one.',
+        feedback: 'Single selection via dropdown menu'
+      },
+      {
+        format: 'checkbox',
+        prompt: 'What types of fruit did you "Checkbox"?', // prompt label
+        options: ['Apple Pie', 'Orange, Lime', 'Banana'],
+        help: 'Select as many as you want.',
+        feedback: 'Supports multiple selections'
+      },
+      {
+        format: 'radio',
+        prompt: 'What do you think "Radio"?', // prompt label
+        options: [
+          'It makes sense',
+          'I disagree',
+          "I don't know",
+          'Handle, comma, please'
+        ],
+        help: 'Select only one.',
+        feedback: 'Mutually exclusive single selections'
+      },
+      {
+        format: 'likert',
+        prompt: 'How did you like it "likert"?', // prompt label
+        options: ['💙', '💚', '💛', '🧡', '🩷'],
+        help: 'Select one of a series listed horizontally',
+        feedback: 'Select with a single click.  Supports emojis.'
+      },
+      {
+        format: 'discrete-slider',
+        prompt: 'Star Rating "discrete-slider"?', // prompt label
+        options: ['★', '★', '★', '★', '★'],
+        help: 'Select one of a series stacked horizontally',
+        feedback: 'Select with a single click.  Supports emojis.'
+      }
+    ]
+  },
+  {
     id: 'cmt',
     label: 'Comment', // comment type label
     prompts: [
@@ -180,6 +232,7 @@ const DEFAULT_CommentTypes: Array<TCommentType> = [
     label: 'Tell me more', // comment type label
     prompts: [
       {
+        format: 'text',
         prompt: 'Please tell me more', // prompt label
         help: 'Can you tell me more about ... ',
         feedback: ''
@@ -191,11 +244,13 @@ const DEFAULT_CommentTypes: Array<TCommentType> = [
     label: 'Source', // comment type label
     prompts: [
       {
+        format: 'text',
         prompt: 'Is this well sourced?', // prompt label
         help: 'Yes/No',
         feedback: ''
       },
       {
+        format: 'text',
         prompt: 'Changes', // prompt label
         help: 'What about the sourcing could be improved?',
         feedback: ''

--- a/_ur_addons/comment/dc-comment.ts
+++ b/_ur_addons/comment/dc-comment.ts
@@ -69,31 +69,37 @@ const PR = 'dc-comments';
 /// TYPE DEFINITIONS //////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ///
-type TUserID = string;
+export type TUserID = string;
 type TUserName = string;
 type TUserObject = {
   id: TUserID;
   name: TUserName;
 };
 
-type CType = 'cmt' | 'tellmemore' | 'source' | 'demo';
-type CFormat = 'text' | 'dropdown' | 'checkbox' | 'radio' | 'stacked';
-type TCommentID = string;
-type TCommentType = {
+export type CType = 'cmt' | 'tellmemore' | 'source' | 'demo';
+type CPromptFormat =
+  | 'text'
+  | 'dropdown'
+  | 'checkbox'
+  | 'radio'
+  | 'likert'
+  | 'discrete-slider';
+export type TCommentID = string;
+export type TCommentType = {
   id: CType;
   label: string;
   prompts: TCommentPrompt[];
 };
 type TCommentPrompt = {
-  format: CFormat;
+  format: CPromptFormat;
   prompt: string;
   options?: string[];
   help: string;
   feedback: string;
 };
 
-type TCollectionRef = any;
-type TComment = {
+export type TCollectionRef = any;
+export type TComment = {
   collection_ref: TCollectionRef; // aka 'cref'
   comment_id: TCommentID;
   comment_id_parent: any;
@@ -121,22 +127,22 @@ type TLokiData = {
   readby?: TReadByObject[];
 };
 
-type TCommentQueueActions =
-  | TCommentQueueActionRemoveCommentID
-  | TCommentQueueActionRemoveCollectionRef
-  | TCommentQueueActionUpdate;
-type TCommentQueueActionRemoveCommentID = {
+export type TCommentQueueActions =
+  | TCommentQueueAction_RemoveCommentID
+  | TCommentQueueAction_RemoveCollectionRef
+  | TCommentQueueAction_Update;
+type TCommentQueueAction_RemoveCommentID = {
   commentID: TCommentID;
 };
-type TCommentQueueActionRemoveCollectionRef = {
+type TCommentQueueAction_RemoveCollectionRef = {
   collection_ref: TCollectionRef;
 };
-type TCommentQueueActionUpdate = {
+type TCommentQueueAction_Update = {
   comment: TComment;
 };
 
 type TUserMap = Map<TUserID, TUserName>;
-type TCommentTypeMap = Map<CType, TCommentType>;
+export type TCommentTypeMap = Map<CType, TCommentType>;
 type TCommentMap = Map<TCommentID, TComment>;
 type TReadByMap = Map<TCommentID, TUserID[]>;
 

--- a/app/view/netcreate/NetCreate.css
+++ b/app/view/netcreate/NetCreate.css
@@ -2,11 +2,12 @@
 
       5000  NCDialog
       3000  nc-savelert
+      2500  commentThread
       2010  NCDialog .dialogWindow
       2001  NCDialog .screen ==========
       2000  comment-bar
       1030  bootstrap .fixed-top
-       100  commentThread
+       100  Node/EdgeTable thead
         15  NCAutoSuggest .matchlist
         15  NCNode .ncedge
         10  NCNode .nccomponent
@@ -90,11 +91,6 @@ svg#netgraph .nodes text {
 }
 .noselect {
   user-select: none;
-}
-
-/* Tables ------------------------------------------------------------------ */
-.table thead th {
-  z-index: 100; /* override bootstrap, comment buttons */
 }
 
 /* Button Icons ------------------------------------------------------------ */

--- a/app/view/netcreate/comment-mgr.js
+++ b/app/view/netcreate/comment-mgr.js
@@ -233,8 +233,8 @@ MOD.GetUserName = uid => {
 MOD.GetCommentTypes = () => {
   return COMMENT.GetCommentTypes();
 };
-MOD.GetCommentType = typeid => {
-  return COMMENT.GetCommentType(typeid);
+MOD.GetCommentType = slug => {
+  return COMMENT.GetCommentType(slug);
 };
 MOD.GetDefaultCommentType = () => {
   return COMMENT.GetDefaultCommentType();
@@ -291,13 +291,11 @@ MOD.GetCommentUIState = uiref => {
 };
 /**
  *
- * @param {Object} data
- * @param {Object} data.uiref
- * @param {Object} data.cref
- * @param {Object} data.isOpen
+ * @param {string} uiref
+ * @param {TCommentOpenState} openState
  */
-MOD.UpdateCommentUIState = data => {
-  COMMENT.UpdateCommentUIState(data);
+MOD.UpdateCommentUIState = (uiref, openState) => {
+  COMMENT.UpdateCommentUIState(uiref, openState);
   m_SetAppStateCommentCollections();
 };
 

--- a/app/view/netcreate/comment-mgr.js
+++ b/app/view/netcreate/comment-mgr.js
@@ -41,7 +41,7 @@ MOD.Hook('INITIALIZE', () => {
    *  @param {Object} data.users
    *  @param {Object} data.commenttypes
    *  @param {Object} data.comments
-  */
+   */
   // Comment AddOn Handlers
   UDATA.HandleMessage('LOAD_COMMENT_DATACORE', data => COMMENT.LoadDB(data));
   /// STATE UPDATES and Message Handlers
@@ -71,15 +71,12 @@ MOD.Hook('APP_READY', function (info) {
   if (DBG) console.log('comment-mgr APP_READY');
 }); // end APP_READY Hook
 
-
 /// HELPER FUNCTIONS //////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 MOD.COMMENTICON = (
   <svg id="comment-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 42 42">
-    <path
-      d="M21,0C9.4,0,0,9.4,0,21c0,4.12,1.21,7.96,3.26,11.2l-2.26,9.8,11.56-1.78c2.58,1.14,5.44,1.78,8.44,1.78,11.6,0,21-9.4,21-21S32.6,0,21,0Z"
-    />
+    <path d="M21,0C9.4,0,0,9.4,0,21c0,4.12,1.21,7.96,3.26,11.2l-2.26,9.8,11.56-1.78c2.58,1.14,5.44,1.78,8.44,1.78,11.6,0,21-9.4,21-21S32.6,0,21,0Z" />
   </svg>
 );
 
@@ -128,7 +125,7 @@ MOD.GetProjectCREF = projectId => `p${projectId}`;
 function deconstructCref(cref) {
   const type = cref.substring(0, 1);
   const id = cref.substring(1);
-  return { type, id }
+  return { type, id };
 }
 
 /**
@@ -164,7 +161,7 @@ MOD.GetCREFSourceLabel = cref => {
       break;
   }
   return { typeLabel, sourceLabel };
-}
+};
 
 MOD.OpenSource = cref => {
   const { type, id } = deconstructCref(cref);
@@ -183,7 +180,7 @@ MOD.OpenSource = cref => {
       // do something?
       break;
   }
-}
+};
 
 MOD.OpenComment = (cref, cid) => {
   const { type, id } = deconstructCref(cref);
@@ -193,7 +190,7 @@ MOD.OpenComment = (cref, cid) => {
       UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [parseInt(id)] }).then(() => {
         UDATA.LocalCall('COMMENT_SELECT', { cref }).then(() => {
           const commentEl = document.getElementById(cid);
-          commentEl.scrollIntoView({ behavior: "smooth" });
+          commentEl.scrollIntoView({ behavior: 'smooth' });
         });
       });
       break;
@@ -203,7 +200,7 @@ MOD.OpenComment = (cref, cid) => {
         UDATA.LocalCall('EDGE_SELECT', { edgeId: edge.id }).then(() => {
           UDATA.LocalCall('COMMENT_SELECT', { cref }).then(() => {
             const commentEl = document.getElementById(cid);
-            commentEl.scrollIntoView({ behavior: "smooth" });
+            commentEl.scrollIntoView({ behavior: 'smooth' });
           });
         });
       });
@@ -212,7 +209,7 @@ MOD.OpenComment = (cref, cid) => {
       // do something?
       break;
   }
-}
+};
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// User Id
@@ -220,22 +217,22 @@ MOD.GetCurrentUserId = () => {
   const session = UDATA.AppState('SESSION');
   const uid = session.token;
   return uid;
-}
-MOD.GetUserName = (uid) => {
+};
+MOD.GetUserName = uid => {
   return COMMENT.GetUserName(uid);
-}
+};
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// Comment Type
 MOD.GetCommentTypes = () => {
   return COMMENT.GetCommentTypes();
-}
+};
 MOD.GetCommentType = typeid => {
   return COMMENT.GetCommentType(typeid);
-}
+};
 MOD.GetDefaultCommentType = () => {
   return COMMENT.GetDefaultCommentType();
-}
+};
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// Global Operations
@@ -245,16 +242,16 @@ MOD.MarkAllRead = () => {
   crefs.forEach(cref => {
     m_DBUpdateReadBy(cref, uid);
     COMMENT.MarkRead(cref, uid);
-  })
+  });
   COMMENT.DeriveAllThreadedViewObjects(uid);
   m_SetAppStateCommentCollections();
-}
+};
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// Comment Collections
-MOD.GetCommentCollection = (uiref) => {
+MOD.GetCommentCollection = uiref => {
   return COMMENT.GetCommentCollection(uiref);
-}
+};
 /**
  * Marks a comment as read, and closes the component.
  * Called by NCCommentBtn when clicking "Close"
@@ -265,25 +262,27 @@ MOD.GetCommentCollection = (uiref) => {
 MOD.CloseCommentCollection = (uiref, cref, uid) => {
   if (!MOD.OKtoClose(cref)) {
     // Comment is still being edited, prevent close
-    alert('This comment is still being edited!  Please Save or Cancel before closing the comment.')
+    alert(
+      'This comment is still being edited!  Please Save or Cancel before closing the comment.'
+    );
     return;
   }
   // OK to close
   m_DBUpdateReadBy(cref, uid);
   COMMENT.CloseCommentCollection(uiref, cref, uid);
   m_SetAppStateCommentCollections();
-}
+};
 
 MOD.GetCommentStats = () => {
   const uid = MOD.GetCurrentUserId();
   return COMMENT.GetCommentStats(uid);
-}
+};
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// Comment UI State
 MOD.GetCommentUIState = uiref => {
   return COMMENT.GetCommentUIState(uiref);
-}
+};
 /**
  *
  * @param {Object} data
@@ -294,7 +293,7 @@ MOD.GetCommentUIState = uiref => {
 MOD.UpdateCommentUIState = data => {
   COMMENT.UpdateCommentUIState(data);
   m_SetAppStateCommentCollections();
-}
+};
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// Open Comments
@@ -304,64 +303,63 @@ MOD.GetOpenComments = cref => COMMENT.GetOpenComments(cref);
 /// Editable Comments (comments being ddited)
 
 MOD.OKtoClose = cref => {
-  const cvobjs = MOD.GetThreadedViewObjects(cref)
+  const cvobjs = MOD.GetThreadedViewObjects(cref);
   let isBeingEdited = false;
   cvobjs.forEach(cvobj => {
-    if (COMMENT.GetCommentBeingEdited(cvobj.comment_id)) isBeingEdited = true
+    if (COMMENT.GetCommentBeingEdited(cvobj.comment_id)) isBeingEdited = true;
   });
   return !isBeingEdited;
-}
+};
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// Threaded View Objects
 MOD.GetThreadedViewObjects = (cref, uid) => {
   return COMMENT.GetThreadedViewObjects(cref, uid);
-}
+};
 MOD.GetThreadedViewObjectsCount = (cref, uid) => {
   return COMMENT.GetThreadedViewObjectsCount(cref, uid);
-}
+};
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// Comment View Objects
 MOD.GetCommentVObj = (cref, cid) => {
   return COMMENT.GetCommentVObj(cref, cid);
-}
+};
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// Comments
-MOD.GetComment = (cid) => {
+MOD.GetComment = cid => {
   return COMMENT.GetComment(cid);
-}
+};
 MOD.GetUnreadRepliesToMe = ui => {
   return COMMENT.GetUnreadRepliesToMe(ui);
-}
+};
 MOD.GetUnreadComments = () => {
   return COMMENT.GetUnreadComments();
-}
+};
 /**
  *
  * @param {Object} cobj Comment Object
  */
-MOD.AddComment = (cobj) => {
+MOD.AddComment = cobj => {
   // This just generates a new ID, but doesn't update the DB
   DATASTORE.PromiseNewCommentID().then(newCommentID => {
     cobj.comment_id = newCommentID;
     COMMENT.AddComment(cobj); // creates a comment vobject
     m_SetAppStateCommentVObjs();
   });
-
-}
+};
 /**
  * Update the ac/dc comments, then save it to the db
  * This will also broadcast COMMENT_UPDATE so other clients on the network
  * update the data to match the server.
  * @param {Object} cobj
  */
-MOD.UpdateComment = (cobj) => {
+MOD.UpdateComment = cobj => {
   COMMENT.UpdateComment(cobj);
   m_DBUpdateComment(cobj);
   m_SetAppStateCommentVObjs();
-}
+};
 /**
  * Removing a comment can affect multiple comments, so this is done
  * via a batch operation.  We queue up all of the comment changes
@@ -385,7 +383,7 @@ MOD.RemoveComment = (parms, cb) => {
     // Are you sure you want to cancel?
     confirmMessage = `Are you sure you want to cancel editing this comment #${parms.comment_id}?`;
     okmessage = 'Cancel Editing and Delete';
-    cancelmessage = "Go Back to Editing";
+    cancelmessage = 'Go Back to Editing';
   } else {
     // Are you sure you want to delete?
     parms.isAdmin = SETTINGS.IsAdmin();
@@ -406,7 +404,7 @@ MOD.RemoveComment = (parms, cb) => {
   );
   const container = document.getElementById(dialogContainerId);
   ReactDOM.render(dialog, container);
-}
+};
 /**
  * The db call is made AFTER ac/dc handles the removal and the logic of
  * relinking comments.  The db call is dumb, all the logic is in dc-comments.
@@ -438,7 +436,7 @@ MOD.RemoveAllCommentsForCref = cref => {
   const queuedActions = COMMENT.RemoveAllCommentsForCref(parms);
   m_DBRemoveComment(queuedActions);
   m_SetAppStateCommentVObjs();
-}
+};
 
 /// EVENT HANDLERS ////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -453,7 +451,7 @@ MOD.RemoveAllCommentsForCref = cref => {
  * (does not trigger another DB update)
  * @param {Object[]} dataArray
  */
-MOD.HandleCOMMENTS_UPDATE = (dataArray) => {
+MOD.HandleCOMMENTS_UPDATE = dataArray => {
   if (DBG) console.log('COMMENTS_UPDATE======================', dataArray);
   const updatedComments = [];
   const removedComments = [];
@@ -464,8 +462,7 @@ MOD.HandleCOMMENTS_UPDATE = (dataArray) => {
       updatedCrefs.set(data.comment.collection_ref, 'flag');
     }
     if (data.commentID) removedComments.push(data.commentID);
-    if (data.collection_ref)
-      updatedCrefs.set(data.collection_ref, 'flag');
+    if (data.collection_ref) updatedCrefs.set(data.collection_ref, 'flag');
   });
   const uid = MOD.GetCurrentUserId();
   COMMENT.HandleRemovedComments(removedComments, uid);
@@ -477,7 +474,7 @@ MOD.HandleCOMMENTS_UPDATE = (dataArray) => {
   // and broadcast a state change
   m_SetAppStateCommentCollections();
   m_SetAppStateCommentVObjs();
-}
+};
 /**
  * Respond to COMMENT_UPDATE Messages from the network
  * After the server/db saves the new/updated comment, COMMENT_UPDATE is
@@ -487,14 +484,14 @@ MOD.HandleCOMMENTS_UPDATE = (dataArray) => {
  * @param {Object} data
  * @param {Object} data.comment cobj
  */
-MOD.HandleCOMMENT_UPDATE = (data) => {
+MOD.HandleCOMMENT_UPDATE = data => {
   if (DBG) console.log('COMMENT_UPDATE======================', data);
   const { comment } = data;
   m_UpdateComment(comment);
   // and broadcast a state change
   m_SetAppStateCommentCollections();
   m_SetAppStateCommentVObjs();
-}
+};
 MOD.HandleREADBY_UPDATE = data => {
   if (DBG) console.log('READBY_UPDATE======================');
   // Not used currently
@@ -505,7 +502,7 @@ MOD.HandleREADBY_UPDATE = data => {
   //
   // The exception to this would be if we wanted to support a single user
   // logged in to multiple browsers.
-}
+};
 
 /// DB CALLS //////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -539,7 +536,7 @@ function m_DBUpdateReadBy(cref, uid) {
       commenter_ids
     };
     readbys.push(readby);
-  })
+  });
   UDATA.LocalCall('DB_UPDATE', { readbys }).then(data => {
     if (typeof cb === 'function') cb(data);
   });

--- a/app/view/netcreate/comment-mgr.js
+++ b/app/view/netcreate/comment-mgr.js
@@ -13,6 +13,8 @@ const UNISYS = require('unisys/client');
 const { COMMENT } = require('@ursys/addons');
 const DATASTORE = require('system/datastore');
 const { ARROW_RIGHT } = require('system/util/constant');
+const { EDITORTYPE } = require('system/util/enum');
+const NCUI = require('./nc-ui');
 const NCDialog = require('./components/NCDialog');
 const SETTINGS = require('settings');
 
@@ -115,6 +117,10 @@ function m_UpdatePermissions(data) {
 }
 /// API METHODS ///////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// CONSTANTS
+MOD.VIEWMODE = NCUI.VIEWMODE;
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// Collection Reference Generators
@@ -510,6 +516,21 @@ MOD.HandleREADBY_UPDATE = data => {
 
 /// DB CALLS //////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+MOD.LockComment = comment_id => {
+  UDATA.NetCall('SRV_DBLOCKCOMMENT', { commentID: comment_id }).then(
+    () => {
+      UDATA.NetCall('SRV_REQ_EDIT_LOCK', { editor: EDITORTYPE.COMMENT });
+      UDATA.LocalCall('SELECTMGR_SET_MODE', { mode: 'comment_edit' });
+    }
+  );
+}
+MOD.UnlockComment = comment_id => {
+  UDATA.NetCall('SRV_DBUNLOCKCOMMENT', { commentID: comment_id }).then(() => {
+    UDATA.NetCall('SRV_RELEASE_EDIT_LOCK', { editor: EDITORTYPE.COMMENT });
+    UDATA.LocalCall('SELECTMGR_SET_MODE', { mode: 'normal' });
+  });
+}
+
 function m_DBUpdateComment(cobj, cb) {
   const comment = {
     collection_ref: cobj.collection_ref,

--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -705,7 +705,7 @@ class EdgeTable extends UNISYS.Component {
                   {edgeDefs.provenance.displayLabel} {this.sortSymbol('provenance')}
                 </Button>
               </th>
-              <th>
+              <th style={{ zIndex: 1 }}>
                 <div
                   className="comment-icon-inline comment-intable"
                   onClick={() => this.setSortKey('commentbtn')}
@@ -746,7 +746,7 @@ class EdgeTable extends UNISYS.Component {
                     edge.filteredTransparency > 0.5 ? 1 : edge.filteredTransparency,
                   border:
                     selectedEdgeId === edge.id
-                      ? `2px solid ${selectedEdgeColor}`
+                      ? `3px solid ${selectedEdgeColor}`
                       : 'none'
                 }}
               >

--- a/app/view/netcreate/components/NCComment.css
+++ b/app/view/netcreate/components/NCComment.css
@@ -316,6 +316,9 @@ svg#comment-icon {
   color: #0008;
   font-size: 0.8em;
 }
+.comment .label {
+  margin-top: 10px;
+}
 .commentThread .comment .help {
   /* override nccomponent */
   font-style: italic; /* emulate nccomponent */
@@ -334,12 +337,13 @@ svg#comment-icon {
 }
 .comment .feedback,
 .comment .error {
-  opacity: 0.8;
+  opacity: 0.7;
   font-size: 12px;
   line-height: 14px;
 }
 .comment .feedback {
-  color: #0007; /* emulate nccomponent help */
+  color: #0008; /* emulate nccomponent help */
+  font-style: italic;
 }
 .comment .error {
   color: var(--comment-status-font-color);
@@ -454,15 +458,55 @@ svg#comment-icon {
   background-color: #fff8;
   margin-bottom: 5px;
 }
-/* emulate nccomponent */
-.comment textarea {
+/* emulate nccomponent and override */
+.comment div textarea {
   width: 100%;
   border-radius: 2px;
   border-color: #0006;
   border-width: 1px;
   border-style: solid;
   background-color: #fff8;
-  margin-bottom: 5px;
+  margin: 0; /* override nccomponent */
   padding: 0 5px;
   resize: none;
+}
+
+.comment label {
+  display: block;
+  margin-right: 1rem;
+  margin-bottom: 0;
+}
+.comment label input {
+  display: inline;
+  width: fit-content;
+  margin-right: 0.25rem;
+}
+
+/* prompt format */
+.comment .prompt input[type='checkbox'] {
+  opacity: 1;
+}
+.comment .prompt input[type='checkbox'].readonly {
+  opacity: 0.5;
+}
+.comment .prompt button {
+  border: none;
+  margin-left: 0; /* override nccomponent */
+}
+.comment .prompt button:disabled {
+}
+.comment .prompt button:disabled:hover {
+  background-color: #0003;
+}
+.comment .prompt button:hover {
+  background-color: #fff8;
+}
+.comment .prompt button.selected {
+  background-color: #fff;
+  color: #000;
+  border: 1px solid;
+  border-color: var(--comment-status-font-color);
+}
+.comment .prompt button.notselected {
+  opacity: 0.5;
 }

--- a/app/view/netcreate/components/NCComment.css
+++ b/app/view/netcreate/components/NCComment.css
@@ -494,9 +494,7 @@ svg#comment-icon {
   margin-left: 0; /* override nccomponent */
 }
 .comment .prompt button:disabled {
-}
-.comment .prompt button:disabled:hover {
-  background-color: #0003;
+  cursor: default; /* override nccomponent */
 }
 .comment .prompt button:hover {
   background-color: #fff8;

--- a/app/view/netcreate/components/NCComment.css
+++ b/app/view/netcreate/components/NCComment.css
@@ -493,11 +493,18 @@ svg#comment-icon {
   border: none;
   margin-left: 0; /* override nccomponent */
 }
-.comment .prompt button:disabled {
-  cursor: default; /* override nccomponent */
+.comment .prompt button:hover:disabled.notselected {
+  background-color: inherit;
+  border: none;
 }
 .comment .prompt button:hover {
-  background-color: #fff8;
+  background-color: #fff9;
+  opacity: 0.8;
+  border: 1px solid;
+  border-color: var(--comment-status-font-color);
+}
+.comment .prompt button:disabled {
+  cursor: default; /* override nccomponent */
 }
 .comment .prompt button.selected {
   background-color: #fff;

--- a/app/view/netcreate/components/NCComment.css
+++ b/app/view/netcreate/components/NCComment.css
@@ -4,6 +4,7 @@
   --comment-bg-new: #d84a00;
   --comment-status-font-color: #d84a0088;
   --comment-system-font-color: #0003;
+  --disabled-opacity: 0.5;
 }
 
 /* Comment Bar ------------------------------------------------------------- */
@@ -264,6 +265,10 @@ svg#comment-icon {
   text-transform: uppercase;
   font-size: 0.9em;
 }
+.commentThread button:disabled {
+  cursor: default;
+  opacity: var(--disabled-opacity);
+}
 
 /* Comment */
 .comment {
@@ -505,6 +510,7 @@ svg#comment-icon {
 }
 .comment .prompt button:disabled {
   cursor: default; /* override nccomponent */
+  opacity: var(--disabled-opacity);
 }
 .comment .prompt button.selected {
   background-color: #fff;

--- a/app/view/netcreate/components/NCComment.jsx
+++ b/app/view/netcreate/components/NCComment.jsx
@@ -79,9 +79,10 @@ class NCComment extends React.Component {
     let selected_comment_type = comment.comment_type;
     let comment_error = '';
     if (!CMTMGR.GetCommentType(selected_comment_type)) {
-      const defaultTypeObject = CMTMGR.GetDefaultCommentType();
-      comment_error = `Comment type "${selected_comment_type}" not found: Using "${defaultTypeObject.label}"`;
-      selected_comment_type = defaultTypeObject.id;
+      const defaultCommentTypeObject = CMTMGR.GetDefaultCommentType();
+      comment_error = `Comment type "${selected_comment_type}" not found: Falling back to default  "${defaultCommentTypeObject.label}"`;
+      console.warn(comment_error);
+      selected_comment_type = defaultCommentTypeObject.slug;
     }
 
     this.setState({

--- a/app/view/netcreate/components/NCComment.jsx
+++ b/app/view/netcreate/components/NCComment.jsx
@@ -347,6 +347,7 @@ class NCComment extends React.Component {
               cvobj={cvobj}
               viewMode={NCUI.VIEWMODE.EDIT}
               onChange={this.UIOnInputUpdate}
+              errorMessage={comment_error}
             />
             <div className="editbar">
               {CancelBtn}
@@ -375,6 +376,7 @@ class NCComment extends React.Component {
               cvobj={cvobj}
               viewMode={NCUI.VIEWMODE.VIEW}
               onChange={this.UIOnInputUpdate}
+              errorMessage={comment_error}
             />
             {uid && (
               <div className="commentbar">

--- a/app/view/netcreate/components/NCCommentBtn.jsx
+++ b/app/view/netcreate/components/NCCommentBtn.jsx
@@ -182,11 +182,7 @@ class NCCommentBtn extends React.Component {
       y: position.y
     };
     this.setState(updatedState, () => {
-      CMTMGR.UpdateCommentUIState({
-        uiref: commentButtonId,
-        cref,
-        isOpen
-      });
+      CMTMGR.UpdateCommentUIState(commentButtonId, { cref, isOpen });
     });
   }
 

--- a/app/view/netcreate/components/NCCommentPrompt.jsx
+++ b/app/view/netcreate/components/NCCommentPrompt.jsx
@@ -4,7 +4,7 @@
 
   In edit mode, displays input widgets for entering prompts.
   In view mode, displays static comment prompt.
-  A comment can contain one ore more comment prompts.
+  A comment can contain one or more comment prompts.
   Each prompt can use a different prompt format.
 
   PROMPT FORMATS:
@@ -51,7 +51,6 @@ const CMTMGR = require('../comment-mgr');
 const DBG = false;
 const PR = 'NCCommentPrompt';
 
-const OPTION_DELIMITER = '::::';
 const CHECKBOX_DELIMITER = /\n/;
 
 /// REACT COMPONENT ///////////////////////////////////////////////////////////
@@ -62,8 +61,8 @@ class NCCommentPrompt extends React.Component {
     this.state = {};
 
     // DATA PROCESSORS
-    this.SplitCheckboxText = this.SplitCheckboxText.bind(this);
-    this.Stacked2Text = this.Stacked2Text.bind(this);
+    this.SplitCheckboxCommentText = this.SplitCheckboxCommentText.bind(this);
+    this.SelectedIndex2CommentText = this.SelectedIndex2CommentText.bind(this);
 
     // RENDERERS
     this.RenderEditMode = this.RenderEditMode.bind(this);
@@ -71,7 +70,6 @@ class NCCommentPrompt extends React.Component {
 
     // UI HANDLERS
     this.UIOnCheck = this.UIOnCheck.bind(this);
-    // this.UIOnRating = this.UIOnRating.bind(this);
   }
 
   /**
@@ -79,29 +77,26 @@ class NCCommentPrompt extends React.Component {
    * @param {string} commenterTextString newline delimited string, e.g. "Apple Pie\nApple Fritter"
    * @returns {string[]}
    */
-  SplitCheckboxText(commenterTextString) {
+  SplitCheckboxCommentText(commenterTextString) {
     if (commenterTextString === undefined) return [];
     return commenterTextString.split(CHECKBOX_DELIMITER);
   }
 
   /**
-   * Converts a selection index into a stacked discrete slider string,
-   * e.g. 2 becomes `★★★`
+   * Converts a selection index into a stacked discrete slider string
+   * to save as comment text, e.g. 2 becomes `★★★`
    * Each option can have a different value
    * @param {number} index the selected item index (0-based)
    * @param {string[]} options e.g.  ['💙', '💚', '💛', '🧡', '🩷']
    * @returns {string} e.g. 2 returns '💙💚💛'
    */
-  Stacked2Text(index, options) {
-    let result = '';
-    for (let i = 0; i < options.length; i++) {
-      if (i <= index) result += options[i];
-    }
-    return result;
+  SelectedIndex2CommentText(index, options) {
+    return options.map((o, i) => (i <= index ? o : '')).join('');
   }
 
   /**
-   * Combines all checkbox items into a single string
+   * Triggers onChange handler with derived data
+   * Combines all checkbox items into a single newline-delimited string
    * e.g. "Apple\nBanana"
    * @param {*} promptIndex
    * @param {*} optionIndex
@@ -111,7 +106,7 @@ class NCCommentPrompt extends React.Component {
   UIOnCheck(promptIndex, optionIndex, options, event) {
     const { comment, onChange } = this.props;
     // e.g. selectedCheckboxes =  ["Apple Pie", "Apple Fritter"]
-    const selectedCheckboxes = this.SplitCheckboxText(
+    const selectedCheckboxes = this.SplitCheckboxCommentText(
       comment.commenter_text[promptIndex]
     );
     let items = [];
@@ -165,7 +160,7 @@ class NCCommentPrompt extends React.Component {
           break;
         case 'checkbox': {
           // converts commment text into ["Apple", "Banana"]
-          const selectedCheckboxes = this.SplitCheckboxText(
+          const selectedCheckboxes = this.SplitCheckboxCommentText(
             commenterText[promptIndex]
           );
           inputJSX = (
@@ -235,7 +230,10 @@ class NCCommentPrompt extends React.Component {
               {prompt.options.map((option, index) => (
                 <button
                   key={index}
-                  value={[index, this.Stacked2Text(index, prompt.options)]} // {option}
+                  value={[
+                    index,
+                    this.SelectedIndex2CommentText(index, prompt.options)
+                  ]}
                   className={
                     String(index) <= commenterText[promptIndex]
                       ? 'selected'
@@ -287,7 +285,7 @@ class NCCommentPrompt extends React.Component {
           break;
         case 'checkbox': {
           // converts commment text into ["Apple", "Banana"]
-          const selectedCheckboxes = this.SplitCheckboxText(
+          const selectedCheckboxes = this.SplitCheckboxCommentText(
             commenterText[promptIndex]
           );
           displayJSX = (

--- a/app/view/netcreate/components/NCCommentPrompt.jsx
+++ b/app/view/netcreate/components/NCCommentPrompt.jsx
@@ -269,6 +269,7 @@ class NCCommentPrompt extends React.Component {
     const commenterText = comment.commenter_text;
 
     const comment_error = 'placeholder';
+    const NOTHING_SELECTED = <span className="help">(nothing selected)</span>;
 
     let promptsJSX = [];
     commentTypes.get(commentType).prompts.map((prompt, promptIndex) => {
@@ -280,6 +281,7 @@ class NCCommentPrompt extends React.Component {
           displayJSX = (
             <div className="commenttext">
               {!comment.comment_isMarkedDeleted && commenterText[promptIndex]}
+              {commenterText[promptIndex] === undefined && NOTHING_SELECTED}
             </div>
           );
           break;
@@ -309,7 +311,6 @@ class NCCommentPrompt extends React.Component {
           break;
         }
         case 'likert':
-          if (commenterText[promptIndex] === undefined) break;
           displayJSX = (
             <div className="prompt">
               {prompt.options.map((option, index) => (
@@ -328,7 +329,6 @@ class NCCommentPrompt extends React.Component {
           );
           break;
         case 'discrete-slider':
-          if (commenterText[promptIndex] === undefined) break;
           displayJSX = (
             <div className="prompt">
               {prompt.options.map((option, index) => (

--- a/app/view/netcreate/components/NCCommentPrompt.jsx
+++ b/app/view/netcreate/components/NCCommentPrompt.jsx
@@ -88,7 +88,7 @@ class NCCommentPrompt extends React.Component {
   }
 
   /**
-   * Converts a selection index into a stacked discrete slider string
+   * Converts a selection 0-based index into a stacked discrete slider string
    * to save as comment text, e.g. 2 becomes `★★★`
    * Each option can have a different value
    * @param {number} index the selected item index (0-based)

--- a/app/view/netcreate/components/NCCommentPrompt.jsx
+++ b/app/view/netcreate/components/NCCommentPrompt.jsx
@@ -38,6 +38,7 @@
       cvobj={cvobj}
       viewMode={uViewMode}
       onChange={this.UIOnInputUpdate}
+      errorMessage={comment_error}
     />
 
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
@@ -130,10 +131,10 @@ class NCCommentPrompt extends React.Component {
   }
 
   RenderEditMode() {
-    const { commentType, comment, cvobj, viewMode, onChange } = this.props;
+    const { commentType, comment, cvobj, viewMode, onChange, errorMessage } =
+      this.props;
     const commentTypes = CMTMGR.GetCommentTypes();
     const commenterText = comment.commenter_text;
-    const comment_error = 'placeholder';
 
     let promptsJSX = [];
     commentTypes.get(commentType).prompts.map((prompt, promptIndex) => {
@@ -258,7 +259,7 @@ class NCCommentPrompt extends React.Component {
           <div className="help">{prompt.help}</div>
           {inputJSX}
           <div className="feedback">{prompt.feedback}</div>
-          <div className="error">{comment_error}</div>
+          <div className="error">{errorMessage}</div>
           <hr />
         </div>
       );
@@ -268,11 +269,11 @@ class NCCommentPrompt extends React.Component {
   }
 
   RenderViewMode() {
-    const { commentType, comment, cvobj, viewMode, onChange } = this.props;
+    const { commentType, comment, cvobj, viewMode, onChange, errorMessage } =
+      this.props;
     const commentTypes = CMTMGR.GetCommentTypes();
     const commenterText = comment.commenter_text;
 
-    const comment_error = 'placeholder';
     const NOTHING_SELECTED = <span className="help">(nothing selected)</span>;
 
     let promptsJSX = [];
@@ -367,7 +368,7 @@ class NCCommentPrompt extends React.Component {
           <div className="help">{prompt.help}</div>
           {displayJSX}
           <div className="feedback">{prompt.feedback}</div>
-          <div className="error">{comment_error}</div>
+          <div className="error">{errorMessage}</div>
           <hr />
         </div>
       );

--- a/app/view/netcreate/components/NCCommentPrompt.jsx
+++ b/app/view/netcreate/components/NCCommentPrompt.jsx
@@ -61,6 +61,7 @@ class NCCommentPrompt extends React.Component {
     this.state = {};
 
     // DATA PROCESSORS
+    this.IsEmpty = this.IsEmpty.bind(this);
     this.SplitCheckboxCommentText = this.SplitCheckboxCommentText.bind(this);
     this.SelectedIndex2CommentText = this.SelectedIndex2CommentText.bind(this);
 
@@ -72,6 +73,9 @@ class NCCommentPrompt extends React.Component {
     this.UIOnCheck = this.UIOnCheck.bind(this);
   }
 
+  IsEmpty(commentText) {
+    return commentText === undefined || commentText === null || commentText === '';
+  }
   /**
    * Converts "Apple Pie\nApple Fritter" into ["Apple Pie", "Apple Fritter"]
    * @param {string} commenterTextString newline delimited string, e.g. "Apple Pie\nApple Fritter"
@@ -281,7 +285,7 @@ class NCCommentPrompt extends React.Component {
           displayJSX = (
             <div className="commenttext">
               {!comment.comment_isMarkedDeleted && commenterText[promptIndex]}
-              {commenterText[promptIndex] === undefined && NOTHING_SELECTED}
+              {this.IsEmpty(commenterText[promptIndex]) && NOTHING_SELECTED}
             </div>
           );
           break;

--- a/app/view/netcreate/components/NCCommentPrompt.jsx
+++ b/app/view/netcreate/components/NCCommentPrompt.jsx
@@ -1,0 +1,388 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  CommentPrompt
+
+  In edit mode, displays input widgets for entering prompts.
+  In view mode, displays static comment prompt.
+  A comment can contain one ore more comment prompts.
+  Each prompt can use a different prompt format.
+
+  PROMPT FORMATS:
+    - text
+    - dropdown
+    - checkbox
+    - likert
+    - radio
+    - discrete-slider
+
+  Prompt formats use exact `text` matching to determine the selected item,
+  not an index.  So if you change the label on the prompt type, you will
+  have to update the selection as well.  The rationale for this is that
+  we want the comment database data to be as human-readable as possible.
+  Otherwise comment data would mostly be a series of indices that you
+  would have to back-match:
+    - dropdown
+    - likert
+    - radio
+  The exceptions are:
+    - checkbox -- matches `text` within a \n-delimited string
+    - discrete-slider -- matches based on the selected index value
+                         In this case, using the value makes sense
+                         because the saved data is a number.
+
+  USE:
+
+    <NCCommentPrompt
+      commentType={comment_type} // currently selected comment type, not stored comment.comment_type
+      comment={comment}
+      cvobj={cvobj}
+      viewMode={uViewMode}
+      onChange={this.UIOnInputUpdate}
+    />
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+const React = require('react');
+const NCUI = require('../nc-ui');
+const CMTMGR = require('../comment-mgr');
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const DBG = false;
+const PR = 'NCCommentPrompt';
+
+const OPTION_DELIMITER = '::::';
+const CHECKBOX_DELIMITER = /\n/;
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+class NCCommentPrompt extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+
+    // DATA PROCESSORS
+    this.SplitCheckboxText = this.SplitCheckboxText.bind(this);
+    this.Stacked2Text = this.Stacked2Text.bind(this);
+
+    // RENDERERS
+    this.RenderEditMode = this.RenderEditMode.bind(this);
+    this.RenderViewMode = this.RenderViewMode.bind(this);
+
+    // UI HANDLERS
+    this.UIOnCheck = this.UIOnCheck.bind(this);
+    // this.UIOnRating = this.UIOnRating.bind(this);
+  }
+
+  /**
+   * Converts "Apple Pie\nApple Fritter" into ["Apple Pie", "Apple Fritter"]
+   * @param {string} commenterTextString newline delimited string, e.g. "Apple Pie\nApple Fritter"
+   * @returns {string[]}
+   */
+  SplitCheckboxText(commenterTextString) {
+    if (commenterTextString === undefined) return [];
+    return commenterTextString.split(CHECKBOX_DELIMITER);
+  }
+
+  /**
+   * Converts a selection index into a stacked discrete slider string,
+   * e.g. 2 becomes `★★★`
+   * Each option can have a different value
+   * @param {number} index the selected item index (0-based)
+   * @param {string[]} options e.g.  ['💙', '💚', '💛', '🧡', '🩷']
+   * @returns {string} e.g. 2 returns '💙💚💛'
+   */
+  Stacked2Text(index, options) {
+    let result = '';
+    for (let i = 0; i < options.length; i++) {
+      if (i <= index) result += options[i];
+    }
+    return result;
+  }
+
+  /**
+   * Combines all checkbox items into a single string
+   * e.g. "Apple\nBanana"
+   * @param {*} promptIndex
+   * @param {*} optionIndex
+   * @param {*} options
+   * @param {*} event
+   */
+  UIOnCheck(promptIndex, optionIndex, options, event) {
+    const { comment, onChange } = this.props;
+    // e.g. selectedCheckboxes =  ["Apple Pie", "Apple Fritter"]
+    const selectedCheckboxes = this.SplitCheckboxText(
+      comment.commenter_text[promptIndex]
+    );
+    let items = [];
+    options.forEach((o, index) => {
+      if (optionIndex === index) {
+        // handle the current selection
+        if (event.target.checked) items[index] = o;
+        else items[index] = '';
+      } else {
+        // handle previous selections
+        if (selectedCheckboxes.includes(o)) items[index] = o;
+        else items[index] = '';
+      }
+    });
+    event.target.value = items.join('\n');
+    onChange(promptIndex, event);
+  }
+
+  RenderEditMode() {
+    const { commentType, comment, cvobj, viewMode, onChange } = this.props;
+    const commentTypes = CMTMGR.GetCommentTypes();
+    const commenterText = comment.commenter_text;
+    const comment_error = 'placeholder';
+
+    let promptsJSX = [];
+    commentTypes.get(commentType).prompts.map((prompt, promptIndex) => {
+      let inputJSX;
+      switch (prompt.format) {
+        case 'text':
+          inputJSX = (
+            <textarea
+              autoFocus
+              onChange={event => onChange(promptIndex, event)}
+              value={commenterText[promptIndex]}
+            />
+          );
+          break;
+        case 'dropdown':
+          inputJSX = (
+            <select
+              value={commenterText[promptIndex]}
+              onChange={event => onChange(promptIndex, event)}
+            >
+              {prompt.options.map((option, index) => (
+                <option key={index} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          );
+          break;
+        case 'checkbox': {
+          // converts commment text into ["Apple", "Banana"]
+          const selectedCheckboxes = this.SplitCheckboxText(
+            commenterText[promptIndex]
+          );
+          inputJSX = (
+            <div className="prompt">
+              {prompt.options.map((option, optionIndex) => {
+                return (
+                  <label key={optionIndex}>
+                    <input
+                      type="checkbox"
+                      value={option}
+                      onChange={event =>
+                        this.UIOnCheck(
+                          promptIndex,
+                          optionIndex,
+                          prompt.options,
+                          event
+                        )
+                      }
+                      checked={selectedCheckboxes.includes(option)}
+                    />
+                    {option}
+                  </label>
+                );
+              })}
+            </div>
+          );
+          break;
+        }
+        case 'radio':
+          inputJSX = (
+            <div>
+              {prompt.options.map((option, index) => (
+                <label key={index}>
+                  <input
+                    type="radio"
+                    value={option}
+                    onChange={event => onChange(promptIndex, event)}
+                    checked={commenterText[promptIndex] === option}
+                  />
+                  {option}
+                </label>
+              ))}
+            </div>
+          );
+          break;
+        case 'likert':
+          inputJSX = (
+            <div className="prompt">
+              {prompt.options.map((option, optionIndex) => (
+                <button
+                  key={optionIndex}
+                  value={option}
+                  className={
+                    commenterText[promptIndex] === option ? 'selected' : 'notselected'
+                  }
+                  onClick={event => onChange(promptIndex, event)}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+          );
+          break;
+        case 'discrete-slider':
+          inputJSX = (
+            <div className="prompt">
+              {prompt.options.map((option, index) => (
+                <button
+                  key={index}
+                  value={[index, this.Stacked2Text(index, prompt.options)]} // {option}
+                  className={
+                    String(index) <= commenterText[promptIndex]
+                      ? 'selected'
+                      : 'notselected'
+                  }
+                  onClick={event => onChange(promptIndex, event)}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+          );
+          break;
+      }
+      let promptJSX = (
+        <div key={promptIndex}>
+          <div className="label">{prompt.prompt}</div>
+          <div className="help">{prompt.help}</div>
+          {inputJSX}
+          <div className="feedback">{prompt.feedback}</div>
+          <div className="error">{comment_error}</div>
+          <hr />
+        </div>
+      );
+      promptsJSX.push(promptJSX);
+    });
+    return promptsJSX;
+  }
+
+  RenderViewMode() {
+    const { commentType, comment, cvobj, viewMode, onChange } = this.props;
+    const commentTypes = CMTMGR.GetCommentTypes();
+    const commenterText = comment.commenter_text;
+
+    const comment_error = 'placeholder';
+
+    let promptsJSX = [];
+    commentTypes.get(commentType).prompts.map((prompt, promptIndex) => {
+      let displayJSX;
+      switch (prompt.format) {
+        case 'text':
+        case 'dropdown':
+        case 'radio':
+          displayJSX = (
+            <div className="commenttext">
+              {!comment.comment_isMarkedDeleted && commenterText[promptIndex]}
+            </div>
+          );
+          break;
+        case 'checkbox': {
+          // converts commment text into ["Apple", "Banana"]
+          const selectedCheckboxes = this.SplitCheckboxText(
+            commenterText[promptIndex]
+          );
+          displayJSX = (
+            <div className="prompt">
+              {prompt.options.map((option, optionIndex) => (
+                <label key={optionIndex}>
+                  <input
+                    type="checkbox"
+                    value={option}
+                    checked={selectedCheckboxes.includes(option)}
+                    readOnly // React will emit warning if there isn't an onChange handler
+                    className={'readonly'} // css: class is necessary for styling
+                    // css: `input[type='checkbox']:read-only` doesn't work -- it matches non-`readOnly` too
+                    // css: `disabled` grays out the checkbox too much, use the css class to style
+                  />
+                  {option}
+                </label>
+              ))}
+            </div>
+          );
+          break;
+        }
+        case 'likert':
+          if (commenterText[promptIndex] === undefined) break;
+          displayJSX = (
+            <div className="prompt">
+              {prompt.options.map((option, index) => (
+                <button
+                  key={index}
+                  value={option}
+                  className={
+                    commenterText[promptIndex] === option ? 'selected' : 'notselected'
+                  }
+                  disabled
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+          );
+          break;
+        case 'discrete-slider':
+          if (commenterText[promptIndex] === undefined) break;
+          displayJSX = (
+            <div className="prompt">
+              {prompt.options.map((option, index) => (
+                <button
+                  key={index}
+                  value={option}
+                  className={
+                    String(index) <= commenterText[promptIndex]
+                      ? 'selected'
+                      : 'notselected'
+                  }
+                  disabled
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+          );
+          break;
+      }
+
+      let promptJSX = (
+        <div key={promptIndex} className="comment-item">
+          <div className="label">
+            <div className="comment-icon-inline">
+              {!cvobj.isMarkedRead &&
+                !comment.comment_isMarkedDeleted &&
+                CMTMGR.COMMENTICON}
+            </div>
+            {prompt.prompt}
+          </div>
+          <div className="help">{prompt.help}</div>
+          {displayJSX}
+          <div className="feedback">{prompt.feedback}</div>
+          <div className="error">{comment_error}</div>
+          <hr />
+        </div>
+      );
+      promptsJSX.push(promptJSX);
+    });
+    return promptsJSX;
+  }
+
+  render() {
+    if (this.props.viewMode === NCUI.VIEWMODE.EDIT) {
+      return this.RenderEditMode();
+    } else {
+      return this.RenderViewMode();
+    }
+  }
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = NCCommentPrompt;

--- a/app/view/netcreate/components/NCCommentPrompt.jsx
+++ b/app/view/netcreate/components/NCCommentPrompt.jsx
@@ -44,7 +44,6 @@
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
 
 const React = require('react');
-const NCUI = require('../nc-ui');
 const CMTMGR = require('../comment-mgr');
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
@@ -378,7 +377,7 @@ class NCCommentPrompt extends React.Component {
   }
 
   render() {
-    if (this.props.viewMode === NCUI.VIEWMODE.EDIT) {
+    if (this.props.viewMode === CMTMGR.VIEWMODE.EDIT) {
       return this.RenderEditMode();
     } else {
       return this.RenderViewMode();

--- a/app/view/netcreate/components/NCCommentPrompt.jsx
+++ b/app/view/netcreate/components/NCCommentPrompt.jsx
@@ -78,7 +78,7 @@ class NCCommentPrompt extends React.Component {
    * @returns {string[]}
    */
   SplitCheckboxCommentText(commenterTextString) {
-    if (commenterTextString === undefined) return [];
+    if (!commenterTextString) return [];
     return commenterTextString.split(CHECKBOX_DELIMITER);
   }
 

--- a/app/view/netcreate/components/NCCommentPrompt.jsx
+++ b/app/view/netcreate/components/NCCommentPrompt.jsx
@@ -145,14 +145,14 @@ class NCCommentPrompt extends React.Component {
             <textarea
               autoFocus
               onChange={event => onChange(promptIndex, event)}
-              value={commenterText[promptIndex]}
+              value={commenterText[promptIndex] || ''}
             />
           );
           break;
         case 'dropdown':
           inputJSX = (
             <select
-              value={commenterText[promptIndex]}
+              value={commenterText[promptIndex] || ''}
               onChange={event => onChange(promptIndex, event)}
             >
               {prompt.options.map((option, index) => (

--- a/app/view/netcreate/components/NCCommentPrompt.jsx
+++ b/app/view/netcreate/components/NCCommentPrompt.jsx
@@ -364,9 +364,9 @@ class NCCommentPrompt extends React.Component {
             </div>
             {prompt.prompt}
           </div>
-          <div className="help">{prompt.help}</div>
+          {/* <div className="help">{prompt.help}</div> */}
           {displayJSX}
-          <div className="feedback">{prompt.feedback}</div>
+          {/* <div className="feedback">{prompt.feedback}</div> */}
           <div className="error">{errorMessage}</div>
           <hr />
         </div>

--- a/app/view/netcreate/components/NCCommentThread.jsx
+++ b/app/view/netcreate/components/NCCommentThread.jsx
@@ -117,7 +117,11 @@ class NCCommentThread extends React.Component {
     const { isDisabled } = this.state;
 
     const commentVObjs = CMTMGR.GetThreadedViewObjects(cref, uid);
-    const CloseBtn = <button onClick={this.UIOnClose}>Close</button>;
+    const CloseBtn = (
+      <button onClick={this.UIOnClose} disabled={isDisabled}>
+        Close
+      </button>
+    );
 
     // HACK: To keep the comment from going off screen:
     const windowHeight = Math.min(screen.height, window.innerHeight); // handle Safari and FireFox differences
@@ -139,9 +143,11 @@ class NCCommentThread extends React.Component {
                 {sourceLabel}
               </a>
             </div>
-            <div className="closeBtn" onClick={this.UIOnClose}>
-              X
-            </div>
+            {!isDisabled && (
+              <div className="closeBtn" onClick={this.UIOnClose}>
+                X
+              </div>
+            )}
           </div>
           <div className="commentScroller">
             {commentVObjs.map(cvobj => (

--- a/app/view/netcreate/components/NCSearch.jsx
+++ b/app/view/netcreate/components/NCSearch.jsx
@@ -35,10 +35,12 @@ class NCSearch extends UNISYS.Component {
 
     this.state = {
       isLoggedIn: false,
+      uIsLockedByComment: false,
       value: ''
     }; // initialized on componentDidMount and clearSelection
 
     this.UpdateSession = this.UpdateSession.bind(this);
+    this.SetPermissions = this.SetPermissions.bind(this);
     this.UIOnChange = this.UIOnChange.bind(this);
     this.UIOnSelect = this.UIOnSelect.bind(this);
     this.UINewNode = this.UINewNode.bind(this);
@@ -48,10 +50,12 @@ class NCSearch extends UNISYS.Component {
     /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     /// REGISTER LISTENERS
     UDATA.OnAppStateChange('SESSION', this.UpdateSession);
+    UDATA.HandleMessage('EDIT_PERMISSIONS_UPDATE', this.SetPermissions);
   }
 
   componentWillUnmount() {
     UDATA.AppStateChangeOff('SESSION', this.UpdateSession);
+    UDATA.UnhandleMessage('EDIT_PERMISSIONS_UPDATE', this.SetPermissions);
   }
 
   /**
@@ -67,6 +71,13 @@ class NCSearch extends UNISYS.Component {
     this.setState({ isLoggedIn: decoded.isValid });
   }
 
+  SetPermissions(data) {
+    UDATA.NetCall('SRV_GET_EDIT_STATUS').then(data => {
+      this.setState({
+        uIsLockedByComment: data.commentBeingEditedByMe
+      });
+    });
+  }
   /**
    * The callback function (cb) is used to restore the selection point
    * otherwise the `value` state update will leave the cursor at the end of the field.
@@ -112,8 +123,8 @@ class NCSearch extends UNISYS.Component {
   /// MAIN RENDER
   ///
   render() {
-    const { value, isLoggedIn } = this.state;
-    const newNodeBtnHidden = !isLoggedIn;
+    const { value, isLoggedIn, uIsLockedByComment } = this.state;
+    const newNodeBtnHidden = !isLoggedIn || uIsLockedByComment;
     const newNodeBtnDisabled = value === '';
     const key = 'search'; // used for search/source/target, placeholder for search
     return (

--- a/app/view/netcreate/components/NodeTable.jsx
+++ b/app/view/netcreate/components/NodeTable.jsx
@@ -523,7 +523,6 @@ class NodeTable extends UNISYS.Component {
       disableEdit,
       isLocked
     } = this.state;
-    console.log('selected node id', selectedNodeId);
     const { tableHeight } = this.props;
     const styles = `thead, tbody { font-size: 0.8em }
                   .table {

--- a/app/view/netcreate/components/NodeTable.jsx
+++ b/app/view/netcreate/components/NodeTable.jsx
@@ -613,7 +613,7 @@ class NodeTable extends UNISYS.Component {
                   {nodeDefs.provenance.displayLabel} {this.sortSymbol('provenance')}
                 </Button>
               </th>
-              <th>
+              <th style={{ zIndex: 1 }}>
                 <div
                   className="comment-icon-inline comment-intable"
                   onClick={() => this.setSortKey('commentbtn')}
@@ -643,10 +643,10 @@ class NodeTable extends UNISYS.Component {
                   opacity: node.filteredTransparency,
                   border:
                     (hilitedNodeId === node.id
-                      ? `2px solid ${hilitedNodeColor}`
+                      ? `3px solid ${hilitedNodeColor}`
                       : false) ||
                     (selectedNodeId === node.id
-                      ? `2px solid ${selectedNodeColor}`
+                      ? `3px solid ${selectedNodeColor}`
                       : 'none')
                 }}
                 onMouseOver={() => this.onHighlightRow(node.id)}


### PR DESCRIPTION
This adds new prompt types:
* dropdown
* checkbox
* radio
* likert
* discrete-slider

![screenshot_1540](https://github.com/netcreateorg/netcreate-itest/assets/1403057/61f5b795-b38b-4099-9323-1be84e3d02cb)

#### Dropdown

A standard browser dropdown menu.  You can use emojis, e.g. '😀 I like it'

#### Checkbox

Select one or more checkbox items.

#### Radio

Select one and only one item.  List displayed vertically in a column of radio buttons.

#### Likert

Select one and only one item.  List displayed horizontally in a row as buttons. 

You can use any text and any number of items for the likert items.  And actually the order does not matter either.  The selection is made by matching the text exactly.  So you can use `["1", "2", "3"]` or emojis `['💙', '💚', '💛', '🧡', '🩷']`

#### Discrete Slider (aka "Star Rating")

This is the star rating.  This is actually handled similar to the "Likert" but it'll display the selected item in a stack.  Each item can use a different value.  For example, you could actually use a different color for every star.  e.g. if you use `['💙', '💚', '💛', '🧡', '🩷']` and select the third item, you'd see 💙💚💛.  


## Technical Notes

* Human-readable
   WIth the exception of the Discrete Slider, all items are stored as text values so that research logs are as human-readable as possible.  e.g. selected radio/checkbox/likert values are not saved nor logged as indices but with the displayed text values.  
   
   Matching of the selected value is also done with an exact text match.  The downside of this approach is that if you change the template, the selected value will be lost.  E.g. if a user selected and saved "Apple" in their checkbox, and then you change the template so that it read "Apples" instead, the user's checkbox would be unchecked.  So this should mostly be a problem if you change templates mid-study.

* No limit on number of items
   You can add as few or as many items as you want for the menus/lists.  Practically speaking there will be space considerations, so use with discretion.


# To Do
* [x] Display "nothing selected"
* [x] Fix z order
   * [x] node < alert < comment
   * [x] table heading < alert
