### PR TITLE
Feature: Provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,54 +1,68 @@
 # CHANGELOG
-
-
 [Unreleased](#unreleased)  
-[1.5.1](#1.5.1) -- 2024 Jan 8 -- [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.5.1)  
-[1.5.0](#1.5.0) -- 2023 Dec 23 -- [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.5.0)  
-[1.4.0](#1.4.0) -- 2022 Apr 11 -- [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.4.0)  
-[1.3.1](#1.3.1) -- 2020 Sep 21 -- [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.3.1)  
-[1.3.0](#1.3.0) -- 2020 Aug 26 -- [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.3.0)  
-[1.2.1](#1.2.1) -- 2020 Jun 5 -- [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.2.1)  
-[1.2.0](#1.2.0) -- 2019 May 2 -- [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.2.0)  
-[1.1.0](#1.1.0) -- 2019 Feb 12 -- [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.1.0)  
-[1.0.1](#1.0.1) -- 2018 Oct 2 -- [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.0.1)  
-[1.0.0](#1.0.0) -- 2018 Sep 30 -- [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.0.0)  
-[0.1.0](#0.1.0) -- 2018 Aug 28 -- [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/0.1.0)  
+[1.5.1](#1.5.1) - 2024-01-08 - January 2024 Data Collection [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.5.1)  
+[1.5.0](#1.5.0) - 2023-12-23 - January 2024 Data Collection [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.5.0)  
+[1.4.0](#1.4.0) - 2022-04-11 - Filtering, Data Import/Export [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.4.0)  
+[1.3.1](#1.3.1) - 2020-09-21 - Network Optimization [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.3.1)  
+[1.3.0](#1.3.0) - 2020-08-26 - Multiple Instances, Filtering [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.3.0)  
+[1.2.1](#1.2.1) - 2020-06-05 - [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.2.1)  
+[1.2.0](#1.2.0) - 2019-05-02  - ns.js script [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.2.0)  
+[1.1.0](#1.1.0) - 2019-02-12 - Tacitus Study [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.1.0)  
+[1.0.1](#1.0.1) - 2018-10-02 - Oct 2018 Study Day 2: Alexander [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.0.1)  
+[1.0.0](#1.0.0) - 2018-09-30 - Oct 2018 Study: Alexander [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/1.0.0)  
+[0.1.0](#0.1.0) - 2018-08-28 - Proof of Concept Prototype [tag](https://github.com/netcreateorg/netcreate-itest/releases/tag/0.1.0)  
 
----
-# [Unreleased] <a name="unreleased"></a>
+-------------------------------------------------------------------------------
+# Unreleased <a name="unreleased"></a>
 
-Candidate version 1.6.0 "Commenting"
-To be released April 2024
+Candidate version 2.0 "Commenting"
+To be released May 2024
 
-v1.6.0 introduces "commenting".  Database/file data format has changed significantly with 1.5.x so pre-1.4.x data (*.loki) and template (*.json) files are no longer compatible.
+v2.0.0 introduces "commenting".  Database/file data format has changed significantly with 1.5.x so pre-1.4.x data (*.loki) and template (*.json) files are no longer compatible.
 
-### Breaking Changes
+**Breaking Changes**
 - Pre-Version 1.5.x project files are no longer compatible.
   - Comments have been added to the database #133
   - `created`, `updated`, `revision` meta fields are now consistently used #129
+- Add Template Versioning
+  - Templates now have a version designation.
+  - The version should match the github Release version. Hopefully this will be less confusing than having separate version numbers. The one caveat is that it's harder to track interim development/alpha versions prior to a release.
+  - When opening projects, the template version (or lack of a template version) will allow the system to decide how to migrate or ignore data fields. e.g. previously built-in fields like comments will continue to be displayed and will not break in table views.
 
-### Significant Features
+**Significant Features**
 - Add Comment System  #133 -- including support for:
 	- floating draggable comment windows
 	- displays of comment counts
 	- two levels of comment replies
 	- comment templates
+  - comment prompt types for comment templates: text, dropdown, checkbox, radio, likert, discrete-slider #201
 	- displaying "read" status on a per-user basis
 	- editing, deletion
+	- deleting comments now will prune any orphaned comments marked for deletion #156
 	- confirmation dialog when canceling or editing an unsaved comment
 	- working with comments directly in tables
+	- comments that have been added or updated now broadcast alerts to other users on the network #157
+	- "Unread" and "Unread replies to me" are now displayed both as summary statistics in a "Unread Comment Panel" that lists all unread comments. In addition, comments (as well as source nodes/edge) can be opened directly from the panel #157
+	- during comment edit, node and edge selection from the graph and NodeTable and EdgeTable are disabled
+- The Provenance tab has been reformatted to show two sections: "PROVENANCE" and "HISTORY".
+  - Any fields that are designated isProvenance will be added to the "PROVENANCE" tab.
+  - Added a createdBy and updatedBy built-in fields 6fc8dee
 - Module Infrastructure -- #132 #134 #138
 
-### Changes (Minor)
+**Changes (Minor)**
 - AutoSuggest now has a placeholder text and scrolls #123
 - `Provenance` is now displayed in Node and Edge Tables #129
+- Added more research logging with consistent column format:
+  - Node and Edge "edit", "save", "cancel" events
+  - Info Panel tab selection (Graph, Node Table, Edge Table, More) 
+  - Selecting and clearing filters
 
-### Fixed
+**Fixed**
 - The focus filter for Edge Tables are now properly refreshed after switching to an Edge Table view #129
 - `Provenance` fields can be edited again #129
 - Importing exported csv files into Windows Excel no longer chokes on blank lines #137
 
-### Developer Improvements
+**Developer Improvements**
 - Adds support for `addons` for the core URSYS library #132
 - Adds a testing framework and V2 state manager #134
 - Rewrite URNET messaging system for the following communication interfaces: Unix Domain Sockets, WebSocketServer, and Browser WebSockets. #138
@@ -60,23 +74,22 @@ v1.6.0 introduces "commenting".  Database/file data format has changed significa
 ### Removed
 ### Security
 
-----
-# [1.5.1] -- January 2024 Data Collection<a name="1.5.1"></a>
+-------------------------------------------------------------------------------
+# 1.5.1 - January 2024 Data Collection<a name="1.5.1"></a>
 Released 2024 Jan 8 -- *for January 11, 2024 Data Collection*
-### Added
+
+#### Added
 * Numeric input fields default to 0 rather than blank
 
-----
-# [1.5.0] -- January 2024 Data Collection<a name="1.5.0"></a>
+-------------------------------------------------------------------------------
+# 1.5.0 - January 2024 Data Collection<a name="1.5.0"></a>
 Released 2023 Dec 23 -- *for January 11, 2024 Data Collection*
 
-### Significant Features
-
-v1.5.0 introduces a two new significant features:
+#### Significant Features
 * A **new UI** for **Node** and **Edge** editing that splits out "ATTRIBUTES", "EDGES", and "PROVENANCE" into separate tabs. #39
 * Custom Node and Edge fields can now be added via templates (prior to this you could only rename an existing field). #39
 
-### Minor Features
+#### Minor Features
 * A "Focus" filter can highlight a selected node and a customizable range of connected nodes. [#275](https://github.com/netcreateorg/netcreate-2018/pull/275)
 * Filters will now show statistics of how many nodes and edges are currently being filtered. #95
 * Filters now support using `&&` and `||` in search strings. #105
@@ -84,7 +97,7 @@ v1.5.0 introduces a two new significant features:
 * Markdown now supports images (with scaling) and emoticons for Nodes, Edges, and tables. #91
 * Research logs now follow a consistent column format so that exports can be more easily compared. #112
 
-### Developer Improvements
+#### Developer Improvements
 * Required node version updated to `v18.18.2` (was v18.16.0 and v10.22.0) #89, #2, #1
 * `npm` version detection now shows errors and instructions for handling Apple Silicon (ARM) processors #1
 * Prettier linting is now fixed and enabled, so code format consistency is maintained. #7
@@ -92,18 +105,18 @@ v1.5.0 introduces a two new significant features:
 
 And many other infrastructure and minor fixes.
 
-### Caveats
+#### Caveats
 * **Template Editor not fully functional** -- With the introduction of custom attribute fields, the JSON-Editor functionality is broken. You can still use the Template Editor to change templates for projects that use the default fields, but any project that has custom fields (e.g. fields that have **NOT** been defined in `template-schema.js`) will corrupt your template.  See #115.
 
----
-# [1.4.0]<a name="1.4.0"></a>
+-------------------------------------------------------------------------------
+# 1.4.0 - Filtering, Data Import/Export<a name="1.4.0"></a>
 Released 2022 Apr 18
 
 Version 1.4.0 release focuses on improvements in filtering, data import and export.
 
 The Net.Create database/file data format has changed significantly with 1.4.0 so pre-1.4.0  data (`*.loki`) and template (`*.json`) files are no longer compatible.
 
-### Key Features
+#### Key Features
 See the [wiki](../../wiki) and pull requests for details:
 
 * #169 Filters
@@ -153,8 +166,8 @@ See [Using Templates](../../wiki/Using-Templates) for more information.
 #### Misc Changes
 See also commits by JDanish dated between Oct and Dec 2020 for miscellaneous changes.
 
----
-# [1.3.1]<a name="1.3.1"></a>
+-------------------------------------------------------------------------------
+# 1.3.1 - Network Optimization<a name="1.3.1"></a>
 Released 2020 Sep 17
 
 Version 1.3.1 release focuses on performance optimizations, especially around network  #129
@@ -195,8 +208,8 @@ This isn't a perfect solution but perhaps it'll give us a little more informatio
 * Properly unmount NodeTable and EdgeTable db864d645515e632a196f07a37750493b5ffd9df
 
 
----
-# [1.3.0]<a name="1.3.0"></a>
+-------------------------------------------------------------------------------
+# 1.3.0 - Multiple Instances, Filtering<a name="1.3.0"></a>
 Released 2020 Aug 25
 
 Version 1.3.0 introduces two main sets of features:
@@ -289,8 +302,8 @@ A new filters panel allows users to show or hide nodes and edges based on specif
 
 * Misc bug fixes.
 
----
-# [1.2.1]<a name="1.2.1"></a>
+-------------------------------------------------------------------------------
+# 1.2.1<a name="1.2.1"></a>
 Released 2020 May 27
 
 Tagged prior to NetCreate extension work for version 1.3.0.
@@ -316,8 +329,8 @@ Tagged prior to NetCreate extension work for version 1.3.0.
   *  added tooltips to the graph title in the main graph area
   *  moved tooltip css out of the index file to a separate tooltip,css
 
----
-# [1.2.0]<a name="1.2.0"></a>
+-------------------------------------------------------------------------------
+# 1.2.0 - ns.js script<a name="1.2.0"></a>
 Released 2019 May 2
 (changes were implemented 3/12/2019)
 
@@ -334,8 +347,8 @@ Released prior to transfer of repository to `netcreateorg`.
 
 * Allow edit target when source and target share the same parent node. -- #71 -- When the source and target nodes both point to the parent node, they could not be edited.  The fix was to allow editing only of the target node.  This addresses issues #68  and #70.
 
----
-# [1.1.0] -- Tacitus Study<a name="1.1.0"></a>
+-------------------------------------------------------------------------------
+# 1.1.0 - Tacitus Study<a name="1.1.0"></a>
 Released 2019 Feb 3 -- *for the February 4, 2019 study with Tacitus*
 
 ### New Features:
@@ -363,8 +376,8 @@ Released 2019 Feb 3 -- *for the February 4, 2019 study with Tacitus*
 * Node and Edge IDs now better enforce integer type IDs. -- #51
 * Many errors, weird conditions, and bugs stemming from network edit activity -- #46, #58, #62
 
----
-# [1.0.1] -- Oct 2018 Study Day 2: Alexander<a name="1.0.1"></a>
+-------------------------------------------------------------------------------
+# 1.0.1 - Oct 2018 Study Day 2: Alexander<a name="1.0.1"></a>
 Released 2018 Oct 2 -- *for the second day (Oct 3) of the October 1, 2018 study with Ptolemy's Alexander the Great*
 
 ### New Features:
@@ -386,8 +399,8 @@ Released 2018 Oct 2 -- *for the second day (Oct 3) of the October 1, 2018 study 
 
 * Group ID information has now been restored in the research logs.
 
----
-# [1.0.0] -- Oct 2018 Study: Alexander<a name="1.0.0"></a>
+-------------------------------------------------------------------------------
+# 1.0.0 - Oct 2018 Study: Alexander<a name="1.0.0"></a>
 Released 2018 Sep 30 -- *for the October 1, 2018 study with Ptolemy's Alexander the Great.*
 
 ### New Features:
@@ -408,8 +421,8 @@ Released 2018 Sep 30 -- *for the October 1, 2018 study with Ptolemy's Alexander 
 
 * **Node Edit Locking** -- Nodes are not yet locked out when someone is editing them.  If two people edit a node at the same time, their changes will clobber each other.
 
----
-# [0.1.0] -- Proof of Concept Prototype<a name="0.1.0"></a>
+-------------------------------------------------------------------------------
+# 0.1.0 - Proof of Concept Prototype<a name="0.1.0"></a>
 Released 2018 Sep 30.
 First major release of the tool for internal testing.
 

--- a/_ur_addons/comment/dc-comment.ts
+++ b/_ur_addons/comment/dc-comment.ts
@@ -569,7 +569,7 @@ function RemoveComment(parms): TCommentQueueActions[] {
   } else if (markDeleted) {
     // MARK TARGET DELETED
     if (DBG) console.log('markDeleted', cidToDelete);
-    cobjToDelete.comment_type = DEFAULT_CommentTypes[0].id; // revert to default comment type
+    cobjToDelete.comment_type = DEFAULT_CommentTypes[0].slug; // revert to default comment type
     cobjToDelete.comment_isMarkedDeleted = true;
     COMMENTS.set(cobjToDelete.comment_id, cobjToDelete);
     queuedActions.push({ comment: cobjToDelete });

--- a/app-templates/_default.template.toml
+++ b/app-templates/_default.template.toml
@@ -22,6 +22,7 @@ nodeDefaultTransparency = 1
 edgeDefaultTransparency = 0.7
 searchColor = "#008800"
 sourceColor = "#FFa500"
+version = 2
 
 [citation]
 text = "No citation set"
@@ -33,6 +34,7 @@ displayLabel = "Id"
 exportLabel = "ID"
 help = "System-generated unique id number"
 includeInGraphTooltip = true
+isProvenance = false
 hidden = false
 
 [nodeDefs.label]
@@ -41,6 +43,7 @@ displayLabel = "label"
 exportLabel = "Label"
 help = "Display name of the node"
 includeInGraphTooltip = true
+isProvenance = false
 hidden = false
 
 [nodeDefs.type]
@@ -49,6 +52,7 @@ displayLabel = "Type"
 exportLabel = "NodeType"
 help = "Select a category"
 includeInGraphTooltip = true
+isProvenance = false
 hidden = false
 
   [[nodeDefs.type.options]]
@@ -61,6 +65,7 @@ displayLabel = "Notes"
 exportLabel = "Notes"
 help = "General purpose notes text field"
 includeInGraphTooltip = true
+isProvenance = false
 hidden = false
 
 [nodeDefs.info]
@@ -69,22 +74,16 @@ displayLabel = "Number"
 exportLabel = "Info"
 help = "Some number comparison"
 includeInGraphTooltip = true
+isProvenance = false
 hidden = false
 
-[nodeDefs.provenance]
+[nodeDefs.infoSource]
 type = "string"
-displayLabel = "Provenance"
-exportLabel = "Provenance"
-help = "Who created this?  (aka Provenance)"
+displayLabel = "Info Source"
+exportLabel = "InfoSource"
+help = "Who created this?  (aka Source)"
 includeInGraphTooltip = true
-hidden = false
-
-[nodeDefs.comments]
-type = "string"
-displayLabel = "Comments"
-exportLabel = "Comments"
-help = 'Enter "<comment> -- <name> <date>"'
-includeInGraphTooltip = true
+isProvenance = true
 hidden = false
 
 [nodeDefs.degrees]
@@ -93,27 +92,47 @@ displayLabel = "Degrees"
 exportLabel = "Degrees"
 help = "Number of edges connected to this node"
 includeInGraphTooltip = true
+isProvenance = false
 hidden = false
 
 [nodeDefs.created]
 displayLabel = "Created"
 exportLabel = "Created"
-includeInGraphTooltip = true
 help = "Date and time node was created"
+includeInGraphTooltip = true
+isProvenance = false
+hidden = false
+
+[nodeDefs.createdBy]
+displayLabel = "Created By"
+help = "Author who created the node"
+exportLabel = "Created By"
+includeInGraphTooltip = true
+isProvenance = false
 hidden = false
 
 [nodeDefs.updated]
 displayLabel = "Updated"
 exportLabel = "Updated"
-includeInGraphTooltip = true
 help = "Date and time node was last modified"
+includeInGraphTooltip = true
+isProvenance = false
+hidden = false
+
+[nodeDefs.updatedBy]
+displayLabel = "Updated By"
+exportLabel = "Updated By"
+help = "Author who updated the node"
+includeInGraphTooltip = true
+isProvenance = false
 hidden = false
 
 [nodeDefs.revision]
 displayLabel = "Revision"
 exportLabel = "Revision"
-includeInGraphTooltip = true
 help = "Number of times this node has been revised"
+includeInGraphTooltip = true
+isProvenance = false
 hidden = true
 
 [edgeDefs.id]
@@ -121,6 +140,7 @@ type = "number"
 displayLabel = "Id"
 exportLabel = "ID"
 help = "System-generated unique id number"
+isProvenance = false
 hidden = false
 
 [edgeDefs.source]
@@ -128,6 +148,7 @@ type = "number"
 displayLabel = "Source"
 exportLabel = "Source"
 help = "Edge source node"
+isProvenance = false
 hidden = false
 
 [edgeDefs.target]
@@ -142,6 +163,7 @@ type = "select"
 displayLabel = "Type"
 exportLabel = "EdgeType"
 help = "Type of edge connection"
+isProvenance = false
 hidden = false
 
   [[edgeDefs.type.options]]
@@ -153,6 +175,7 @@ type = "string"
 displayLabel = "Notes"
 exportLabel = "Notes"
 help = "Significance of the connection"
+isProvenance = false
 hidden = false
 
 [edgeDefs.info]
@@ -160,6 +183,7 @@ type = "number"
 displayLabel = "Date"
 exportLabel = "Date"
 help = '"YYYY-MM-DD" format"'
+isProvenance = false
 hidden = false
 
 [edgeDefs.weight]
@@ -170,21 +194,16 @@ exportLabel = "Weight"
 help = "Weight of edge"
 includeInGraphTooltip = true
 isRequired = true
+isProvenance = false
 hidden = false
 
-[edgeDefs.provenance]
+[edgeDefs.infoSource]
 type = "string"
-displayLabel = "Provenance"
-exportLabel = "Provenance"
-help = "Who created this?  (aka Provenance)"
-hidden = false
-
-[edgeDefs.comments]
-type = "string"
-displayLabel = "Comments"
-exportLabel = "Comments"
-help = 'Enter "<comment> -- <name> <date>"'
+displayLabel = "Info Source"
+exportLabel = "InfoSource"
+help = "Who created this?  (aka Source)"
 includeInGraphTooltip = true
+isProvenance = true
 hidden = false
 
 [edgeDefs.citation]
@@ -192,6 +211,7 @@ type = "string"
 displayLabel = "Citation"
 exportLabel = "Citation"
 help = 'Source Book.Chapter (e.g. "Part 2 06.03")'
+isProvenance = false
 hidden = false
 
 [edgeDefs.category]
@@ -199,6 +219,7 @@ type = "string"
 displayLabel = "Category"
 exportLabel = "Category"
 help = "Category (deprecated)"
+isProvenance = false
 hidden = true
 
 [edgeDefs.created]
@@ -206,6 +227,15 @@ displayLabel = "Created"
 exportLabel = "Created"
 includeInGraphTooltip = true
 help = "Date and time edge was created"
+isProvenance = false
+hidden = false
+
+[edgeDefs.createdBy]
+displayLabel = "Created By"
+exportLabel = "Created By"
+includeInGraphTooltip = true
+help = "Author who created the edge"
+isProvenance = true
 hidden = false
 
 [edgeDefs.updated]
@@ -213,6 +243,15 @@ displayLabel = "Updated"
 exportLabel = "Updated"
 includeInGraphTooltip = true
 help = "Date and time edge was last modified"
+isProvenance = false
+hidden = false
+
+[edgeDefs.updatedBy]
+displayLabel = "Updated By"
+exportLabel = "Updated By"
+includeInGraphTooltip = true
+help = "Author who updated the nodedgee"
+isProvenance = true
 hidden = false
 
 [edgeDefs.revision]
@@ -220,4 +259,5 @@ displayLabel = "Revision"
 exportLabel = "Revision"
 includeInGraphTooltip = true
 help = "Number of times this edge has been revised"
+isProvenance = false
 hidden = true

--- a/app/system/util/enum.js
+++ b/app/system/util/enum.js
@@ -30,6 +30,7 @@ ENUM.BUILTIN_FIELDS_EDGE = [
   'id',
   'source',
   'target',
+  'weight',
   'degrees',
   'created',
   'createdBy',

--- a/app/system/util/enum.js
+++ b/app/system/util/enum.js
@@ -19,20 +19,22 @@ ENUM.EDITORTYPE = {
 ENUM.BUILTIN_FIELDS_NODE = [
   'id',
   'label',
-  'provenance',
   'degrees',
   'created',
+  'createdBy',
   'updated',
+  'updatedBy',
   'revision'
 ];
 ENUM.BUILTIN_FIELDS_EDGE = [
   'id',
   'source',
   'target',
-  'provenance',
   'degrees',
   'created',
+  'createdBy',
   'updated',
+  'updatedBy',
   'revision',
   'sourceLabel', // used internally for filters
   'targetLabel' // used internally for filters

--- a/app/unisys/common-session.js
+++ b/app/unisys/common-session.js
@@ -31,17 +31,18 @@ var m_current_groupid = null;
     complete decode succes. groupId is also set if successful
  */
 SESUTIL.DecodeToken = function (token, dataset) {
+  const DELIMITER = '-';
   if (token === undefined) return {};
   if (dataset === undefined) {
     console.error('SESUTIL.DecodeToken called without "dataset" parameter.');
     return {};
   }
-  let tokenBits = token.split('-');
+  let tokenBits = token.split(DELIMITER);
   let classId, projId, hashedId, groupId, subId, isValid;
   // optimistically set valid flag to be negated on failure
   isValid = true;
   // check for superficial issues
-  if (token.substr(-1) === '-') {
+  if (token.substr(-1) === DELIMITER) {
     isValid = false;
   }
   // token is of form CLS-PRJ-HASHEDID
@@ -90,8 +91,10 @@ SESUTIL.DecodeToken = function (token, dataset) {
     }
   }
 
+  // reconstruct user id for use with author data for nodes, edges, comments
+  const userId = [classId, projId, hashedId].join(DELIMITER);
   // if isValid is false, check groupId is 0 or subId is 0, indicating error
-  let decoded = { token, isValid, classId, projId, hashedId, groupId, subId };
+  let decoded = { token, isValid, classId, projId, hashedId, groupId, subId, userId };
   return decoded;
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/unisys/server-database.js
+++ b/app/unisys/server-database.js
@@ -416,20 +416,20 @@ function m_LoadTOMLTemplate(templateFilePath) {
 
       const DEFAULT_TEMPLATE = TEMPLATE_SCHEMA.ParseTemplateSchema();
       const NODEDEFS = DEFAULT_TEMPLATE.nodeDefs;
-      if (json.nodeDefs.provenance === undefined) {
+      if (json.nodeDefs.provenance === undefined && NODEDEFS.provenance) {
         json.nodeDefs.provenance = NODEDEFS.provenance;
         json.nodeDefs.provenance.hidden = true;
       }
-      if (json.nodeDefs.comments === undefined) {
+      if (json.nodeDefs.comments === undefined && NODEDEFS.coments) {
         json.nodeDefs.comments = NODEDEFS.comments;
         json.nodeDefs.comments.hidden = true;
       }
       const EDGEDEFS = DEFAULT_TEMPLATE.edgeDefs;
-      if (json.edgeDefs.provenance === undefined) {
+      if (json.edgeDefs.provenance === undefined && EDGEDEFS.provenance) {
         json.edgeDefs.provenance = EDGEDEFS.provenance;
         json.edgeDefs.provenance.hidden = true;
       }
-      if (json.edgeDefs.comments === undefined) {
+      if (json.edgeDefs.comments === undefined && EDGEDEFS.comments) {
         json.edgeDefs.comments = EDGEDEFS.comments;
         json.edgeDefs.comments.hidden = true;
       }

--- a/app/view/netcreate/comment-mgr.js
+++ b/app/view/netcreate/comment-mgr.js
@@ -14,6 +14,7 @@ const { COMMENT } = require('@ursys/addons');
 const DATASTORE = require('system/datastore');
 const { ARROW_RIGHT } = require('system/util/constant');
 const { EDITORTYPE } = require('system/util/enum');
+const NCLOGIC = require('./nc-logic');
 const NCUI = require('./nc-ui');
 const NCDialog = require('./components/NCDialog');
 const SETTINGS = require('settings');
@@ -226,9 +227,7 @@ MOD.OpenComment = (cref, cid) => {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// User Id
 MOD.GetCurrentUserId = () => {
-  const session = UDATA.AppState('SESSION');
-  const uid = String(session.token).toLowerCase();
-  return uid;
+  return NCLOGIC.GetCurrentUserId();
 };
 MOD.GetUserName = uid => {
   return COMMENT.GetUserName(uid);

--- a/app/view/netcreate/comment-mgr.js
+++ b/app/view/netcreate/comment-mgr.js
@@ -14,7 +14,6 @@ const { COMMENT } = require('@ursys/addons');
 const DATASTORE = require('system/datastore');
 const { ARROW_RIGHT } = require('system/util/constant');
 const { EDITORTYPE } = require('system/util/enum');
-const NCLOGIC = require('./nc-logic');
 const NCUI = require('./nc-ui');
 const NCDialog = require('./components/NCDialog');
 const SETTINGS = require('settings');
@@ -29,6 +28,8 @@ const PR = 'comment-mgr: ';
 let MOD = UNISYS.NewModule(module.id);
 let UDATA = UNISYS.NewDataLink(MOD);
 const dialogContainerId = 'dialog-container'; // used to inject dialogs into NetCreate.jsx
+
+let UID; // user id, cached.  nc-logic updates this on INITIALIZE and SESSION
 
 /// UNISYS LIFECYCLE HOOKS ////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -226,9 +227,8 @@ MOD.OpenComment = (cref, cid) => {
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// User Id
-MOD.GetCurrentUserId = () => {
-  return NCLOGIC.GetCurrentUserId();
-};
+MOD.SetCurrentUserId = uid => UID = uid;
+MOD.GetCurrentUserId = () => UID; // called by other comment classes
 MOD.GetUserName = uid => {
   return COMMENT.GetUserName(uid);
 };

--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -696,16 +696,6 @@ class EdgeTable extends UNISYS.Component {
                   </Button>
                 </th>
               ))}
-              <th width="10%" hidden={edgeDefs.provenance.hidden}>
-                <Button
-                  size="sm"
-                  onClick={() =>
-                    this.setSortKey('provenance', edgeDefs.provenance.type)
-                  }
-                >
-                  {edgeDefs.provenance.displayLabel} {this.sortSymbol('provenance')}
-                </Button>
-              </th>
               <th style={{ zIndex: 1 }}>
                 <div
                   className="comment-icon-inline comment-intable"
@@ -809,7 +799,6 @@ class EdgeTable extends UNISYS.Component {
                       : edge[a]}
                   </td>
                 ))}
-                <td hidden={edgeDefs.provenance.hidden}>{edge.provenance}</td>
                 <td>
                   <NCCommentBtn cref={CMTMGR.GetEdgeCREF(edge.id)} isTable />
                 </td>

--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -415,7 +415,7 @@ class EdgeTable extends UNISYS.Component {
    */
   sortByComment(edges) {
     // stuff the count into edges for calculation
-    const uid = CMTMGR.GetCurrentUserId();
+    const uid = NCLOGIC.GetCurrentUserId();
     const countededges = edges.map(e => {
       const cref = CMTMGR.GetEdgeCREF(e.id);
       e.commentcount = CMTMGR.GetThreadedViewObjectsCount(cref, uid);

--- a/app/view/netcreate/components/NCCommentBtn.jsx
+++ b/app/view/netcreate/components/NCCommentBtn.jsx
@@ -191,11 +191,10 @@ class NCCommentBtn extends React.Component {
     const { isDisabled } = this.state;
     // disable open toggle if comment is being edited
     if (!isDisabled) {
-    const updatedIsOpen = !this.state.isOpen;
-    this.UIOpenComment(updatedIsOpen);
+      const updatedIsOpen = !this.state.isOpen;
+      this.UIOpenComment(updatedIsOpen);
+    }
   }
-  }
-
 
   UIOnResize(event) {
     const position = this.GetCommentThreadPosition();

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -113,6 +113,7 @@ class NCEdge extends UNISYS.Component {
     this.UIDisableEditMode = this.UIDisableEditMode.bind(this);
     this.UIDeleteEdge = this.UIDeleteEdge.bind(this);
     this.UIInputUpdate = this.UIInputUpdate.bind(this);
+    this.UIProvenanceInputUpdate = this.UIProvenanceInputUpdate.bind(this);
     this.UIEnableSourceTargetSelect = this.UIEnableSourceTargetSelect.bind(this);
     this.UISourceTargetInputUpdate = this.UISourceTargetInputUpdate.bind(this);
     this.UISourceTargetInputSelect = this.UISourceTargetInputSelect.bind(this);
@@ -330,7 +331,9 @@ class NCEdge extends UNISYS.Component {
         attributes: attributes,
         provenance: provenance,
         created: edge.meta ? new Date(edge.meta.created).toLocaleString() : '',
+        createdBy: edge.createdBy,
         updated: edge.meta ? new Date(edge.meta.updated).toLocaleString() : '',
+        updatedBy: edge.updatedBy,
         revision: edge.meta ? edge.meta.revision : ''
       },
       () => this.UpdateDerivedValues()
@@ -628,7 +631,8 @@ class NCEdge extends UNISYS.Component {
     const edge = {
       id,
       source: sourceId,
-      target: targetId
+      target: targetId,
+      updatedBy: uid
     };
     Object.keys(attributes).forEach(k => (edge[k] = attributes[k]));
     Object.keys(provenance).forEach(k => (edge[k] = provenance[k]));
@@ -822,6 +826,17 @@ class NCEdge extends UNISYS.Component {
       const { attributes } = this.state;
       attributes[key] = value;
       this.setState({ attributes }, () => this.SetBackgroundColor());
+    }
+  }
+  UIProvenanceInputUpdate(key, value) {
+    if (BUILTIN_FIELDS_EDGE.includes(key)) {
+      const data = {};
+      data[key] = value;
+      this.setState(data);
+    } else {
+      const { provenance } = this.state;
+      provenance[key] = value;
+      this.setState({ provenance }, () => this.SetBackgroundColor());
     }
   }
 
@@ -1048,7 +1063,11 @@ class NCEdge extends UNISYS.Component {
                 {uSelectedTab === TABS.ATTRIBUTES &&
                   NCUI.RenderAttributesTabEdit(this.state, defs, this.UIInputUpdate)}
                 {uSelectedTab === TABS.PROVENANCE &&
-                  NCUI.RenderProvenanceTabEdit(this.state, defs, this.UIInputUpdate)}
+                  NCUI.RenderProvenanceTabEdit(
+                    this.state,
+                    defs,
+                    this.UIProvenanceInputUpdate
+                  )}
               </div>
             </div>
             {/* CONTROL BAR - - - - - - - - - - - - - - - - */}

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -33,6 +33,7 @@ const {
 } = require('system/util/constant');
 const NCUI = require('../nc-ui');
 const CMTMGR = require('../comment-mgr');
+const NCLOGIC = require('../nc-logic');
 const NCAutoSuggest = require('./NCAutoSuggest');
 const NCDialog = require('./NCDialog');
 const NCCommentBtn = require('./NCCommentBtn');
@@ -623,7 +624,7 @@ class NCEdge extends UNISYS.Component {
   ///
   SaveEdge() {
     const { id, sourceId, targetId, attributes, provenance } = this.state;
-
+    const uid = NCLOGIC.GetCurrentUserId();
     const edge = {
       id,
       source: sourceId,

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -251,6 +251,19 @@
   padding: 10px 5px 5px 5px;
   background-color: #fff8;
 }
+.nccomponent .provenance .category {
+  grid-column: span 2;
+  margin-top: 2em;
+  padding: 1em 0 0.5em 10px;
+  text-align: center;
+  border-top: 1px solid #0003;
+  /* text-decoration: underline; */
+}
+.nccomponent .provenance .category:nth-child(1) {
+  margin-top: 0;
+  padding-top: 0;
+  border: none;
+}
 .nccomponent .provenance label {
   line-height: 12px;
   margin-bottom: 0.25rem; /* override bootstrap */

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -952,7 +952,7 @@ class NCNode extends UNISYS.Component {
           const color = EDGEMGR.LookupEdgeColor(e, TEMPLATE);
           const bgcolor = color + '33'; // opacity hack
           if (e.id === selectedEdgeId) {
-            return <NCEdge key={e.id} edge={e} parentNodeId={id} />;
+            return <NCEdge edgeId={e.id} parentNodeId={id} key={e.id} />;
           } else {
             return (
               <div key={e.id}>

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -360,7 +360,7 @@ class NCNode extends UNISYS.Component {
         provenance: provenance,
         created: node.meta ? new Date(node.meta.created).toLocaleString() : '',
         createdBy: node.createdBy,
-        updated: node.meta ? new Date(node.meta.created).toLocaleString() : '',
+        updated: node.meta ? new Date(node.meta.updated).toLocaleString() : '',
         updatedBy: node.updatedBy,
         revision: node.meta ? node.meta.revision : ''
       },

--- a/app/view/netcreate/components/NodeTable.jsx
+++ b/app/view/netcreate/components/NodeTable.jsx
@@ -397,7 +397,7 @@ class NodeTable extends UNISYS.Component {
    */
   sortByComment(nodes) {
     // stuff the count into nodes for calculation
-    const uid = CMTMGR.GetCurrentUserId();
+    const uid = NCLOGIC.GetCurrentUserId();
     const countednodes = nodes.map(n => {
       const cref = CMTMGR.GetNodeCREF(n.id);
       n.commentcount = CMTMGR.GetThreadedViewObjectsCount(cref, uid);

--- a/app/view/netcreate/components/NodeTable.jsx
+++ b/app/view/netcreate/components/NodeTable.jsx
@@ -603,16 +603,6 @@ class NodeTable extends UNISYS.Component {
                   </Button>
                 </th>
               ))}
-              <th width="10%" hidden={nodeDefs.provenance.hidden}>
-                <Button
-                  size="sm"
-                  onClick={() =>
-                    this.setSortKey('provenance', nodeDefs.provenance.type)
-                  }
-                >
-                  {nodeDefs.provenance.displayLabel} {this.sortSymbol('provenance')}
-                </Button>
-              </th>
               <th style={{ zIndex: 1 }}>
                 <div
                   className="comment-icon-inline comment-intable"
@@ -687,7 +677,6 @@ class NodeTable extends UNISYS.Component {
                       : node[a]}
                   </td>
                 ))}
-                <td hidden={nodeDefs.provenance.hidden}>{node.provenance}</td>
                 <td>
                   <NCCommentBtn cref={CMTMGR.GetNodeCREF(node.id)} isTable />
                 </td>

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -510,10 +510,12 @@ MOD.Hook('INITIALIZE', () => {
     const session = UDATA.AppState('SESSION');
     const timestamp = new Date().toLocaleString('en-US');
     const provenance = `Added by ${session.token} on ${timestamp}`;
+    const createdBy = MOD.GetCurrentUserId();
+    const updatedBy = createdBy;
 
     return DATASTORE.PromiseNewNodeID().then(newNodeID => {
       const node = {
-        id: newNodeID, label: data.label, provenance
+        id: newNodeID, label: data.label, provenance, createdBy, updatedBy
       };
       return UDATA.LocalCall('DB_UPDATE', { node }).then(() => {
         NCDATA.nodes.push(node);

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -846,6 +846,18 @@ MOD.Hook('APP_READY', function (info) {
   });
 }); // end UNISYS_READY
 
+/// GLOBAL HELPERS ////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+MOD.GetCurrentUserId = () => {
+  const session = UDATA.AppState('SESSION');
+  console.log('session', session)
+  // match upper case conversion of login form -- this is necessary because
+  // the token can be defined via the URL, which might be lower case
+  const uid = String(session.token).toUpperCase();
+  return uid;
+};
+
 /// OBJECT HELPERS ////////////////////////////////////////////////////////////
 /// these probably should go into a utility class
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -515,7 +515,7 @@ MOD.Hook('INITIALIZE', () => {
     // provenance
     const session = UDATA.AppState('SESSION');
     const timestamp = new Date().toLocaleString('en-US');
-    const provenance = `Added by ${session.token} on ${timestamp}`;
+    const provenance = [];
     const createdBy = MOD.GetCurrentUserId();
     const updatedBy = createdBy;
 
@@ -644,7 +644,9 @@ MOD.Hook('INITIALIZE', () => {
     // provenance
     const session = UDATA.AppState('SESSION');
     const timestamp = new Date().toLocaleString('en-US');
-    const provenance = `Added by ${session.token} on ${timestamp}`;
+    const provenance = [];
+    const createdBy = MOD.GetCurrentUserId();
+    const updatedBy = createdBy;
 
     // call server to retrieve an unused edge ID
     return DATASTORE.PromiseNewEdgeID().then(newEdgeID => {
@@ -654,7 +656,9 @@ MOD.Hook('INITIALIZE', () => {
         source: data.nodeId,
         target: undefined,
         attributes: {},
-        provenance
+        provenance,
+        createdBy,
+        updatedBy
       };
       return UDATA.LocalCall('DB_UPDATE', { edge }).then(() => {
         console.log('...DB_UPDATE node is now', edge);

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -292,6 +292,12 @@ MOD.Hook('DISCONNECT', () => {
  */
 MOD.Hook('INITIALIZE', () => {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
+  UDATA.OnAppStateChange('SESSION', session => {
+    const { userId } = session;
+    // Push updates to sub modules
+    CMTMGR.SetCurrentUserId(userId);
+  });
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - inside hook
   /** RELOAD_DB
    *  Called by importexport-mgr.js.MOD.Import:818
    *  During import, DB_MERGE will be called to merge the import data
@@ -852,12 +858,10 @@ MOD.Hook('APP_READY', function (info) {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 MOD.GetCurrentUserId = () => {
+  // always get the current session value because it might change at any time
   const session = UDATA.AppState('SESSION');
-  console.log('session', session)
-  // match upper case conversion of login form -- this is necessary because
-  // the token can be defined via the URL, which might be lower case
-  const uid = String(session.token).toUpperCase();
-  return uid;
+  const { userId } = session;
+  return userId;
 };
 
 /// OBJECT HELPERS ////////////////////////////////////////////////////////////

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -228,17 +228,66 @@ function RenderAttributesTabEdit(state, defs, onchange) {
   return <div className="formview">{items}</div>;
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function RenderProvenanceItemsView(state, defs) {
+  const { provenance } = state;
+  const items = [];
+  Object.keys(provenance).forEach(k => {
+    items.push(RenderLabel(k, defs[k].displayLabel, defs[k].help));
+    const type = defs[k].type;
+    switch (type) {
+      case 'markdown':
+        items.push(RenderMarkdownValue(k, provenance[k]));
+        break;
+      case 'string':
+      case 'number':
+      default:
+        items.push(RenderStringValue(k, provenance[k]));
+        break;
+    }
+  });
+  return items;
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function RenderProvenanceItemsEdit(state, defs, onchange) {
+  const { provenance, degrees } = state;
+  const items = [];
+  Object.keys(provenance).forEach(k => {
+    items.push(RenderLabel(k, defs[k].displayLabel));
+    const type = defs[k].type;
+    const value = provenance[k] || ''; // catch `undefined` or React will complain about changing from uncontrolled to controlled
+    const helpText = defs[k].help;
+    switch (type) {
+      case 'markdown':
+        items.push(RenderMarkdownInput(k, value, onchange, helpText));
+        break;
+      case 'string':
+        items.push(RenderStringInput(k, value, onchange, helpText));
+        break;
+      case 'number':
+        items.push(m_RenderNumberInput(k, value, onchange, helpText));
+        break;
+      case 'select':
+        items.push(m_RenderOptionsInput(k, value, defs, onchange, helpText));
+        break;
+      default:
+        items.push(RenderStringValue(k, value, onchange)); // display unsupported type
+    }
+  });
+  return items;
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function RenderProvenanceTabView(state, defs) {
-  const { provenance, degrees, created, updated, revision } = state;
+  const { provenance, degrees, created, createdBy, updated, updatedBy, revision } = state;
   // FIXME: These will be dynamically generated with the new Provenance template
   return (
     <div className="provenance formview">
-      {RenderLabel('provenancelabel', defs.provenance.displayLabel)}
-      {RenderStringValue('provenancelabel', provenance)}
+      <div className="category">PROVENANCE</div>
+      {RenderProvenanceItemsView(state, defs)}
+      <div className="category">HISTORY</div>
       {RenderLabel('createdlabel', defs.created.displayLabel)}
-      {RenderStringValue('createdlabel', created)}
+      {RenderStringValue('createdlabel', RenderProvenanceByline(createdBy, created))}
       {RenderLabel('updatedlabel', defs.updated.displayLabel)}
-      {RenderStringValue('updatedlabel', updated)}
+      {RenderStringValue('updatedlabel', RenderProvenanceByline(updatedBy, updated))}
       {RenderLabel('revisionlabel', defs.revision.displayLabel)}
       {RenderStringValue('revisionlabel', revision)}
     </div>
@@ -246,20 +295,25 @@ function RenderProvenanceTabView(state, defs) {
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function RenderProvenanceTabEdit(state, defs, onchange) {
-  const { provenance, degrees, created, updated, revision } = state;
+  const { provenance, degrees, created, createdBy, updated, updatedBy, revision } = state;
   // FIXME: These will be dynamically generated with the new Provenance template
   return (
     <div className="provenance formview">
-      {RenderLabel('provenancelabel', defs.provenance.displayLabel)}
-      {RenderStringInput('provenance', provenance, onchange)}
+      <div className="category">PROVENANCE</div>
+      {RenderProvenanceItemsEdit(state, defs, onchange)}
+      <div className="category">HISTORY</div>
       {RenderLabel('createdlabel', defs.created.displayLabel)}
-      {RenderStringValue('createdlabel', created)}
+      {RenderStringValue('createdlabel', RenderProvenanceByline(createdBy, created))}
       {RenderLabel('updatedlabel', defs.updated.displayLabel)}
-      {RenderStringValue('updatedlabel', updated)}
+      {RenderStringValue('updatedlabel', RenderProvenanceByline(updatedBy, updated))}
       {RenderLabel('revisionlabel', defs.revision.displayLabel)}
       {RenderStringValue('revisionlabel', revision)}
     </div>
   );
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function RenderProvenanceByline(author, date) {
+  return `${author}, ${date}`;
 }
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -313,7 +313,8 @@ function RenderProvenanceTabEdit(state, defs, onchange) {
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function RenderProvenanceByline(author, date) {
-  return `${author}, ${date}`;
+  const by = author ? `${author}` : `(not recorded)`;
+  return `${by}, ${date}`; // leave author blank for older templates
 }
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/view/netcreate/template-schema.js
+++ b/app/view/netcreate/template-schema.js
@@ -138,6 +138,7 @@ MOD.EDGETYPEOPTIONS = {
  */
 MOD.TEMPLATE = {
   title: 'NetCreate Template',
+  version: '3.0 May 2024',
   type: 'object',
   properties: {
     'name': {
@@ -342,6 +343,12 @@ MOD.TEMPLATE = {
               description: 'Show "id" value in tooltip on graph',
               default: true
             },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
+            },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
@@ -382,6 +389,12 @@ MOD.TEMPLATE = {
               description: 'Show "label" value in tooltip on graph',
               default: true
             },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
+            },
             'hidden': {
               type: 'boolean',
               options: { hidden: true }, // not end-user editable, always hidden from Template Editor
@@ -421,6 +434,12 @@ MOD.TEMPLATE = {
               format: 'checkbox',
               description: 'Show "type" value in tooltip on graph',
               default: true
+            },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
             },
             'hidden': {
               type: 'boolean',
@@ -465,6 +484,12 @@ MOD.TEMPLATE = {
               description: 'Show "notes" value in tooltip on graph',
               default: true
             },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
+            },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
@@ -504,6 +529,12 @@ MOD.TEMPLATE = {
               description: 'Show "info" value in tooltip on graph',
               default: true
             },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
+            },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
@@ -512,42 +543,47 @@ MOD.TEMPLATE = {
             }
           }
         },
-        'provenance': {
-          // Provenance/Source
+        'infoSource': {
           type: 'object',
           description: 'Who created the node',
           properties: {
             'type': {
               type: 'string',
-              description: '"provenance" data type',
+              description: '"infoSource" data type',
               default: 'string'
             },
             'displayLabel': {
               type: 'string',
               description: 'Label to use for system display',
-              default: 'Provenance'
+              default: 'Info Source'
             },
             'exportLabel': {
               type: 'string',
               description: 'Label to use for exported csv file field name',
-              default: 'Provenance'
+              default: 'InfoSource'
             },
             'help': {
               type: 'string',
               description: 'Help text to display on the Node Editor form',
-              default: 'Who created this?  (aka Provenance)'
+              default: 'Who created this?  (aka Source)'
             },
             'includeInGraphTooltip': {
               type: 'boolean',
               format: 'checkbox',
-              description: 'Show "provenance" value in tooltip on graph',
+              description: 'Show "infoSource" value in tooltip on graph',
+              default: true
+            },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
               default: true
             },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
               description:
-                'Hides "provenance" from Node Editor, Nodes Table, and exports',
+                'Hides "infoSource" from Node Editor, Nodes Table, and exports',
               default: false
             }
           }
@@ -582,6 +618,12 @@ MOD.TEMPLATE = {
               description: 'Show "degrees" value in tooltip on graph',
               default: true
             },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
+            },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
@@ -607,21 +649,68 @@ MOD.TEMPLATE = {
               description: 'Label to use for exported csv file field name',
               default: 'Created'
             },
+            'help': {
+              type: 'string',
+              description: 'Help text to display on the Node Editor form',
+              default: 'Date and time node was created'
+            },
             'includeInGraphTooltip': {
               type: 'boolean',
               format: 'checkbox',
               description: 'Show "created" value in tooltip on graph',
               default: true
             },
-            'help': {
-              type: 'string',
-              description: 'Help text to display on the Node Editor form',
-              default: 'Date and time node was created'
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
             },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
               description: 'Requires "created" for exports and imports',
+              default: false
+            }
+          }
+        },
+        'createdBy': {
+          // Built-in data DO NOT MODIFY!
+          type: 'object',
+          description:
+            'System-generated date.  This setting used to show/hide tooltip in graph and import/export',
+          properties: {
+            'displayLabel': {
+              type: 'string',
+              description: 'Label to use for system display',
+              default: 'Created By'
+            },
+            'help': {
+              type: 'string',
+              description: 'Help text to display on the Node Editor form',
+              default: 'Author who created the node'
+            },
+            'exportLabel': {
+              type: 'string',
+              description: 'Label to use for exported csv file field name',
+              default: 'Created By'
+            },
+            'includeInGraphTooltip': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show "created by" value in tooltip on graph',
+              default: true
+            },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
+            },
+            'hidden': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Requires "created by" for exports and imports',
               default: false
             }
           }
@@ -642,21 +731,68 @@ MOD.TEMPLATE = {
               description: 'Label to use for exported csv file field name',
               default: 'Updated'
             },
+            'help': {
+              type: 'string',
+              description: 'Help text to display on the Node Editor form',
+              default: 'Date and time node was last modified'
+            },
             'includeInGraphTooltip': {
               type: 'boolean',
               format: 'checkbox',
               description: 'Show "updated" value in tooltip on graph',
               default: true
             },
-            'help': {
-              type: 'string',
-              description: 'Help text to display on the Node Editor form',
-              default: 'Date and time node was last modified'
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
             },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
               description: 'Requires "updated" for exports and imports',
+              default: false
+            }
+          }
+        },
+        'updatedBy': {
+          // Built-in data DO NOT MODIFY!
+          type: 'object',
+          description:
+            'System-generated date.  This setting used to show/hide tooltip in graph and import/export',
+          properties: {
+            'displayLabel': {
+              type: 'string',
+              description: 'Label to use for system display',
+              default: 'Updated By'
+            },
+            'exportLabel': {
+              type: 'string',
+              description: 'Label to use for exported csv file field name',
+              default: 'Updated By'
+            },
+            'help': {
+              type: 'string',
+              description: 'Help text to display on the Node Editor form',
+              default: 'Author who updated the node'
+            },
+            'includeInGraphTooltip': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show "updated by" value in tooltip on graph',
+              default: true
+            },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
+            },
+            'hidden': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Requires "updated by" for exports and imports',
               default: false
             }
           }
@@ -677,16 +813,22 @@ MOD.TEMPLATE = {
               description: 'Label to use for exported csv file field name',
               default: 'Revision'
             },
+            'help': {
+              type: 'string',
+              description: 'Help text to display on the Node Editor form',
+              default: 'Number of times this node has been revised'
+            },
             'includeInGraphTooltip': {
               type: 'boolean',
               format: 'checkbox',
               description: 'Show "revision" value in tooltip on graph',
               default: true
             },
-            'help': {
-              type: 'string',
-              description: 'Help text to display on the Node Editor form',
-              default: 'Number of times this node has been revised'
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
             },
             'hidden': {
               type: 'boolean',
@@ -726,6 +868,12 @@ MOD.TEMPLATE = {
               description: 'Help text to display on the Edge Editor form',
               default: 'System-generated unique id number'
             },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
+            },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
@@ -759,6 +907,12 @@ MOD.TEMPLATE = {
               type: 'string',
               description: 'Help text to display on the Node Editor form',
               default: 'Edge source node'
+            },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
             },
             'hidden': {
               type: 'boolean',
@@ -828,6 +982,12 @@ MOD.TEMPLATE = {
               description: 'Help text to display on the Node Editor form',
               default: 'Type of edge connection'
             },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
+            },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
@@ -865,6 +1025,12 @@ MOD.TEMPLATE = {
               description: 'Help text to display on the Node Editor form',
               default: 'Significance of the connection'
             },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
+            },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
@@ -897,6 +1063,12 @@ MOD.TEMPLATE = {
               type: 'string',
               description: 'Help text to display on the Node Editor form',
               default: '"YYYY-MM-DD" format"'
+            },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
             },
             'hidden': {
               type: 'boolean',
@@ -949,6 +1121,12 @@ MOD.TEMPLATE = {
                 'Make "weight" a required value.  When "true", "weight" will be set to `defaultValue` for all edges if "weight" was not previously defined.  Be sure to define `defaultValue`',
               default: true
             },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
+            },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
@@ -958,41 +1136,51 @@ MOD.TEMPLATE = {
             }
           }
         },
-        'provenance': {
-          // Provenance/Source
+        'infoSource': {
           type: 'object',
-          description: 'Provenance of the edge',
+          description: 'Who created the edge',
           properties: {
             'type': {
               type: 'string',
-              description: '"provenance" data type',
+              description: '"infoSource" data type',
               default: 'string'
             },
             'displayLabel': {
               type: 'string',
               description: 'Label to use for system display',
-              default: 'Provenance'
+              default: 'Info Source'
             },
             'exportLabel': {
               type: 'string',
               description: 'Label to use for exported csv file field name',
-              default: 'Provenance'
+              default: 'InfoSource'
             },
             'help': {
               type: 'string',
               description: 'Help text to display on the Edge Editor form',
-              default: 'Who created this?  (aka Provenance)'
+              default: 'Who created this?  (aka Source)'
+            },
+            'includeInGraphTooltip': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show "infoSource" value in tooltip on graph',
+              default: true
+            },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: true
             },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
               description:
-                'Hides "provenance" from Edge Editor, Edges Table, and exports',
+                'Hides "infoSource" from Edge Editor, Edges Table, and exports',
               default: false
             }
           }
         },
-
         'citation': {
           type: 'object',
           description: 'Source of the edge',
@@ -1016,6 +1204,12 @@ MOD.TEMPLATE = {
               type: 'string',
               description: 'Help text to display on the Node Editor form',
               default: 'Source Book.Chapter (e.g. "Part 2 06.03")'
+            },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
             },
             'hidden': {
               type: 'boolean',
@@ -1049,6 +1243,12 @@ MOD.TEMPLATE = {
               type: 'string',
               description: 'Help text to display on the Node Editor form',
               default: 'Category (deprecated)'
+            },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
             },
             'hidden': {
               type: 'boolean',
@@ -1086,10 +1286,57 @@ MOD.TEMPLATE = {
               description: 'Help text to display on the Edge Editor form',
               default: 'Date and time edge was created'
             },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
+            },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
               description: 'Requires "created" for exports and imports',
+              default: false
+            }
+          }
+        },
+        'createdBy': {
+          // Built-in data DO NOT MODIFY!
+          type: 'object',
+          description:
+            'System-generated date.  This setting used to show/hide tooltip in graph and import/export',
+          properties: {
+            'displayLabel': {
+              type: 'string',
+              description: 'Label to use for system display',
+              default: 'Created By'
+            },
+            'exportLabel': {
+              type: 'string',
+              description: 'Label to use for exported csv file field name',
+              default: 'Created By'
+            },
+            'includeInGraphTooltip': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show "created by" value in tooltip on graph',
+              default: true
+            },
+            'help': {
+              type: 'string',
+              description: 'Help text to display on the Edge Editor form',
+              default: 'Author who created the edge'
+            },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: true
+            },
+            'hidden': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Requires "created by" for exports and imports',
               default: false
             }
           }
@@ -1121,10 +1368,57 @@ MOD.TEMPLATE = {
               description: 'Help text to display on the Edge Editor form',
               default: 'Date and time edge was last modified'
             },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
+            },
             'hidden': {
               type: 'boolean',
               format: 'checkbox',
               description: 'Requires "updated" for exports and imports',
+              default: false
+            }
+          }
+        },
+        'updatedBy': {
+          // Built-in data DO NOT MODIFY!
+          type: 'object',
+          description:
+            'System-generated date.  This setting used to show/hide tooltip in graph and import/export',
+          properties: {
+            'displayLabel': {
+              type: 'string',
+              description: 'Label to use for system display',
+              default: 'Updated By'
+            },
+            'exportLabel': {
+              type: 'string',
+              description: 'Label to use for exported csv file field name',
+              default: 'Updated By'
+            },
+            'includeInGraphTooltip': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show "updated by" value in tooltip on graph',
+              default: true
+            },
+            'help': {
+              type: 'string',
+              description: 'Help text to display on the Edge Editor form',
+              default: 'Author who updated the nodedgee'
+            },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: true
+            },
+            'hidden': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Requires "updated by" for exports and imports',
               default: false
             }
           }
@@ -1155,6 +1449,12 @@ MOD.TEMPLATE = {
               type: 'string',
               description: 'Help text to display on the Edge Editor form',
               default: 'Number of times this edge has been revised'
+            },
+            'isProvenance': {
+              type: 'boolean',
+              format: 'checkbox',
+              description: 'Show in Provenance tab',
+              default: false
             },
             'hidden': {
               type: 'boolean',

--- a/app/view/netcreate/template-schema.js
+++ b/app/view/netcreate/template-schema.js
@@ -552,46 +552,6 @@ MOD.TEMPLATE = {
             }
           }
         },
-        'comments': {
-          // Comments
-          type: 'object',
-          description: 'User comments on the node',
-          properties: {
-            'type': {
-              type: 'string',
-              description: '"comments" data type',
-              default: 'string'
-            },
-            'displayLabel': {
-              type: 'string',
-              description: 'Label to use for system display',
-              default: 'Comments'
-            },
-            'exportLabel': {
-              type: 'string',
-              description: 'Label to use for exported csv file field name',
-              default: 'Comments'
-            },
-            'help': {
-              type: 'string',
-              description: 'Help text to display on the Node Editor form',
-              default: 'Enter "<comment> -- <name> <date>"'
-            },
-            'includeInGraphTooltip': {
-              type: 'boolean',
-              format: 'checkbox',
-              description: 'Show "comments" value in tooltip on graph',
-              default: true
-            },
-            'hidden': {
-              type: 'boolean',
-              format: 'checkbox',
-              description:
-                'Hides "comments" from Node Editor, Nodes Table, and exports',
-              default: false
-            }
-          }
-        },
         'degrees': {
           type: 'object',
           description: 'Number of edges connected to this node (auto-calculated)',
@@ -1032,46 +992,7 @@ MOD.TEMPLATE = {
             }
           }
         },
-        'comments': {
-          // Comments
-          type: 'object',
-          description: 'Comments on the edge',
-          properties: {
-            'type': {
-              type: 'string',
-              description: '"comments" data type',
-              default: 'string'
-            },
-            'displayLabel': {
-              type: 'string',
-              description: 'Label to use for system display',
-              default: 'Comments'
-            },
-            'exportLabel': {
-              type: 'string',
-              description: 'Label to use for exported csv file field name',
-              default: 'Comments'
-            },
-            'help': {
-              type: 'string',
-              description: 'Help text to display on the Edge Editor form',
-              default: 'Enter "<comment> -- <name> <date>"'
-            },
-            'includeInGraphTooltip': {
-              type: 'boolean',
-              format: 'checkbox',
-              description: 'Show "comments" value in tooltip on graph',
-              default: true
-            },
-            'hidden': {
-              type: 'boolean',
-              format: 'checkbox',
-              description:
-                'Hides "comments" from Edge Editor, Edges Table, and exports',
-              default: false
-            }
-          }
-        },
+
         'citation': {
           type: 'object',
           description: 'Source of the edge',

--- a/app/view/netcreate/template-schema.js
+++ b/app/view/netcreate/template-schema.js
@@ -138,7 +138,7 @@ MOD.EDGETYPEOPTIONS = {
  */
 MOD.TEMPLATE = {
   title: 'NetCreate Template',
-  version: '3.0 May 2024',
+  version: 2.0, // match github Release number
   type: 'object',
   properties: {
     'name': {
@@ -1572,7 +1572,7 @@ MOD.ParseTemplateSchema = () => {
     });
     return currJson;
   }
-  let json = {};
+  let json = { version: MOD.TEMPLATE.version };  // Insert template version
   u_ParseProperties(MOD.TEMPLATE.properties, json);
   return json;
 };


### PR DESCRIPTION
This introduces a revamped "Provenance" tab.

To implement this, we've introduced another major revision to the template format, and are adding a `version` designator to gracefully handle migrations in the future.

![screenshot_1574](https://github.com/netcreateorg/netcreate-itest/assets/1403057/0b7d1e90-b996-4f8a-ad24-7dd77108737a)

## Breaking Changes

NOTE: the template format has changed, but the app should still gracefully load older projects.  You may need to manually update the project's template to add new Provenance functionality.  See [Working with older projects](#working-with-older-projects) below.

* Add Template Versioning
  - Templates now have a version designation.
  - The version should match the github Release version. Hopefully this will be less confusing than having separate version numbers.  The one caveat is that it's harder to track interim development/alpha versions prior to a release.
  - When opening projects, the template version (or lack of a template version) will allow the system to decide how to migrate or ignore data fields. e.g. previously built-in fields like `comments` will continue to be displayed and will not break in table views.
* Nodes and Edges recently added semi-built-in `comments` and `provenance` fields to the default template as placeholders.  These have now been removed in favor of the "real" implementation. d713ca1a6f85fe832f0114ef810042054fb0b903

## Significant Features
* The Provenance tab has been reformatted to show two sections: "PROVENANCE" and "HISTORY".
* Any fields that are designated `isProvenance` will be added to the "PROVENANCE" tab.
* Added a `createdBy` and `updatedBy` built-in fields 6fc8dee6eea91c9fd96a323745fabf91f4c74d37

## Minor Features
* The old semi-built-in fields`Provenance` and `Comments` have been removed from Node and Edge tables.  Any new "isProvenance" field will be displayed in the tables.

See also #37 and [Provenance Ideas](https://docs.google.com/document/d/174JMW5ktUbS3Chygu82dwMdtUlkSk6ef4XcWwnFxXSE/edit#heading=h.knf6zq2bqjv8)


--- 

# To Test

The easiest way to test this is to create a new project. (`_default.template.toml` has been updated, so any new project should use the new template schema).
1. `./nc.js --dataset=newtest`
2. Create a token and log in. (`ncMakeTokens('new','a','newtest',2)`)
3. Create a node
4. Savet eh node
5. Click on "Provenance" -- you should see "Info Source" and "HISTORY" sections with your login data as the created by and updated by author.

### Working with older projects
Older projects (e.g. any project created before May 23, 2024), will still open.  
* Any fields that have not been designated as `isProvenance` (in the template definition) will be displayed in the main "ATTRIBUTES" tab.  e.g. if you recently created a project, it probaby has a `provenance` and `comments` field defined.  These will show up in "ATTRIBUTES".
* The new Provenance tab should work, e.g.:
  - "HISTORY" wil show created by and updated by.
  - Any created/updated author that is missing will be displayed as "(not recorded)"
  - Since there aren't any fields designated as `isProvenance`, there won't be any fields available.

If you want to add provenance fields to an older project you have two options:
1. Create a new field, e.g. "Info Source", or
2. Add `isProvenance` to an existing field to have it appear in the "PROVENANCE" tab.  e.g. you can convert the old `provenance` field into an active provenance field by adding the `isProvenance` flag.


# To Do
- [x] `updated` field is not updating
- [x] custom *edge* provenance fields are not accepting input
- [x] Update template migration to support semantic versioning strings (e.g. `10.1` is NOT less than `2.0`)? -- won't do now.  See #217 
- [X] Date fields do not support historical dates -- won't do now.  See #207
- [X] Support filter by provenance dates -- won't do now.  See #130 