### PR TITLE
hotfix-for-234c: Improve NetMessage create-from-object handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 #   git config --global core.excludesfile ~/.gitignore
 
 # NetCreate ignored directories
+/app-data/*
 /runtime
 netcreate-config.js
 

--- a/app/unisys/common-netmessage-class.js
+++ b/app/unisys/common-netmessage-class.js
@@ -62,6 +62,7 @@ class NetMessage {
     if (typeof msg === 'object' && data === undefined) {
       // make sure it has a msg and data obj
       if (typeof msg.msg !== 'string' || typeof msg.data !== 'object') {
+        console.log('bad message object', JSON.stringify(msg));
         throw ERR_NOT_NETMESG;
       }
       // merge properties into this new class instance and return it

--- a/app/unisys/server-network.js
+++ b/app/unisys/server-network.js
@@ -306,7 +306,7 @@ function m_SocketMessage(socket, json) {
         throw new Error(`${PR} unknown packet type '${pkt.Type()}'`);
     } // end switch
   } catch (err) {
-    console.error(PR, 'ERROR:', err);
+    console.error(PR, 'm_SocketMessage try:', err);
   }
 } // end m_SocketMessage()
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/unisys/server-network.js
+++ b/app/unisys/server-network.js
@@ -290,21 +290,24 @@ function m_SocketMessage(socket, json) {
     m_ResetPongTimer(socket.UADDR);
     return;
   }
-
-  let pkt = new NetMessage(json);
-  // figure out what to do
-  switch (pkt.Type()) {
-    case 'state':
-      m_HandleState(socket, pkt);
-      break;
-    case 'msig':
-    case 'msend':
-    case 'mcall':
-      m_HandleMessage(socket, pkt);
-      break;
-    default:
-      throw new Error(`${PR} unknown packet type '${pkt.Type()}'`);
-  } // end switch
+  try {
+    let pkt = new NetMessage(json);
+    // figure out what to do
+    switch (pkt.Type()) {
+      case 'state':
+        m_HandleState(socket, pkt);
+        break;
+      case 'msig':
+      case 'msend':
+      case 'mcall':
+        m_HandleMessage(socket, pkt);
+        break;
+      default:
+        throw new Error(`${PR} unknown packet type '${pkt.Type()}'`);
+    } // end switch
+  } catch (err) {
+    console.error(PR, 'ERROR:', err);
+  }
 } // end m_SocketMessage()
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** handle global state and rebroadcast
@@ -454,7 +457,8 @@ function m_PromiseRemoteHandlers(pkt) {
     if (verbose) {
       console.log(
         'make_resolver_func:',
-        `PKT: ${srcPkt.Type()} '${srcPkt.Message()}' from ${srcPkt.Info()} to d_uaddr:${d_uaddr} dispatch to d_sock.UADDR:${d_sock.UADDR
+        `PKT: ${srcPkt.Type()} '${srcPkt.Message()}' from ${srcPkt.Info()} to d_uaddr:${d_uaddr} dispatch to d_sock.UADDR:${
+          d_sock.UADDR
         }`
       );
     }


### PR DESCRIPTION
This hotfix adds a `try-catch` around socket 'message' event handling when receiving data, printing out the received packet as JSON to the console. This hopefully will prevent the instance servers from crashing when being used by nc-multiplex.

It also adds `app-data` directory to `.gitignore`, as files in this directory are not part of the application but are part of individual datasets.

See #234 comments for more information.