### PR TITLE
hotfix: Move GetCurrentUserId to `comment-mgr`

### DIFF
--- a/app/view/netcreate/components/EdgeTable.jsx
+++ b/app/view/netcreate/components/EdgeTable.jsx
@@ -415,7 +415,7 @@ class EdgeTable extends UNISYS.Component {
    */
   sortByComment(edges) {
     // stuff the count into edges for calculation
-    const uid = NCLOGIC.GetCurrentUserId();
+    const uid = CMTMGR.GetCurrentUserId();
     const countededges = edges.map(e => {
       const cref = CMTMGR.GetEdgeCREF(e.id);
       e.commentcount = CMTMGR.GetThreadedViewObjectsCount(cref, uid);

--- a/app/view/netcreate/components/NodeTable.jsx
+++ b/app/view/netcreate/components/NodeTable.jsx
@@ -397,7 +397,7 @@ class NodeTable extends UNISYS.Component {
    */
   sortByComment(nodes) {
     // stuff the count into nodes for calculation
-    const uid = NCLOGIC.GetCurrentUserId();
+    const uid = CMTMGR.GetCurrentUserId();
     const countednodes = nodes.map(n => {
       const cref = CMTMGR.GetNodeCREF(n.id);
       n.commentcount = CMTMGR.GetThreadedViewObjectsCount(cref, uid);


### PR DESCRIPTION
Since NodeTable/EdgeTable comment sorting uses comment-mgr anyway it makes sense to use that rather than introducing NCLOGIC for that one purpose.

Fixes #223