### PR TITLE
Add Object Spread (ES2018) Syntax to Brunch Babel Config

### DIFF
--- a/brunch-config.js
+++ b/brunch-config.js
@@ -94,7 +94,8 @@ module.exports = {
   plugins: {
     babel: {
       ignore: [/^node_modules\/@ursys/],
-      presets: ['env', 'react']
+      presets: ['env', 'react'],
+      plugins: ['transform-object-rest-spread']
     },
     autoReload: { enabled: true },
     copycat: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "auto-reload-brunch": "^2.7.1",
         "babel-brunch": "^6.1.1",
         "babel-loader": "^8.1.0",
+        "babel-plugin-transform-object-rest-spread": "^6.26.0",
         "babel-preset-env": "^1.7.0",
         "babel-preset-react": "^6.24.1",
         "brunch": "^2.10.17",
@@ -3379,6 +3380,12 @@
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
+    "node_modules/babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha512-C4Aq+GaAj83pRQ0EFgTvw5YO6T3Qz2KGrNRwIj9mSoNHVvdZY4KO2uA6HNtNXCw993iSZnckY1aLW8nOi8i4+w==",
+      "dev": true
+    },
     "node_modules/babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
@@ -3649,6 +3656,16 @@
       "dependencies": {
         "babel-plugin-syntax-flow": "^6.18.0",
         "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha512-ocgA9VJvyxwt+qJB0ncxV8kb/CjfTcECUY4tQ5VT7nP6Aohzobm8CDFaQ5FHdvZQzLmf0sgDxB8iRXZXxwZcyA==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
       }
     },
     "node_modules/babel-plugin-transform-react-display-name": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "auto-reload-brunch": "^2.7.1",
     "babel-brunch": "^6.1.1",
     "babel-loader": "^8.1.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "brunch": "^2.10.17",


### PR DESCRIPTION
## The Problem 

You can't use object spread in NetCreate, eg `const clone = { ...original, id: 1}` or something like that. This PR modifies the babel config used by brunch to enable it.

## Testing

After pulling the branch, try replacing any `Object.assign` code with the equivalent spread syntax. E.g. change
`const bar =  Object.assign({}, foo, {name:'foo2')`
to
`const foo = { ...foo, name:'foo2' }`

See if NetCreate handles this correctly

---
## TECHNICAL BACKGROUND

In current NetCreate 2.0, we are maintaining the 2017-era `brunch` build system, which is unaware of features that occurred afterwards. The difficulties are summarized in the aborted #80 "Module Architecture Stage 2". 

We are dependent on the pre-7.0 version of Babel because Brunch 2.10 uses the old Babel as a dependency. It appears to be around version 6.7, though we can go right up to 6.26.3 (the last pre-7.0 Babel). This means we use the [old babel repo](https://github.com/babel/babel/tree/v6.26.3) for our reference, as syntax changed significantly in 7.

### THE FIX

Install the [old version of babel object spread](https://www.npmjs.com/package/babel-plugin-transform-object-rest-spread), not the newer one.

```
npm i -D babel-plugin-transform-object-rest-spread
```

Then update the `brunch-config.js` file by adding this line to the `plugins/babel` field.
```
plugins: ['transform-object-rest-spread']
```

