### PR TITLE
hotfix-for-234: use POSIX dot command for Digital Ocean compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "_ur_addons/"
   ],
   "scripts": {
-    "dev": "source ./@build-ursys.sh && brunch w -s",
+    "dev": ". @build-ursys.sh && brunch w -s",
     "lint": "npm exec --workspaces -- npm run lint && eslint app/",
     "dev:inspect": "node --inspect brunch-server.js",
     "classroom": "brunch build -e classroom",


### PR DESCRIPTION
This PR changes the way that `npm run dev` works, as the system shell on Ubuntu is different than MacOs. Specifically, it replaces the `source` command with the "dot" command which is more universal.

Previously, we had assumed that `/bin/sh` implemented the same interface so if it worked on MacOs then it would work elsewhere. In actuality, the system shell is merely a "default shell" and can vary quite a lot. 

See issue #234 for details.

## TESTING

* pull this branch on Digital Ocean
* try `npm run dev`

You should be greeted with something like this:
![image](https://github.com/user-attachments/assets/2d15a9a6-0510-4910-9849-72e95ba6ef0b)
instead of 
![image](https://github.com/user-attachments/assets/01e6aad7-d995-45f2-b814-2a59a10dbc30)
