### PR TITLE
hotfix-for-234b: Digital Ocean NPM Script Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "_ur_addons/"
   ],
   "scripts": {
-    "dev": ". @build-ursys.sh && brunch w -s",
+    "dev": ". ./@build-ursys.sh && brunch w -s",
     "lint": "npm exec --workspaces -- npm run lint && eslint app/",
     "dev:inspect": "node --inspect brunch-server.js",
     "classroom": "brunch build -e classroom",
-    "package": "brunch build -e package",
+    "package": ". ./@build-ursys.sh && brunch build -e package",
     "package:debug": "brunch watch -e package_debug -s",
     "clean": "rm -rf ./public ./node_modules && npm exec --workspaces -- npm run clean",
     "debug": "LOGGY_STACKS=true BRUNCH_DEVTOOLS=true ./brunch-debug watch --server",


### PR DESCRIPTION
This PR changes the way that `npm run dev` and `npm run package` work due to differences in our MacOS shell environment and Digital Ocean's environment.

1. **npm run dev** now uses the `./@build-ursys.sh` because `./` isn't included in the path by default, as it is in our VSCode integrated terminal
2. **npm run package** now also invokes `./@build-ursys.sh` because it was not being run at all, causing a potential failure to load in net graphs because the libraries were not built.

See issue https://github.com/netcreateorg/netcreate-itest/issues/234 for details.

## TECHNICAL NOTES

On Digital Ocean running **nc-multiplex**, the installation instructions call for running `npm run package` **once** after doing a pull of the `netcreate-itest` repo. This is to ensure that all built libraries are available, as `nc-multiplex` does not do it automatically. Up to now, `npm run package` did not build the ursys libraries as `npm run dev` does automatically. This can cause URSYS versions to not be available (showing load errors in the javascript console) or cause URSYS versions to be out-of-date.

NetCreate makes fairly minimum use of URSYS itself with the exception of the "Comments" addon, but the libraries must be present for the app to load.