### PR TITLE
Feature: Resizable table columns

### DIFF
--- a/_ur_addons/comment/ac-comment.ts
+++ b/_ur_addons/comment/ac-comment.ts
@@ -8,7 +8,7 @@
   
     COMMENTCOLLECTION ccol
     -----------------
-    A COMENTCOLLECTION is the main data source for the CommentBtn.
+    A COMMENTCOLLECTION is the main data source for the CommentBtn.
     It primarily shows summary information for the three states of the button:
     * has no comments
     * has unread comments
@@ -24,31 +24,22 @@
       
     COMMENTUISTATE cui
     --------------
-    A COMMENTUISTATE object can be opened and closed from multiple UI elements.
-    COMMENTUI keeps track of the `isOpen` status based on the UI element.
+    COMMENTUISTATE keeps track of the `isOpen` state of currently selected/open 
+    comment ui buttons.
+    Comments can be opened and closed from multiple UI elements.
     e.g. a comment button in a node can open a comment but the same comment can
-    be opeend from the node table view.
+    be opened from the node table view.
     
       COMMENTUISTATE Map<uiref, {cref, isOpen}>
     
     
     OPENCOMMENTS
-    ------------
-    OPENCOMMENTS keeps track of currently open comment buttons.  This is 
+    ---------------
+    OPENCOMMENTS keeps track of currently open comments.  This is 
     used prevent two comment buttons from opening the same comment collection,
     e.g. if the user opens a node and a node table comment at the same time.
     
       OPENCOMMENTS Map<cref, uiref>
-
-      
-    EDITABLECOMMENTS
-    ----------------
-    EDITABLECOMMENTS keeps track of which comment is currently open for 
-    editing.  This is used to prevent close requests coming from NCCOmmentThreads
-    from closing a NCComment that is in the middle of being edited.
-    Tracked locally only.
-    
-      EDITABLECOMMENTS Map<cid, cid>
 
       
     COMMENTVOBJS

--- a/app/unisys/component/SessionShell.jsx
+++ b/app/unisys/component/SessionShell.jsx
@@ -265,7 +265,7 @@ class SessionShell extends UNISYS.Component {
         onSubmit={this.onSubmit}
         style={NAV_LOGIN_STYLE}
       >
-        <FormGroup row>
+        <FormGroup row style={{ marginRight: '-5px' }}>
           <InputGroup>
             <InputGroupAddon addonType="prepend">
               <Button

--- a/app/view/netcreate/NetCreate.css
+++ b/app/view/netcreate/NetCreate.css
@@ -7,13 +7,13 @@
       2001  NCDialog .screen ==========
       2000  comment-bar
       1030  bootstrap .fixed-top
+       200  nc-navbar
        100  Node/EdgeTable thead
         15  NCAutoSuggest .matchlist
         15  NCNode .ncedge
         10  NCNode .nccomponent
          1  NCNode .screen ============
          1  ToolTip .modal, .tooltiptextabove, .tooltiptext
-         1  nc-navbar
          0  NetCreate
 */
 
@@ -51,7 +51,7 @@ nav.fixed-top {
   height: 38px;
   display: flex;
   flex-flow: row-reverse;
-  z-index: 1;
+  z-index: 200;
 }
 /* Bootstrap override */
 .nav-item {

--- a/app/view/netcreate/NetCreate.css
+++ b/app/view/netcreate/NetCreate.css
@@ -1,13 +1,14 @@
 /* Z-Index
 
       5000  NCDialog
-      3000  nc-savelert
+      3000  nc-savelert      
+      2500  nc-navbar > comment-status
       2500  commentThread
       2010  NCDialog .dialogWindow
       2001  NCDialog .screen ==========
       2000  comment-bar
+      1500  FiltersPanel
       1030  bootstrap .fixed-top
-       200  nc-navbar
        100  Node/EdgeTable thead
         15  NCAutoSuggest .matchlist
         15  NCNode .ncedge
@@ -51,7 +52,7 @@ nav.fixed-top {
   height: 38px;
   display: flex;
   flex-flow: row-reverse;
-  z-index: 200;
+  z-index: 2500; /* sets comment-status and comment threads */
 }
 /* Bootstrap override */
 .nav-item {

--- a/app/view/netcreate/NetCreate.css
+++ b/app/view/netcreate/NetCreate.css
@@ -106,3 +106,14 @@ button svg {
   width: 16px;
   height: 16px;
 }
+
+/* NC Tables --------------------------------------------------------------- */
+.NCNodeTable,
+.NCEdgeTable {
+  overflow: auto;
+  position: relative;
+  display: block;
+  left: 1px;
+  right: 10px;
+  background-color: #eafcff;
+}

--- a/app/view/netcreate/NetCreate.jsx
+++ b/app/view/netcreate/NetCreate.jsx
@@ -192,10 +192,12 @@ class NetCreate extends UNISYS.Component {
         </div>
         <div className="--NetCreate_Fixed_Top nc-navbar">
           <SessionShell />
+          <div style={{ flexGrow: 1 }}></div>
           <URCommentStatus
             message={commentStatusMessage}
             handleMessageUpdate={handleMessageUpdate}
           />
+          <div style={{ flexGrow: 1 }}></div>
         </div>
 
         <div

--- a/app/view/netcreate/comment-mgr.js
+++ b/app/view/netcreate/comment-mgr.js
@@ -90,6 +90,32 @@ MOD.COMMENTICON = (
     <path d="M21,0C9.4,0,0,9.4,0,21c0,4.12,1.21,7.96,3.26,11.2l-2.26,9.8,11.56-1.78c2.58,1.14,5.44,1.78,8.44,1.78,11.6,0,21-9.4,21-21S32.6,0,21,0Z" />
   </svg>
 );
+// From Evan O'Neil https://drive.google.com/drive/folders/1fJ5WiLMVQxxaqghrCOFwegmnYoOvst7E
+// NOTE viewbox is set to y=1 to better center the text
+MOD.ICN_COMMENT_UNREAD = (
+  <svg id="icn-comment-unread" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 1 16 16">
+    <path fill="#FFE143" d='M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 9.15705 1.28072 10.2485 1.77778 11.21V15H8Z' />
+    <path fill="#FFE143" d='M3.17778 10.8696V13.6H8C11.0928 13.6 13.6 11.0928 13.6 8C13.6 4.90721 11.0928 2.4 8 2.4C4.90721 2.4 2.4 4.90721 2.4 8C2.4 8.92813 2.62469 9.79968 3.02143 10.5671L3.17778 10.8696Z' />
+  </svg>
+)
+MOD.ICN_COMMENT_UNREAD_SELECTED = (
+  <svg id="icn-comment-unread" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 1 16 16">
+    <path fill="#D44127" d='M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 9.15705 1.28072 10.2485 1.77778 11.21V15H8Z' />
+    <path fill="#FFE143" d='M3.17778 10.8696V13.6H8C11.0928 13.6 13.6 11.0928 13.6 8C13.6 4.90721 11.0928 2.4 8 2.4C4.90721 2.4 2.4 4.90721 2.4 8C2.4 8.92813 2.62469 9.79968 3.02143 10.5671L3.17778 10.8696Z' />
+  </svg>
+)
+MOD.ICN_COMMENT_READ = (
+  <svg id="icn-comment-unread" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 1 16 16">
+    <path fill="#696969" d='M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 9.15705 1.28072 10.2485 1.77778 11.21V15H8Z' />
+    <path fill="#696969" d='M3.17778 10.8696V13.6H8C11.0928 13.6 13.6 11.0928 13.6 8C13.6 4.90721 11.0928 2.4 8 2.4C4.90721 2.4 2.4 4.90721 2.4 8C2.4 8.92813 2.62469 9.79968 3.02143 10.5671L3.17778 10.8696Z' />
+  </svg>
+)
+MOD.ICN_COMMENT_READ_SELECTED = (
+  <svg id="icn-comment-unread" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 1 16 16">
+    <path fill="#D44127" d='M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 9.15705 1.28072 10.2485 1.77778 11.21V15H8Z' />
+    <path fill="#696969" d='M3.17778 10.8696V13.6H8C11.0928 13.6 13.6 11.0928 13.6 8C13.6 4.90721 11.0928 2.4 8 2.4C4.90721 2.4 2.4 4.90721 2.4 8C2.4 8.92813 2.62469 9.79968 3.02143 10.5671L3.17778 10.8696Z' />
+  </svg>
+)
 
 function m_SetAppStateCommentCollections() {
   const COMMENTCOLLECTION = COMMENT.GetCommentCollections();

--- a/app/view/netcreate/comment-mgr.js
+++ b/app/view/netcreate/comment-mgr.js
@@ -299,6 +299,7 @@ MOD.MarkAllRead = () => {
 MOD.GetCommentCollection = uiref => {
   return COMMENT.GetCommentCollection(uiref);
 };
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /**
  * Marks a comment as read, and closes the component.
  * Called by NCCommentBtn when clicking "Close"
@@ -315,15 +316,35 @@ MOD.CloseCommentCollection = (uiref, cref, uid) => {
     return;
   }
   // OK to close
+  UDATA.LocalCall('CTHREADMGR_THREAD_CLOSE', { cref });
   m_DBUpdateReadBy(cref, uid);
   COMMENT.CloseCommentCollection(uiref, cref, uid);
   m_SetAppStateCommentCollections();
 };
-
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 MOD.GetCommentStats = () => {
   const uid = MOD.GetCurrentUserId();
   return COMMENT.GetCommentStats(uid);
 };
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+MOD.OpenCommentThread = (cref, position) => {
+  UDATA.LocalCall('CTHREADMGR_THREAD_OPEN', { cref, position });
+};
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+MOD.GetCommentThreadPosition = commentButtonId => {
+  const btn = document.getElementById(commentButtonId);
+  const cmtbtnx = btn.getBoundingClientRect().left;
+  const windowWidth = Math.min(screen.width, window.innerWidth);
+  let x;
+  if (windowWidth - cmtbtnx < 500) {
+    x = cmtbtnx - 405;
+  } else {
+    x = cmtbtnx + 35;
+  }
+  const y = btn.getBoundingClientRect().top + window.scrollY;
+  return { x, y };
+}
+
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// Comment UI State

--- a/app/view/netcreate/components/InfoPanel.jsx
+++ b/app/view/netcreate/components/InfoPanel.jsx
@@ -20,7 +20,7 @@ const ReactStrap = require('reactstrap');
 const { TabContent, TabPane, Nav, NavItem, NavLink, Row, Col, Button } = ReactStrap;
 const classnames = require('classnames');
 const NCNodeTable = require('./NCNodeTable');
-const EdgeTable = require('./EdgeTable');
+const NCEdgeTable = require('./NCEdgeTable');
 const More = require('./More');
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
@@ -273,7 +273,7 @@ class InfoPanel extends UNISYS.Component {
               <Row>
                 <Col sm="12">
                   {activeTab === TABS.EDGESTABLE && (
-                    <EdgeTable tableHeight={tableHeight} />
+                    <NCEdgeTable tableHeight={tableHeight} />
                   )}
                 </Col>
               </Row>

--- a/app/view/netcreate/components/InfoPanel.jsx
+++ b/app/view/netcreate/components/InfoPanel.jsx
@@ -19,7 +19,7 @@ const React = require('react');
 const ReactStrap = require('reactstrap');
 const { TabContent, TabPane, Nav, NavItem, NavLink, Row, Col, Button } = ReactStrap;
 const classnames = require('classnames');
-const NodeTable = require('./NodeTable');
+const NCNodeTable = require('./NCNodeTable');
 const EdgeTable = require('./EdgeTable');
 const More = require('./More');
 
@@ -264,7 +264,7 @@ class InfoPanel extends UNISYS.Component {
               <Row>
                 <Col sm="12">
                   {activeTab === TABS.NODESTABLE && (
-                    <NodeTable tableHeight={tableHeight} />
+                    <NCNodeTable tableHeight={tableHeight} />
                   )}
                 </Col>
               </Row>

--- a/app/view/netcreate/components/InfoPanel.jsx
+++ b/app/view/netcreate/components/InfoPanel.jsx
@@ -263,18 +263,20 @@ class InfoPanel extends UNISYS.Component {
             <TabPane tabId={TABS.NODESTABLE}>
               <Row>
                 <Col sm="12">
-                  {activeTab === TABS.NODESTABLE && (
-                    <NCNodeTable tableHeight={tableHeight} />
-                  )}
+                  <NCNodeTable
+                    tableHeight={tableHeight}
+                    isOpen={activeTab === TABS.NODESTABLE}
+                  />
                 </Col>
               </Row>
             </TabPane>
             <TabPane tabId={TABS.EDGESTABLE}>
               <Row>
                 <Col sm="12">
-                  {activeTab === TABS.EDGESTABLE && (
-                    <NCEdgeTable tableHeight={tableHeight} />
-                  )}
+                  <NCEdgeTable
+                    tableHeight={tableHeight}
+                    isOpen={activeTab === TABS.EDGESTABLE}
+                  />
                 </Col>
               </Row>
             </TabPane>

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -566,10 +566,10 @@ class NCEdgeTable extends UNISYS.Component {
     // }
     function RenderNode(value) {
       if (!value) return; // skip if not defined yet
-      if (value.id === undefined)
-        throw new Error('RenderNode: value.id is undefined');
-      if (value.label === undefined)
-        throw new Error('RenderNode: value.label is undefined');
+      if (value.id === undefined || value.label === undefined) {
+        // During Edge creation, source/target may not be defined yet
+        return <span style={{ color: 'red' }}>...</span>;
+      }
       return (
         <button
           className="outline"

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -1,0 +1,676 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  ## OVERVIEW
+
+    EdgeTable is used to to display a table of edges for review.
+
+    It displays NCDATA.
+    But also read FILTEREDNCDATA to show highlight/filtered state
+
+
+  ## TO USE
+
+    EdgeTable is self contained and relies on global NCDATA to load.
+
+      <EdgeTable/>
+
+
+    Set `DBG` to true to show the `ID` column.
+
+  ## 2018-12-07 Update
+
+    Since we're not using tab navigation:
+    1. The table isExpanded is now true by default.
+    2. The "Show/Hide Table" button is hidden.
+
+    Reset these to restore previous behavior.
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+const React = require('react');
+const NCUI = require('../nc-ui');
+const CMTMGR = require('../comment-mgr');
+const SETTINGS = require('settings');
+const FILTER = require('./filter/FilterEnums');
+const UNISYS = require('unisys/client');
+import HDATE from 'system/util/hdate';
+import URCommentVBtn from './URCommentVBtn';
+import URTable from './URTable';
+const { BUILTIN_FIELDS_EDGE } = require('system/util/enum');
+const { ICON_PENCIL, ICON_VIEW } = require('system/util/constant');
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const DBG = false;
+const isAdmin = SETTINGS.IsAdmin();
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+var UDATA = null;
+
+/// UTILITY METHODS ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function u_GetButtonId(cref) {
+  return `comment-button-${cref}`;
+}
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// export a class object for consumption by brunch/require
+class NCEdgeTable extends UNISYS.Component {
+  constructor(props) {
+    super(props);
+
+    const TEMPLATE = this.AppState('TEMPLATE');
+    this.state = {
+      edgeDefs: TEMPLATE.edgeDefs,
+      edges: [],
+      selectedEdgeId: undefined,
+      selectedEdgeColor: TEMPLATE.sourceColor,
+      filteredEdges: [],
+      nodes: [], // needed for dereferencing source/target
+      disableEdit: false,
+      isLocked: false,
+      isExpanded: true,
+      sortkey: 'Relationship'
+    };
+
+    this.onStateChange_SESSION = this.onStateChange_SESSION.bind(this);
+    this.onStateChange_SELECTION = this.onStateChange_SELECTION.bind(this);
+    this.onEDGE_OPEN = this.onEDGE_OPEN.bind(this);
+    this.updateEdgeFilterState = this.updateEdgeFilterState.bind(this);
+    this.handleDataUpdate = this.handleDataUpdate.bind(this);
+    this.handleFilterDataUpdate = this.handleFilterDataUpdate.bind(this);
+    this.updateEditState = this.updateEditState.bind(this);
+    this.OnTemplateUpdate = this.OnTemplateUpdate.bind(this);
+    this.onViewButtonClick = this.onViewButtonClick.bind(this);
+    this.onEditButtonClick = this.onEditButtonClick.bind(this);
+    this.onToggleExpanded = this.onToggleExpanded.bind(this);
+    this.onHighlightNode = this.onHighlightNode.bind(this);
+    this.m_FindMatchingObjsByProp = this.m_FindMatchingObjsByProp.bind(this);
+    this.m_FindMatchingEdgeByProp = this.m_FindMatchingEdgeByProp.bind(this);
+    this.m_FindEdgeById = this.m_FindEdgeById.bind(this);
+    this.lookupNodeLabel = this.lookupNodeLabel.bind(this);
+
+    this.sortDirection = 1;
+
+    /// Initialize UNISYS DATA LINK for REACT
+    UDATA = UNISYS.NewDataLink(this);
+
+    UDATA.HandleMessage('EDGE_OPEN', this.onEDGE_OPEN);
+    UDATA.HandleMessage('EDIT_PERMISSIONS_UPDATE', this.updateEditState);
+
+    // SESSION is called by SessionSHell when the ID changes
+    //  set system-wide. data: { classId, projId, hashedId, groupId, isValid }
+    this.OnAppStateChange('SESSION', this.onStateChange_SESSION);
+
+    // Always make sure class methods are bind()'d before using them
+    // as a handler, otherwise object context is lost
+    this.OnAppStateChange('NCDATA', this.handleDataUpdate);
+
+    // Handle Template updates
+    this.OnAppStateChange('TEMPLATE', this.OnTemplateUpdate);
+
+    // Track Filtered Data Updates too
+    this.OnAppStateChange('FILTEREDNCDATA', this.handleFilterDataUpdate);
+
+    this.OnAppStateChange('SELECTION', this.onStateChange_SELECTION);
+  } // constructor
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  componentDidMount() {
+    if (DBG) console.log('EdgeTable.componentDidMount!');
+
+    this.onStateChange_SESSION(this.AppState('SESSION'));
+
+    // Explicitly retrieve data because we may not have gotten a NCDATA
+    // update while we were hidden.
+    // filtered data needs to be set before D3Data
+    const FILTEREDNCDATA = UDATA.AppState('FILTEREDNCDATA');
+    this.setState({ filteredEdges: FILTEREDNCDATA.edges }, () => {
+      let NCDATA = this.AppState('NCDATA');
+      this.handleDataUpdate(NCDATA);
+    });
+
+    // Request edit state too because the update may have come
+    // while we were hidden
+    this.updateEditState();
+  }
+
+  componentWillUnmount() {
+    UDATA.UnhandleMessage('EDGE_OPEN', this.onEDGE_OPEN);
+    UDATA.UnhandleMessage('EDIT_PERMISSIONS_UPDATE', this.updateEditState);
+    this.AppStateChangeOff('SESSION', this.onStateChange_SESSION);
+    this.AppStateChangeOff('NCDATA', this.handleDataUpdate);
+    this.AppStateChangeOff('FILTEREDNCDATA', this.handleFilterDataUpdate);
+    this.AppStateChangeOff('TEMPLATE', this.OnTemplateUpdate);
+    this.AppStateChangeOff('SELECTION', this.onStateChange_SELECTION);
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  onStateChange_SELECTION(data) {
+    this.setState({
+      selectedEdgeId: data.edges.length > 0 ? data.edges[0].id : undefined
+    });
+  }
+  /** Handle change in SESSION data
+    Called both by componentWillMount() and AppStateChange handler.
+    The 'SESSION' state change is triggered in two places in SessionShell during
+    its handleChange() when active typing is occuring, and also during
+    SessionShell.componentWillMount()
+   */
+  onStateChange_SESSION(decoded) {
+    this.setState({ isLocked: !decoded.isValid });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  displayUpdated(nodeEdge) {
+    // Prevent error if `meta` info is not defined yet, or not properly imported
+    if (!nodeEdge.meta) return '';
+
+    var d = new Date(
+      nodeEdge.meta.revision > 0 ? nodeEdge.meta.updated : nodeEdge.meta.created
+    );
+
+    var year = String(d.getFullYear());
+    var date = d.getMonth() + 1 + '/' + d.getDate() + '/' + year.substr(2, 4);
+    var time = d.toTimeString().substr(0, 5);
+    var dateTime = date + ' at ' + time;
+    var titleString = 'v' + nodeEdge.meta.revision;
+    if (nodeEdge._nlog)
+      titleString += ' by ' + nodeEdge._nlog[nodeEdge._nlog.length - 1];
+    var tag = <span title={titleString}> {dateTime} </span>;
+
+    return tag;
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// User selected edge usu by clicking NCNode's edge item in Edges tab
+  onEDGE_OPEN(data) {
+    this.setState({ selectedEdgeId: data.edge.id });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// Set edge filtered status based on current filteredNodes
+  updateEdgeFilterState(edges, filteredEdges) {
+    // add highlight/filter status
+    if (filteredEdges.length > 0) {
+      // If we're transitioning from "HILIGHT/FADE" to "COLLAPSE" or "FOCUS", then we
+      // also need to remove edges that are not in filteredEdges
+      const FILTERDEFS = UDATA.AppState('FILTERDEFS');
+      if (
+        FILTERDEFS.filterAction === FILTER.ACTION.REDUCE ||
+        FILTERDEFS.filterAction === FILTER.ACTION.FOCUS
+      ) {
+        edges = edges.filter(edge => {
+          const filteredEdge = filteredEdges.find(n => n.id === edge.id);
+          return filteredEdge; // keep if it's in the list of filtered edges
+        });
+      } else {
+        edges = edges.map(edge => {
+          const filteredEdge = filteredEdges.find(n => n.id === edge.id);
+          edge.isFiltered = !filteredEdge;
+          return edge;
+        });
+      }
+    }
+    this.setState({ edges });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** Handle updated SELECTION: NCDATA updates
+   */
+  handleDataUpdate(data) {
+    if (data && data.edges && data.nodes) {
+      // NCDATA.edges no longer uses source/target objects
+      // ...1. So we need to save nodes for dereferencing.
+      this.setState({ nodes: data.nodes }, () => {
+        // ...2. So we stuff 'sourceLabel' and 'targetLabel' into the local edges array
+        let edges = data.edges.map(e => {
+          e.sourceLabel = this.lookupNodeLabel(e.source); // requires `state.nodes` be set
+          e.targetLabel = this.lookupNodeLabel(e.target);
+          return e;
+        });
+        // ...   sort it also
+        // FIXME handle sort!
+        // edges = this.sortTable(this.state.sortkey, edges);
+        // ...1. So we need to save nodes for dereferencing.
+        this.setState({ edges });
+        const { filteredEdges } = this.state;
+        this.updateEdgeFilterState(edges, filteredEdges);
+      });
+    }
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** Handle FILTEREDNCDATA updates sent by filters-logic.m_FiltersApply
+      Note that edge.soourceLabel and edge.targetLabel should already be set
+      by filter-mgr.
+   */
+  handleFilterDataUpdate(data) {
+    if (data.edges) {
+      const filteredEdges = data.edges;
+      // If we're transitioning from "COLLAPSE" or "FOCUS" to "HILIGHT/FADE", then we
+      // also need to add back in edges that are not in filteredEdges
+      // (because "COLLAPSE" and "FOCUS" removes edges that are not matched)
+      const FILTERDEFS = UDATA.AppState('FILTERDEFS');
+      if (FILTERDEFS.filterAction === FILTER.ACTION.FADE) {
+        const NCDATA = UDATA.AppState('NCDATA');
+        this.setState(
+          {
+            edges: NCDATA.edges,
+            filteredEdges
+          },
+          () => {
+            // FIXME handle sort table
+            // const edges = this.sortTable(this.state.sortkey, NCDATA.edges);
+            const edges = NCDATA.edges;
+            this.updateEdgeFilterState(edges, filteredEdges);
+          }
+        );
+      } else {
+        this.setState(
+          {
+            edges: filteredEdges,
+            filteredEdges
+          },
+          () => {
+            // FIXME handle sort table
+            // const edges = this.sortTable(this.state.sortkey, filteredEdges);
+            const edges = filteredEdges;
+            this.updateEdgeFilterState(edges, filteredEdges);
+          }
+        );
+      }
+    }
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  updateEditState() {
+    // disable edit if someone else is editing a template, node, or edge
+    let disableEdit = false;
+    UDATA.NetCall('SRV_GET_EDIT_STATUS').then(data => {
+      // someone else might be editing a template or importing or editing node or edge
+      disableEdit =
+        data.templateBeingEdited ||
+        data.importActive ||
+        data.nodeOrEdgeBeingEdited ||
+        data.commentBeingEditedByMe; // only lock out if this user is the one editing comments, allow network commen edits
+      this.setState({ disableEdit });
+    });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  OnTemplateUpdate(data) {
+    this.setState({
+      edgeDefs: data.edgeDefs,
+      selectedEdgeColor: data.sourceColor
+    });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** Look up the Node label for source / target ids
+   */
+  lookupNodeLabel(nodeId) {
+    const node = this.state.nodes.find(n => n.id === nodeId);
+    if (node === undefined) return '...';
+    // if (node === undefined) throw new Error('EdgeTable: Could not find node', nodeId);
+    return node.label;
+  }
+
+  /// UI EVENT HANDLERS /////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /**
+   */
+  onViewButtonClick(event, edgeId) {
+    event.preventDefault();
+    event.stopPropagation();
+    let edgeID = parseInt(edgeId);
+    let edge = this.m_FindEdgeById(edgeID);
+    if (DBG) console.log('EdgeTable: Edge id', edge.id, 'selected for viewing');
+    // Load Source Node then Edge
+    UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [edge.source] }).then(() => {
+      UDATA.LocalCall('EDGE_SELECT', { edgeId: edge.id });
+    });
+  }
+  onEditButtonClick(event, edgeId) {
+    event.preventDefault();
+    event.stopPropagation();
+    let edgeID = parseInt(edgeId);
+    let edge = this.m_FindEdgeById(edgeID);
+    if (DBG) console.log('EdgeTable: Edge id', edge.id, 'selected for editing');
+    // Load Source Node then Edge
+    UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [edge.source] }).then(() => {
+      UDATA.LocalCall('EDGE_SELECT_AND_EDIT', { edgeId: edge.id });
+    });
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /**
+   */
+  onToggleExpanded(event) {
+    this.setState({
+      isExpanded: !this.state.isExpanded
+    });
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /**
+  /*/
+  onHighlightNode(nodeId) {
+    UDATA.LocalCall('TABLE_HILITE_NODE', { nodeId });
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /*/
+   */
+  setSortKey(key, type) {
+    if (key === this.state.sortkey) this.sortDirection = -1 * this.sortDirection;
+    // if this was already the key, flip the direction
+    else this.sortDirection = 1;
+
+    const edges = this.sortTable(key, this.state.edges, type);
+    this.setState({
+      edges,
+      sortkey: key
+    });
+    UNISYS.Log('sort edge table', key, this.sortDirection);
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /**
+   */
+  selectNode(id, event) {
+    event.preventDefault();
+
+    // Load Source
+    if (DBG) console.log('EdgeTable: Edge id', id, 'selected for editing');
+    UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [id] });
+  }
+
+  /// OBJECT HELPERS ////////////////////////////////////////////////////////////
+  /// these probably should go into a utility class
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** Return array of objects that match the match_me object keys/values
+    NOTE: make sure that strings are compared with strings, etc
+   */
+  m_FindMatchingObjsByProp(obj_list, match_me = {}) {
+    // operate on arrays only
+    if (!Array.isArray(obj_list))
+      throw Error('FindMatchingObjectsByProp arg1 must be array');
+    let matches = obj_list.filter(obj => {
+      let pass = true;
+      for (let key in match_me) {
+        if (match_me[key] !== obj[key]) pass = false;
+        break;
+      }
+      return pass;
+    });
+    // return array of matches (can be empty array)
+    return matches;
+  }
+
+  /// EDGE HELPERS //////////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** Return array of nodes that match the match_me object keys/values
+    NOTE: make sure that strings are compared with strings, etc
+   */
+  m_FindMatchingEdgeByProp(match_me = {}) {
+    return this.m_FindMatchingObjsByProp(this.state.edges, match_me);
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** Convenience function to retrieve edge by ID
+   */
+  m_FindEdgeById(id) {
+    return this.m_FindMatchingEdgeByProp({ id })[0];
+  }
+
+  /// REACT LIFECYCLE METHODS ///////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** This is not yet implemented as of React 16.2.  It's implemented in 16.3.
+      getDerivedStateFromProps (props, state) {
+        console.error('getDerivedStateFromProps!!!');
+      }
+   */
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /**
+   */
+  render() {
+    let {
+      edges,
+      edgeDefs,
+      selectedEdgeId,
+      selectedEdgeColor,
+      disableEdit,
+      isLocked
+    } = this.state;
+    if (edgeDefs.category === undefined) {
+      // for backwards compatability
+      edgeDefs.category = {};
+      edgeDefs.category.label = '';
+      edgeDefs.category.hidden = true;
+    }
+    const { tableHeight } = this.props;
+    const styles = `thead, tbody { font-size: 0.8em }
+                    .table {
+                      display: table; /* override bootstrap for fixed header */
+                      border-spacing: 0;
+                    }
+                    .table th {
+                      position: -webkit-sticky;
+                      position: sticky;
+                      top: 0;
+                      background-color: #eafcff;
+                      border-top: none;
+                    }
+                    xtbody { overflow: auto; }
+                    .btn-sm { font-size: 0.6rem; padding: 0.1rem 0.2rem }
+                    `;
+
+    const uid = CMTMGR.GetCurrentUserId();
+
+    let attributeDefs = Object.keys(edgeDefs).filter(
+      k => !BUILTIN_FIELDS_EDGE.includes(k)
+    );
+
+    // show 'type' between 'source' and 'target' if `type` has been defined
+    // if it isn't defined, just show attribute fields after `source` and 'target`
+    const hasTypeField = edgeDefs['type'];
+    if (hasTypeField) attributeDefs = attributeDefs.filter(a => a !== 'type');
+
+    /// TABLE DATA GENERATION
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    const TABLEDATA = edges.map((edge, i) => {
+      const { id, source, target, sourceLabel, targetLabel, type } = edge;
+
+      const sourceDef = { id: source, label: sourceLabel };
+      const targetDef = { id: target, label: targetLabel };
+
+      // custom attributes
+      const attributes = {};
+      attributeDefs.forEach((key, i) => {
+        let data = {};
+        if (edgeDefs[key].type === 'markdown') {
+          // for markdown:
+          // a. provide the raw markdown string
+          // b. provide the HTML string
+          data.html = NCUI.Markdownify(edge[key]);
+          data.raw = edge[key];
+        } else if (edgeDefs[key].type === 'hdate')
+          data = edge[key] && edge[key].formattedDateString;
+        else data = edge[key];
+        attributes[key] = data;
+      });
+
+      // comment button definition
+      const cref = CMTMGR.GetNodeCREF(id);
+      const commentCount = CMTMGR.GetThreadedViewObjectsCount(cref, uid);
+      const ccol = CMTMGR.GetCommentCollection(cref) || {};
+      const hasUnreadComments = ccol.hasUnreadComments;
+      const selected = selectedEdgeId === id;
+      const commentVBtnDef = {
+        cref,
+        count: commentCount,
+        hasUnreadComments,
+        selected
+      };
+
+      return {
+        id,
+        sourceDef,
+        targetDef,
+        type,
+        ...attributes,
+        commentVBtnDef
+      };
+    });
+    console.log('TABLEDATA', TABLEDATA);
+
+    /// CLICK HANDLERS
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    function ui_ClickViewEdge(event, edgeId) {
+      event.preventDefault();
+      event.stopPropagation();
+      // REVIEW Is this necessary?
+      const edgeID = parseInt(edgeId);
+      // let edge = this.m_FindEdgeById(edgeID);
+      // REVIEW: should we be looking up from the local `edges`? or bind tothis?
+      const edge = edges.find(e => e.id === edgeID);
+      if (DBG) console.log('EdgeTable: Edge id', edge.id, 'selected for viewing');
+      // Load Source Node then Edge
+      UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [edge.source] }).then(() => {
+        UDATA.LocalCall('EDGE_SELECT', { edgeId: edge.id });
+      });
+    }
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    function ui_ClickViewNode(event, nodeId) {
+      event.preventDefault();
+      event.stopPropagation();
+      UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [parseInt(nodeId)] });
+    }
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    function ui_ClickComment(cref) {
+      const position = CMTMGR.GetCommentThreadPosition(u_GetButtonId(cref));
+      CMTMGR.OpenCommentThread(cref, position);
+    }
+    /// RENDERERS
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    function RenderViewOrEdit(value) {
+      return (
+        <button className="outline" onClick={event => ui_ClickViewEdge(event, value)}>
+          {ICON_VIEW}
+        </button>
+      );
+    }
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // interface TTblNodeObject {
+    //   id: String;
+    //   label: String;
+    // }
+    function RenderNode(value) {
+      if (!value) return; // skip if not defined yet
+      if (value.id === undefined)
+        throw new Error('RenderNode: value.id is undefined');
+      if (value.label === undefined)
+        throw new Error('RenderNode: value.label is undefined');
+      return (
+        <button
+          className="outline"
+          onClick={event => ui_ClickViewNode(event, value.id)}
+        >
+          <span style={{ color: 'blue' }}>{value.label}</span>
+        </button>
+      );
+    }
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    function RenderCommentBtn(value) {
+      return (
+        <URCommentVBtn
+          id={u_GetButtonId(value.cref)}
+          count={value.count}
+          hasUnreadComments={value.hasUnreadComments}
+          selected={value.selected}
+          cb={e => ui_ClickComment(value.cref)}
+        />
+      );
+    }
+    /// CUSTOM SORTERS
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    /// tdata = TTblNodeObject[] = { id: String, label: String }
+    function SortNodes(key, tdata, order) {
+      const sortedData = [...tdata].sort((a, b) => {
+        console.log('node sort a', a, 'b', b);
+        if (a[key].label < b[key].label) return order;
+        if (a[key].label > b[key].label) return order * -1;
+        return 0;
+      });
+      return sortedData;
+    }
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    function SortCommentsByCount(key, tdata, order) {
+      const sortedData = [...tdata].sort((a, b) => {
+        console.log('comment sort a', a, 'b', b);
+        if (a[key].count < b[key].count) return order;
+        if (a[key].count > b[key].count) return order * -1;
+        return 0;
+      });
+      return sortedData;
+    }
+    /// TABLE DATA SPECIFICATIONS
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // column definitions for custom attributes
+    // (built in columns are: view, degrees, label)
+    const ATTRIBUTE_COLUMNDEFS = attributeDefs.map(key => {
+      let title = String(key);
+      title = title.charAt(0).toUpperCase() + title.slice(1).toLowerCase();
+      let type = edgeDefs[key].type;
+      return {
+        title,
+        type,
+        data: key
+      };
+    });
+    const COLUMNDEFS = [
+      {
+        title: '-', // View/Edit
+        data: 'id',
+        type: 'number',
+        width: 50, // in px
+        renderer: RenderViewOrEdit
+      },
+      {
+        title: 'Source.',
+        width: 130, // in px
+        data: 'sourceDef',
+        renderer: RenderNode,
+        sorter: SortNodes
+      },
+      {
+        title: 'Type',
+        type: 'text',
+        width: 130, // in px
+        data: 'type'
+      },
+      {
+        title: 'Target.',
+        width: 130, // in px
+        data: 'targetDef',
+        renderer: RenderNode,
+        sorter: SortNodes
+      },
+      ...ATTRIBUTE_COLUMNDEFS,
+      {
+        title: 'Comments',
+        data: 'commentVBtnDef',
+        type: 'text',
+        width: 50, // in px
+        renderer: RenderCommentBtn,
+        sorter: SortCommentsByCount
+      }
+    ];
+
+    return (
+      <div className="NCEdgeTable" style={{ height: tableHeight }}>
+        <URTable data={TABLEDATA} columns={COLUMNDEFS} />
+      </div>
+    );
+  }
+} // class EdgeTable
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = NCEdgeTable;

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -633,7 +633,7 @@ class NCEdgeTable extends UNISYS.Component {
         renderer: RenderViewOrEdit
       },
       {
-        title: 'Source.',
+        title: 'Source',
         width: 130, // in px
         data: 'sourceDef',
         renderer: RenderNode,
@@ -646,7 +646,7 @@ class NCEdgeTable extends UNISYS.Component {
         data: 'type'
       },
       {
-        title: 'Target.',
+        title: 'Target',
         width: 130, // in px
         data: 'targetDef',
         renderer: RenderNode,

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -49,7 +49,7 @@ var UDATA = null;
 /// UTILITY METHODS ///////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function u_GetButtonId(cref) {
-  return `comment-button-${cref}`;
+  return `table-comment-button-${cref}`;
 }
 
 /// REACT COMPONENT ///////////////////////////////////////////////////////////
@@ -543,9 +543,11 @@ class NCEdgeTable extends UNISYS.Component {
       UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [parseInt(nodeId)] });
     }
     /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    /// Toggle Comment Button on and off
     function ui_ClickComment(cref) {
       const position = CMTMGR.GetCommentThreadPosition(u_GetButtonId(cref));
-      CMTMGR.OpenCommentThread(cref, position);
+      const uiref = u_GetButtonId(cref);
+      CMTMGR.ToggleCommentCollection(uiref, cref, position);
     }
     /// RENDERERS
     /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -626,12 +626,6 @@ class NCEdgeTable extends UNISYS.Component {
    */
   render() {
     const { edges, edgeDefs, disableEdit, isLocked, COLUMNDEFS } = this.state;
-    if (edgeDefs.category === undefined) {
-      // for backwards compatability
-      edgeDefs.category = {};
-      edgeDefs.category.label = '';
-      edgeDefs.category.hidden = true;
-    }
     const { isOpen, tableHeight } = this.props;
     const uid = CMTMGR.GetCurrentUserId();
 

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -580,7 +580,7 @@ class NCEdgeTable extends UNISYS.Component {
     function RenderCommentBtn(value) {
       return (
         <URCommentVBtn
-          id={u_GetButtonId(value.cref)}
+          uiref={u_GetButtonId(value.cref)}
           count={value.count}
           hasUnreadComments={value.hasUnreadComments}
           selected={value.selected}

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -663,6 +663,11 @@ class NCEdgeTable extends UNISYS.Component {
         sorter: SortCommentsByCount
       }
     ];
+    // Only include built in fields
+    // Only include non-hidden fields
+    let attributeDefs = Object.keys(edgeDefs).filter(
+      k => !BUILTIN_FIELDS_EDGE.includes(k) && !edgeDefs[k].hidden
+    );
 
     return (
       <div className="NCEdgeTable" style={{ height: tableHeight }}>

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -228,16 +228,16 @@ class NCEdgeTable extends UNISYS.Component {
         FILTERDEFS.filterAction === FILTER.ACTION.REDUCE ||
         FILTERDEFS.filterAction === FILTER.ACTION.FOCUS
       ) {
+        // Reduce (remove) or Focus
         edges = edges.filter(edge => {
-          const filteredEdge = filteredEdges.find(n => n.id === edge.id);
+          const filteredEdge = filteredEdges.find(e => e.id === edge.id);
           return filteredEdge; // keep if it's in the list of filtered edges
         });
       } else {
-        edges = edges.map(edge => {
-          const filteredEdge = filteredEdges.find(n => n.id === edge.id);
-          edge.isFiltered = !filteredEdge;
-          return edge;
-        });
+        // Fade
+        // Fading is handled by setting node.filteredTransparency which is
+        // directly handled by the filter now.  So no need to process it
+        // here in the table.
       }
     }
     this.setState({ edges });
@@ -691,7 +691,6 @@ class NCEdgeTable extends UNISYS.Component {
         ...attributes,
         commentVBtnDef,
         meta: {
-          isFiltered: edge.isFiltered,
           filteredTransparency: edge.filteredTransparency
         }
       };

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -1,0 +1,442 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  ## OVERVIEW
+
+    NCNodeTable is used to to display a table of nodes for review.
+
+    It displays NCDATA.
+    But also checks FILTEREDNCDATA to show highlight/filtered state
+
+    This is intended to be a generic table implementation that enables
+    swapping in different table implementations.
+
+    This is an abstraction of the original NodeTable component to make
+    it easier to swap in custom table components.
+
+
+  ## TO USE
+
+    NCNodeTable is self contained and relies on global NCDATA to load.
+
+      <NCNodeTable/>
+
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+const React = require('react');
+const NCUI = require('../nc-ui');
+const CMTMGR = require('../comment-mgr');
+const SETTINGS = require('settings');
+const FILTER = require('./filter/FilterEnums');
+const { BUILTIN_FIELDS_NODE } = require('system/util/enum');
+const UNISYS = require('unisys/client');
+import HDATE from 'system/util/hdate';
+import URTable from './URTable';
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+var DBG = false;
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const isLocalHost =
+  SETTINGS.EJSProp('client').ip === '127.0.0.1' ||
+  location.href.includes('admin=true');
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+var UDATA = null;
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// export a class object for consumption by brunch/require
+class NCNodeTable extends UNISYS.Component {
+  constructor(props) {
+    super(props);
+
+    const TEMPLATE = this.AppState('TEMPLATE');
+    this.state = {
+      nodeDefs: TEMPLATE.nodeDefs,
+      nodes: [],
+      selectedNodeId: undefined,
+      hilitedNodeId: undefined,
+      selectedNodeColor: TEMPLATE.sourceColor,
+      hilitedNodeColor: TEMPLATE.searchColor,
+      filteredNodes: [],
+      disableEdit: false,
+      isLocked: false,
+      isExpanded: true,
+      sortkey: 'label'
+    };
+
+    this.onStateChange_SESSION = this.onStateChange_SESSION.bind(this);
+    this.onStateChange_SELECTION = this.onStateChange_SELECTION.bind(this);
+    this.onStateChange_HILITE = this.onStateChange_HILITE.bind(this);
+    this.displayUpdated = this.displayUpdated.bind(this);
+    this.updateNodeFilterState = this.updateNodeFilterState.bind(this);
+    this.updateEditState = this.updateEditState.bind(this);
+    this.handleDataUpdate = this.handleDataUpdate.bind(this);
+    this.handleFilterDataUpdate = this.handleFilterDataUpdate.bind(this);
+    this.OnTemplateUpdate = this.OnTemplateUpdate.bind(this);
+    this.onViewButtonClick = this.onViewButtonClick.bind(this);
+    this.onEditButtonClick = this.onEditButtonClick.bind(this);
+    this.onToggleExpanded = this.onToggleExpanded.bind(this);
+    this.onHighlightRow = this.onHighlightRow.bind(this);
+
+    this.sortDirection = 1; // alphabetical A-Z
+
+    /// Initialize UNISYS DATA LINK for REACT
+    UDATA = UNISYS.NewDataLink(this);
+
+    UDATA.HandleMessage('EDIT_PERMISSIONS_UPDATE', this.updateEditState);
+
+    // SESSION is called by SessionSHell when the ID changes
+    //  set system-wide. data: { classId, projId, hashedId, groupId, isValid }
+    this.OnAppStateChange('SESSION', this.onStateChange_SESSION);
+
+    // Always make sure class methods are bind()'d before using them
+    // as a handler, otherwise object context is lost
+    this.OnAppStateChange('NCDATA', this.handleDataUpdate);
+
+    // Track Filtered Data Updates too
+    this.OnAppStateChange('FILTEREDNCDATA', this.handleFilterDataUpdate);
+
+    // Handle Template updates
+    this.OnAppStateChange('TEMPLATE', this.OnTemplateUpdate);
+
+    this.OnAppStateChange('SELECTION', this.onStateChange_SELECTION);
+    this.OnAppStateChange('HILITE', this.onStateChange_HILITE);
+  } // constructor
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /**
+   */
+  componentDidMount() {
+    if (DBG) console.error('NodeTable.componentDidMount!');
+
+    this.onStateChange_SESSION(this.AppState('SESSION'));
+
+    // Explicitly retrieve data because we may not have gotten a NCDATA
+    // update while we were hidden.
+    // filtered data needs to be set before D3Data
+    const FILTEREDNCDATA = UDATA.AppState('FILTEREDNCDATA');
+    this.setState({ filteredNodes: FILTEREDNCDATA.nodes }, () => {
+      let NCDATA = this.AppState('NCDATA');
+      this.handleDataUpdate(NCDATA);
+    });
+
+    // Request edit state too because the update may have come
+    // while we were hidden
+    this.updateEditState();
+  }
+
+  componentWillUnmount() {
+    UDATA.UnhandleMessage('EDIT_PERMISSIONS_UPDATE', this.updateEditState);
+    this.AppStateChangeOff('SESSION', this.onStateChange_SESSION);
+    this.AppStateChangeOff('NCDATA', this.handleDataUpdate);
+    this.AppStateChangeOff('FILTEREDNCDATA', this.handleFilterDataUpdate);
+    this.AppStateChangeOff('TEMPLATE', this.OnTemplateUpdate);
+    this.AppStateChangeOff('SELECTION', this.onStateChange_SELECTION);
+    this.AppStateChangeOff('HILITE', this.onStateChange_HILITE);
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  onStateChange_SELECTION(data) {
+    this.setState({
+      selectedNodeId: data.nodes.length > 0 ? data.nodes[0].id : undefined
+    });
+  }
+
+  onStateChange_HILITE(data) {
+    const { userHighlightNodeId, autosuggestHiliteNodeId } = data; // ignores `tableHiliteNodeId`
+    let hilitedNodeId;
+    if (autosuggestHiliteNodeId !== undefined)
+      hilitedNodeId = autosuggestHiliteNodeId;
+    if (userHighlightNodeId !== undefined) hilitedNodeId = userHighlightNodeId;
+    this.setState({ hilitedNodeId });
+  }
+
+  /** Handle change in SESSION data
+    Called both by componentWillMount() and AppStateChange handler.
+    The 'SESSION' state change is triggered in two places in SessionShell during
+    its handleChange() when active typing is occuring, and also during
+    SessionShell.componentWillMount()
+   */
+  onStateChange_SESSION(decoded) {
+    this.setState({ isLocked: !decoded.isValid });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  displayUpdated(nodeEdge) {
+    // Prevent error if `meta` info is not defined yet, or not properly imported
+
+    // this does not ever fire, revert!
+    console.error('NodeTable meta not defined yet', nodeEdge);
+    if (!nodeEdge.meta) {
+      return '';
+    }
+    var d = new Date(
+      nodeEdge.meta.revision > 0 ? nodeEdge.meta.updated : nodeEdge.meta.created
+    );
+
+    var year = String(d.getFullYear());
+    var date = d.getMonth() + 1 + '/' + d.getDate() + '/' + year.substr(2, 4);
+    var time = d.toTimeString().substr(0, 5);
+    var dateTime = date + ' at ' + time;
+    var titleString = 'v' + nodeEdge.meta.revision;
+    if (nodeEdge._nlog)
+      titleString += ' by ' + nodeEdge._nlog[nodeEdge._nlog.length - 1];
+    var tag = <span title={titleString}> {dateTime} </span>;
+
+    return tag;
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// Set node filtered status based on current filteredNodes
+  updateNodeFilterState(nodes, filteredNodes) {
+    // set filter status
+    if (filteredNodes.length > 0) {
+      // If we're transitioning from "HILIGHT/FADE" to "COLLAPSE" or "FOCUS", then we
+      // also need to remove nodes that are not in filteredNodes
+      const FILTERDEFS = UDATA.AppState('FILTERDEFS');
+      if (
+        FILTERDEFS.filterAction === FILTER.ACTION.REDUCE ||
+        FILTERDEFS.filterAction === FILTER.ACTION.FOCUS
+      ) {
+        nodes = nodes.filter(node => {
+          const filteredNode = filteredNodes.find(n => n.id === node.id);
+          return filteredNode; // keep if it's in the list of filtered nodes
+        });
+      } else {
+        nodes = nodes.map(node => {
+          const filteredNode = filteredNodes.find(n => n.id === node.id);
+          node.isFiltered = !filteredNode; // not in filteredNode, so it's been removed
+          return node;
+        });
+      }
+    }
+    this.setState({ nodes, filteredNodes });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  updateEditState() {
+    // disable edit if someone else is editing a template, node, or edge
+    let disableEdit = false;
+    UDATA.NetCall('SRV_GET_EDIT_STATUS').then(data => {
+      // someone else might be editing a template or importing or editing node or edge
+      disableEdit =
+        data.templateBeingEdited ||
+        data.importActive ||
+        data.nodeOrEdgeBeingEdited ||
+        data.commentBeingEditedByMe; // only lock out if this user is the one editing comments, allow network commen edits
+      this.setState({ disableEdit });
+    });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** Handle updated SELECTION
+   */
+  handleDataUpdate(data) {
+    if (DBG) console.log('handle data update');
+    if (data.nodes) {
+      // const nodes = this.sortTable(this.state.sortkey, data.nodes);
+      const nodes = data.nodes;
+      const { filteredNodes } = this.state;
+      this.updateNodeFilterState(nodes, filteredNodes);
+    }
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  handleFilterDataUpdate(data) {
+    if (data.nodes) {
+      const filteredNodes = data.nodes;
+      // If we're transitioning from "COLLAPSE" or "FOCUS" to "HILIGHT/FADE", then we
+      // also need to add back in nodes that are not in filteredNodes
+      // (because "COLLAPSE" and "FOCUS" removes nodes that are not matched)
+      const FILTERDEFS = UDATA.AppState('FILTERDEFS');
+      if (FILTERDEFS.filterAction === FILTER.ACTION.FADE) {
+        const NCDATA = UDATA.AppState('NCDATA');
+        this.setState(
+          {
+            nodes: NCDATA.nodes,
+            filteredNodes
+          },
+          () => {
+            const nodes = this.sortTable(this.state.sortkey, NCDATA.nodes);
+            this.updateNodeFilterState(nodes, filteredNodes);
+          }
+        );
+      } else {
+        this.setState(
+          {
+            nodes: filteredNodes,
+            filteredNodes
+          },
+          () => {
+            const nodes = this.sortTable(this.state.sortkey, filteredNodes);
+            this.updateNodeFilterState(nodes, filteredNodes);
+          }
+        );
+      }
+    }
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  OnTemplateUpdate(data) {
+    this.setState({
+      nodeDefs: data.nodeDefs,
+      selectedNodeColor: data.sourceColor,
+      hilitedNodeColor: data.searchColor
+    });
+  }
+
+  /// UTILITIES /////////////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  /// UI EVENT HANDLERS /////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /**
+   */
+  onViewButtonClick(event, nodeId) {
+    event.preventDefault();
+    event.stopPropagation();
+    let nodeID = parseInt(nodeId);
+    UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [nodeID] });
+  }
+  /**
+   */
+  onEditButtonClick(event, nodeId) {
+    event.preventDefault();
+    event.stopPropagation();
+    let nodeID = parseInt(nodeId);
+    UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [nodeID] }).then(() => {
+      if (DBG) console.error('NodeTable: Calling NODE_EDIT', nodeID);
+      UDATA.LocalCall('NODE_EDIT', { nodeID: nodeID });
+    });
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /**
+   */
+  onToggleExpanded(event) {
+    this.setState({
+      isExpanded: !this.state.isExpanded
+    });
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /**
+   */
+  onHighlightRow(nodeId) {
+    UDATA.LocalCall('TABLE_HILITE_NODE', { nodeId });
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /**
+   */
+  selectNode(id, event) {
+    event.preventDefault();
+
+    // REVIEW: For some reason React converts the integer IDs into string
+    // values when returned in event.target.value.  So we have to convert
+    // it here.
+    // Load Source
+    UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [parseInt(id)] });
+  }
+
+  /// REACT LIFECYCLE METHODS ///////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /*/ This is not yet implemented as of React 16.2.  It's implemented in 16.3.
+    getDerivedStateFromProps (props, state) {
+      console.error('getDerivedStateFromProps!!!');
+    }
+  /*/
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /**
+   */
+  render() {
+    const {
+      nodes,
+      nodeDefs,
+      selectedNodeId,
+      hilitedNodeId,
+      selectedNodeColor,
+      hilitedNodeColor,
+      disableEdit,
+      isLocked
+    } = this.state;
+    if (nodes === undefined) return '';
+    const { tableHeight } = this.props;
+
+    const uid = CMTMGR.GetCurrentUserId();
+
+    const attributeDefs = Object.keys(nodeDefs).filter(
+      k => !BUILTIN_FIELDS_NODE.includes(k)
+    );
+
+    const TABLEDATA = nodes.map((node, i) => {
+      const { id, label, degrees } = node;
+
+      // custom attributes
+      const attributes = {};
+      attributeDefs.forEach((key, i) => {
+        let data;
+        if (nodeDefs[key].type === 'markdown') data = NCUI.Markdownify(node[key]);
+        else if (nodeDefs[key].type === 'hdate')
+          data = node[key] && node[a].formattedDatString;
+        else data = node[key];
+        attributes[key] = data;
+      });
+
+      // comment button definition
+      const cref = CMTMGR.GetNodeCREF(id);
+      const commentCount = CMTMGR.GetThreadedViewObjectsCount(cref, uid);
+      const ccol = CMTMGR.GetCommentCollection(cref) || {};
+      const hasUnreadComments = ccol.hasUnreadComments;
+      const selected = selectedNodeId === id;
+      const commentVBtnDef = {
+        cref,
+        count: commentCount,
+        hasUnreadComments,
+        selected
+      };
+
+      return {
+        id,
+        label,
+        degrees,
+        ...attributes,
+        commentVBtnDef
+      };
+    });
+
+    // column definitions for custom attributes
+    // (built in columns are: view, degrees, label)
+    const ATTRIBUTE_COLUMNDEFS = attributeDefs.map(key => {
+      let title = String(key);
+      title = title.charAt(0).toUpperCase() + title.slice(1).toLowerCase();
+      let type = 'text';
+      if (nodeDefs[key].type === 'markdown') type = 'text';
+      else if (nodeDefs[key].type === 'hdate') type = 'date';
+      return {
+        title,
+        type,
+        data: key
+      };
+    });
+
+    return (
+      <div
+        className="NCNodeTable"
+        style={{
+          overflow: 'auto',
+          position: 'relative',
+          display: 'block',
+          left: '1px',
+          right: '10px',
+          height: tableHeight,
+          backgroundColor: '#eafcff'
+        }}
+      >
+        <URTable data={TABLEDATA} attributeColumndefs={ATTRIBUTE_COLUMNDEFS} />
+      </div>
+    );
+  }
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = NCNodeTable;

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -482,7 +482,7 @@ class NCNodeTable extends UNISYS.Component {
     function RenderCommentBtn(value) {
       return (
         <URCommentVBtn
-          id={u_GetButtonId(value.cref)}
+          uiref={u_GetButtonId(value.cref)}
           count={value.count}
           hasUnreadComments={value.hasUnreadComments}
           selected={value.selected}

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -501,18 +501,7 @@ class NCNodeTable extends UNISYS.Component {
     ];
 
     return (
-      <div
-        className="NCNodeTable"
-        style={{
-          overflow: 'auto',
-          position: 'relative',
-          display: 'block',
-          left: '1px',
-          right: '10px',
-          height: tableHeight,
-          backgroundColor: '#eafcff'
-        }}
-      >
+      <div className="NCNodeTable" style={{ height: tableHeight }}>
         <URTable data={TABLEDATA} columns={COLUMNDEFS} />
       </div>
     );

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -273,9 +273,9 @@ class NCNodeTable extends UNISYS.Component {
       // If we're transitioning from "COLLAPSE" or "FOCUS" to "HILIGHT/FADE", then we
       // also need to add back in nodes that are not in filteredNodes
       // (because "COLLAPSE" and "FOCUS" removes nodes that are not matched)
+      const NCDATA = UDATA.AppState('NCDATA');
       const FILTERDEFS = UDATA.AppState('FILTERDEFS');
       if (FILTERDEFS.filterAction === FILTER.ACTION.FADE) {
-        const NCDATA = UDATA.AppState('NCDATA');
         this.setState(
           {
             nodes: NCDATA.nodes,
@@ -415,8 +415,6 @@ class NCNodeTable extends UNISYS.Component {
       const commentCount = CMTMGR.GetThreadedViewObjectsCount(cref, uid);
       const ccol = CMTMGR.GetCommentCollection(cref) || {};
       const hasUnreadComments = ccol.hasUnreadComments;
-      const uiref = u_GetButtonId(cref); // comment button id is ${cref}${uuiid}
-
       const selected = CMTMGR.GetOpenComments(cref);
       const commentVBtnDef = {
         cref,
@@ -518,7 +516,6 @@ class NCNodeTable extends UNISYS.Component {
     /// tdata = TTblNodeObject[] = { id: String, label: String }
     function SortNodes(key, tdata, order) {
       const sortedData = [...tdata].sort((a, b) => {
-        console.log('node sort a', a, 'b', b);
         if (a[key].label < b[key].label) return order;
         if (a[key].label > b[key].label) return order * -1;
         return 0;
@@ -528,7 +525,6 @@ class NCNodeTable extends UNISYS.Component {
     /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     function SortCommentsByCount(key, tdata, order) {
       const sortedData = [...tdata].sort((a, b) => {
-        console.log('comment sort a', a, 'b', b);
         if (a[key].count < b[key].count) return order;
         if (a[key].count > b[key].count) return order * -1;
         return 0;

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -38,6 +38,7 @@ const { ICON_PENCIL, ICON_VIEW } = require('system/util/constant');
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const DBG = false;
+let UDATA = null;
 
 /// UTILITY METHODS ///////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -410,7 +411,7 @@ class NCNodeTable extends UNISYS.Component {
 
     /// CLICK HANDLERS
     /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    function ui_ClickViewComment(event, nodeId) {
+    function ui_ClickViewNode(event, nodeId) {
       event.preventDefault();
       event.stopPropagation();
       UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [parseInt(nodeId)] });
@@ -424,10 +425,7 @@ class NCNodeTable extends UNISYS.Component {
     /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     function RenderViewOrEdit(value) {
       return (
-        <button
-          className="outline"
-          onClick={event => ui_ClickViewComment(event, value)}
-        >
+        <button className="outline" onClick={event => ui_ClickViewNode(event, value)}>
           {ICON_VIEW}
         </button>
       );
@@ -493,7 +491,6 @@ class NCNodeTable extends UNISYS.Component {
       {
         title: 'Comments',
         data: 'commentVBtnDef',
-        type: 'text',
         width: 50, // in px
         renderer: RenderCommentBtn,
         sorter: SortCommentsByCount

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -231,16 +231,16 @@ class NCNodeTable extends UNISYS.Component {
         FILTERDEFS.filterAction === FILTER.ACTION.REDUCE ||
         FILTERDEFS.filterAction === FILTER.ACTION.FOCUS
       ) {
+        // Reduce (remove) or Focus
         nodes = nodes.filter(node => {
           const filteredNode = filteredNodes.find(n => n.id === node.id);
           return filteredNode; // keep if it's in the list of filtered nodes
         });
       } else {
-        nodes = nodes.map(node => {
-          const filteredNode = filteredNodes.find(n => n.id === node.id);
-          node.isFiltered = !filteredNode; // not in filteredNode, so it's been removed
-          return node;
-        });
+        // Fade
+        // Fading is handled by setting node.filteredTransparency which is
+        // directly handled by the filter now.  So no need to process it
+        // here in the table.
       }
     }
     this.setState({ nodes, filteredNodes });
@@ -597,7 +597,6 @@ class NCNodeTable extends UNISYS.Component {
         ...attributes,
         commentVBtnDef,
         meta: {
-          isFiltered: node.isFiltered,
           filteredTransparency: node.filteredTransparency
         }
       };

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -258,7 +258,9 @@ class NCNodeTable extends UNISYS.Component {
             filteredNodes
           },
           () => {
-            const nodes = this.sortTable(this.state.sortkey, NCDATA.nodes);
+            // FIXME: how to handle sorting?
+            // const nodes = this.sortTable(this.state.sortkey, NCDATA.nodes);
+            const nodes = NCDATA.nodes;
             this.updateNodeFilterState(nodes, filteredNodes);
           }
         );
@@ -269,7 +271,9 @@ class NCNodeTable extends UNISYS.Component {
             filteredNodes
           },
           () => {
-            const nodes = this.sortTable(this.state.sortkey, filteredNodes);
+            // FIXME: how to handle sorting?
+            // const nodes = this.sortTable(this.state.sortkey, filteredNodes);
+            const nodes = NCDATA.nodes;
             this.updateNodeFilterState(nodes, filteredNodes);
           }
         );
@@ -373,10 +377,15 @@ class NCNodeTable extends UNISYS.Component {
       // custom attributes
       const attributes = {};
       attributeDefs.forEach((key, i) => {
-        let data;
-        if (nodeDefs[key].type === 'markdown') data = NCUI.Markdownify(node[key]);
-        else if (nodeDefs[key].type === 'hdate')
-          data = node[key] && node[a].formattedDatString;
+        let data = {};
+        if (nodeDefs[key].type === 'markdown') {
+          // for markdown:
+          // a. provide the raw markdown string
+          // b. provide the HTML string
+          data.html = NCUI.Markdownify(node[key]);
+          data.raw = node[key];
+        } else if (nodeDefs[key].type === 'hdate')
+          data = node[key] && node[key].formattedDateString;
         else data = node[key];
         attributes[key] = data;
       });
@@ -408,9 +417,7 @@ class NCNodeTable extends UNISYS.Component {
     const ATTRIBUTE_COLUMNDEFS = attributeDefs.map(key => {
       let title = String(key);
       title = title.charAt(0).toUpperCase() + title.slice(1).toLowerCase();
-      let type = 'text';
-      if (nodeDefs[key].type === 'markdown') type = 'text';
-      else if (nodeDefs[key].type === 'hdate') type = 'date';
+      let type = nodeDefs[key].type;
       return {
         title,
         type,

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -383,8 +383,10 @@ class NCNodeTable extends UNISYS.Component {
 
     const uid = CMTMGR.GetCurrentUserId();
 
+    // Only include built in fields
+    // Only include non-hidden fields
     const attributeDefs = Object.keys(nodeDefs).filter(
-      k => !BUILTIN_FIELDS_NODE.includes(k)
+      k => !BUILTIN_FIELDS_NODE.includes(k) && !nodeDefs[k].hidden
     );
 
     /// TABLE DATA GENERATION

--- a/app/view/netcreate/components/Template.jsx
+++ b/app/view/netcreate/components/Template.jsx
@@ -36,6 +36,7 @@ const UNISYS = require('unisys/client');
 const { EDITORTYPE } = require('system/util/enum');
 const TEMPLATE_MGR = require('../templateEditor-mgr');
 const SCHEMA = require('../template-schema');
+const DATASTORE = require('system/datastore');
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -59,7 +60,8 @@ class Template extends UNISYS.Component {
       // edgeTypeOptions
       tomlfile: undefined,
       tomlfileStatus: '',
-      tomlfileErrors: undefined
+      tomlfileErrors: undefined,
+      tomlfilename: 'loading...'
     };
     this.loadEditor = this.loadEditor.bind(this);
     this.updateEditState = this.updateEditState.bind(this);
@@ -80,6 +82,9 @@ class Template extends UNISYS.Component {
 
   componentDidMount() {
     this.updateEditState();
+    DATASTORE.GetTemplateTOMLFileName().then(result => {
+      this.setState({ tomlfilename: result.filename });
+    });
   }
 
   componentWillUnmount() {
@@ -266,9 +271,16 @@ class Template extends UNISYS.Component {
   /// REACT LIFECYCLE METHODS ///////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   render() {
-    const { disableEdit, isBeingEdited, tomlfile, tomlfileStatus, tomlfileErrors } =
-      this.state;
+    const {
+      disableEdit,
+      isBeingEdited,
+      tomlfile,
+      tomlfileStatus,
+      tomlfileErrors,
+      tomlfilename
+    } = this.state;
     let editorjsx;
+
     if (disableEdit && !isBeingEdited) {
       // Node or Edge is being edited, show disabled message
       editorjsx = (
@@ -362,6 +374,10 @@ class Template extends UNISYS.Component {
           padding: '10px 20px'
         }}
       >
+        <h4>Template Editor</h4>
+        <p>
+          <label>Current Template File Name:</label> <code>{tomlfilename}</code>
+        </p>
         {editorjsx}
         <div hidden={!isBeingEdited}>
           <Button onClick={this.onCancelEdit} size="sm" outline>

--- a/app/view/netcreate/components/URComment.css
+++ b/app/view/netcreate/components/URComment.css
@@ -541,9 +541,13 @@ svg#comment-icon {
   height: 24px;
 }
 .URCommentVBtn > .count {
-  display: inline-block;
-  margin-left: -16px;
+  height: 24px;
+  width: 24px;
+  margin-top: -21px;
   color: #fff;
+  font-size: 10px;
+  font-weight: bold;
+  text-align: center;
 }
 .URCommentVBtn > .count.unread {
   color: var(--comment-status-font-color);

--- a/app/view/netcreate/components/URComment.css
+++ b/app/view/netcreate/components/URComment.css
@@ -12,6 +12,7 @@
 /* Comment Bar ------------------------------------------------------------- */
 #comment-bar {
   display: flex;
+  align-self: flex-start;
   margin-top: 6px;
   font-size: 0.8rem;
   z-index: 2000;
@@ -84,6 +85,7 @@
   width: fit-content;
   padding: 3px 7px;
   float: right;
+  margin-right: 150px; /* clear "login feedback" */
 }
 #comment-summary.expanded {
   display: none;

--- a/app/view/netcreate/components/URComment.css
+++ b/app/view/netcreate/components/URComment.css
@@ -3,7 +3,8 @@
   --comment-bg-light: #f1e9c5ee;
   --comment-bg-new: #d84a00;
   --comment-bg-new-light: #d84a0088;
-  --comment-status-font-color: #d84a0088;
+  --comment-commenter-font-color: #333;
+  --comment-status-font-color: #d44127; /* <= evan's, orig => #d84a0088; */
   --comment-system-font-color: #0003;
   --disabled-opacity: 0.5;
 }
@@ -318,6 +319,7 @@ svg#comment-icon {
 
 .commentThread .label,
 .comment .commenter,
+.comment label,
 .comment .label,
 .comment .help /* .help uses nccomponent */,
 .comment .commentId,
@@ -358,6 +360,7 @@ svg#comment-icon {
   color: var(--comment-status-font-color);
 }
 .comment .commenttext {
+  color: var(--comment-commenter-font-color);
   background-color: #fff5;
   padding-left: 3px;
   margin-bottom: 3px;
@@ -524,4 +527,24 @@ svg#comment-icon {
 }
 .comment .prompt button.notselected {
   opacity: 0.5;
+}
+
+/* URCommentVBtn */
+.URCommentVBtn {
+  display: inline-block;
+  cursor: pointer;
+  border: none;
+  background-color: transparent;
+}
+.URCommentVBtn svg {
+  width: 24px;
+  height: 24px;
+}
+.URCommentVBtn > .count {
+  display: inline-block;
+  margin-left: -16px;
+  color: #fff;
+}
+.URCommentVBtn > .count.unread {
+  color: var(--comment-status-font-color);
 }

--- a/app/view/netcreate/components/URComment.css
+++ b/app/view/netcreate/components/URComment.css
@@ -84,8 +84,6 @@
   cursor: pointer;
   width: fit-content;
   padding: 3px 7px;
-  float: right;
-  margin-right: 150px; /* clear "login feedback" */
 }
 #comment-summary.expanded {
   display: none;

--- a/app/view/netcreate/components/URComment.jsx
+++ b/app/view/netcreate/components/URComment.jsx
@@ -16,6 +16,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import UNISYS from 'unisys/client';
+import NetMessage from 'unisys/common-netmessage-class';
 import CMTMGR from '../comment-mgr';
 import URCommentPrompt from './URCommentPrompt';
 
@@ -69,9 +70,10 @@ function URComment({ cref, cid, uid }) {
   useEffect(() => {
     // declare helpers
     const urmsg_UpdatePermissions = data => {
+      const isLoggedIn = NetMessage.GlobalGroupID();
       setState(prevState => ({
         ...prevState,
-        uIsDisabled: data.commentBeingEditedByMe
+        uIsDisabled: data.commentBeingEditedByMe || !isLoggedIn
       }));
     };
     const urstate_UpdateCommentVObjs = () => c_LoadCommentVObj();

--- a/app/view/netcreate/components/URCommentBtn.jsx
+++ b/app/view/netcreate/components/URCommentBtn.jsx
@@ -101,6 +101,7 @@ function URCommentBtn({ cref, uuiid }) {
     UDATA.OnAppStateChange('COMMENTVOBJS', urstate_UpdateCommentVObjs);
     UDATA.HandleMessage('COMMENT_UPDATE_PERMISSIONS', urmsg_UpdatePermissions);
     UDATA.HandleMessage('COMMENT_SELECT', urmsg_COMMENT_SELECT);
+    UDATA.HandleMessage('CTHREADMGR_THREAD_OPENED', this.onUpdateCommentUI);
     window.addEventListener('resize', evt_OnResize);
 
     setPosition(c_GetCommentThreadPosition());
@@ -110,6 +111,7 @@ function URCommentBtn({ cref, uuiid }) {
       UDATA.AppStateChangeOff('COMMENTVOBJS', urstate_UpdateCommentVObjs);
       UDATA.UnhandleMessage('COMMENT_UPDATE_PERMISSIONS', urmsg_UpdatePermissions);
       UDATA.UnhandleMessage('COMMENT_SELECT', urmsg_COMMENT_SELECT);
+      UDATA.UnhandleMessage('CTHREADMGR_THREAD_OPENED', this.onUpdateCommentUI);
       window.removeEventListener('resize', evt_OnResize);
     };
   }, []);

--- a/app/view/netcreate/components/URCommentStatus.jsx
+++ b/app/view/netcreate/components/URCommentStatus.jsx
@@ -51,15 +51,13 @@ function URCommentStatus(props) {
 
   /** Component Effect - register listeners on mount */
   useEffect(() => {
-    UDATA.OnAppStateChange('COMMENTCOLLECTION', () => setDummy(dummy => dummy + 1)); // respond to close
-    UDATA.HandleMessage('COMMENTS_UPDATE', urmsg_COMMENTS_UPDATE);
+    UDATA.OnAppStateChange('COMMENTCOLLECTION', urmsg_DUMMY_COMMENTS_UPDATE); // respond to close
+    UDATA.HandleMessage('COMMENTS_UPDATE', urmsg_DUMMY_COMMENTS_UPDATE);
     UDATA.HandleMessage('COMMENT_UPDATE', urmsg_COMMENT_UPDATE);
 
     return () => {
-      UDATA.AppStateChangeOff('COMMENTCOLLECTION', () =>
-        setDummy(dummy => dummy + 1)
-      ); // respond to close
-      UDATA.UnhandleMessage('COMMENTS_UPDATE', urmsg_COMMENTS_UPDATE);
+      UDATA.AppStateChangeOff('COMMENTCOLLECTION', urmsg_DUMMY_COMMENTS_UPDATE); // respond to close
+      UDATA.UnhandleMessage('COMMENTS_UPDATE', urmsg_DUMMY_COMMENTS_UPDATE);
       UDATA.UnhandleMessage('COMMENT_UPDATE', urmsg_COMMENT_UPDATE);
     };
   }, []);
@@ -67,7 +65,7 @@ function URCommentStatus(props) {
   /// UR HANDLERS /////////////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /** force re-render after COMMENTS_UPDATE from a new comment another user */
-  function urmsg_COMMENTS_UPDATE() {
+  function urmsg_DUMMY_COMMENTS_UPDATE() {
     // This is necessary to force a re-render of the comment summaries
     // when the comment collection changes on the net
     setDummy(dummy => dummy + 1); // Trigger re-render

--- a/app/view/netcreate/components/URCommentStatus.jsx
+++ b/app/view/netcreate/components/URCommentStatus.jsx
@@ -21,6 +21,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import UNISYS from 'unisys/client';
 import NetMessage from 'unisys/common-netmessage-class';
 import CMTMGR from '../comment-mgr';
+import URCommentThreadMgr from './URCommentThreadMgr';
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -225,38 +226,41 @@ function URCommentStatus(props) {
   );
 
   return (
-    <div id="comment-bar">
-      <div
-        id="comment-alert"
-        className={`${activeCSS} ${uiIsExpanded ? ' expanded' : ''}`}
-      >
-        {!uiIsExpanded && <div className="comment-status-body">{message}</div>}
-      </div>
-      <div>
+    <div>
+      <URCommentThreadMgr />
+      <div id="comment-bar">
         <div
-          id="comment-summary"
-          className={`${uiIsExpanded ? ' expanded' : ''}`}
-          onClick={evt_ExpandPanel}
+          id="comment-alert"
+          className={`${activeCSS} ${uiIsExpanded ? ' expanded' : ''}`}
         >
-          {UnreadRepliesToMeButtonJSX}&nbsp;&nbsp;{UnreadButtonJSX}
+          {!uiIsExpanded && <div className="comment-status-body">{message}</div>}
         </div>
-        <div
-          id="comment-panel"
-          className={`${uiIsExpanded ? ' expanded' : ''}`}
-          onClick={evt_Close}
-        >
-          <div className="comments-unread">
-            {UnreadRepliesToMeButtonJSX}
-            <div className="comment-status-body">{unreadRepliesToMeItems}</div>
-            {UnreadButtonJSX}
-            <div className="comment-status-body">{unreadCommentItems}</div>
-            <div className="commentbar">
-              <button className="small" onClick={evt_Close}>
-                Close
-              </button>
-              <button className="small" onClick={evt_MarkAllRead}>
-                Mark All Read
-              </button>
+        <div>
+          <div
+            id="comment-summary"
+            className={`${uiIsExpanded ? ' expanded' : ''}`}
+            onClick={evt_ExpandPanel}
+          >
+            {UnreadRepliesToMeButtonJSX}&nbsp;&nbsp;{UnreadButtonJSX}
+          </div>
+          <div
+            id="comment-panel"
+            className={`${uiIsExpanded ? ' expanded' : ''}`}
+            onClick={evt_Close}
+          >
+            <div className="comments-unread">
+              {UnreadRepliesToMeButtonJSX}
+              <div className="comment-status-body">{unreadRepliesToMeItems}</div>
+              {UnreadButtonJSX}
+              <div className="comment-status-body">{unreadCommentItems}</div>
+              <div className="commentbar">
+                <button className="small" onClick={evt_Close}>
+                  Close
+                </button>
+                <button className="small" onClick={evt_MarkAllRead}>
+                  Mark All Read
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/app/view/netcreate/components/URCommentStatus.jsx
+++ b/app/view/netcreate/components/URCommentStatus.jsx
@@ -182,7 +182,6 @@ function URCommentStatus(props) {
   /// COMPONENT RENDER ////////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   const isLoggedIn = NetMessage.GlobalGroupID();
-  if (!isLoggedIn) return '';
 
   const { countRepliesToMe, countUnread } = CMTMGR.GetCommentStats();
   const unreadRepliesToMe = CMTMGR.GetUnreadRepliesToMe();

--- a/app/view/netcreate/components/URCommentThreadMgr.jsx
+++ b/app/view/netcreate/components/URCommentThreadMgr.jsx
@@ -1,0 +1,161 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  URCommentThreadMgr
+
+  URCommentThreadMgr handles the opening and closing of URCommentThreads
+  being requested from three sources:
+  * Evidence Links -- via URCOmmentBtnAlias
+  * SVG props      -- in class-vbadge via UR.Publish(`CTHREADMGR_THREAD_OPEN`) calls
+  * SVG Mechanisms -- in class-vbadge via UR.Publish(`CTHREADMGR_THREAD_OPEN`) calls
+
+  URCommentVBtn is a visual component that passes clicks
+  to URCommentThreadMgr via UR.Publish(`CTHREADMGR_THREAD_OPEN`) calls
+
+
+  HOW IT WORKS
+    When an EVLink, SVG prop, or SVG mechanism clicks on the
+    URCommentVBtn, URCommentThreadMgr will:
+    * Add the requested Thread to the URCommentThreadMgr
+    * Open the URCommentThread
+    * When the URCommentThread is closed, it will be removed from the URCommentThreadMgr
+
+  UR MESSAGES
+    *  CTHREADMGR_THREAD_OPEN {cref, position}
+    *  CTHREADMGR_THREAD_CLOSE {cref}
+    *  CTHREADMGR_THREAD_CLOSE_ALL
+
+
+  NOTES
+
+  * Differences with URCommentBtn
+
+    URCommentBtn displays Comment Collections (e.g. URCommentThread) as children
+    of the URCommentBtn.
+    In contrast, URCommentThread are displayed as children of URCommentTHreadMgr.
+    This gets around t he problem of URCommentBtns beimg hidden inside Evidence Links.
+
+    To get around this, URCommentThreadMgr essentially replaces the
+    functionality of URCommentBtn with three pieces, acting as a middle
+    man and breaking out the...
+    * visual display    -- URCommentBtnAlias
+    * UI click requests -- UR messages
+    * thread opening / closing requests -- URCommentThreadMgr
+    ...into different functions handled by different components.
+
+  USE:
+
+    <URCommentThreadMgr message={message} handleMessageUpdate/>
+
+
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+import React, { useState, useEffect, useCallback } from 'react';
+import UNISYS from 'unisys/client';
+
+import CMTMGR from '../comment-mgr';
+import URCommentThread from './URCommentThread';
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// Initialize UNISYS DATA LINK for functional react component
+const UDATAOwner = { name: 'URCommentThreadMgr' };
+const UDATA = UNISYS.NewDataLink(UDATAOwner);
+//
+const DBG = true;
+const PR = 'URCommentThreadMgr';
+
+/// REACT FUNCTIONAL COMPONENT ////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function URCommentThreadMgr() {
+  const uid = CMTMGR.GetCurrentUserId();
+  const [cmtBtns, setCmtBtns] = useState([]);
+  const [dummy, setDummy] = useState(0);
+
+  /** Component Effect - register listeners on mount */
+  useEffect(() => {
+    UDATA.OnAppStateChange('COMMENTVOBJS', urstate_UpdateCommentVObjs);
+    UDATA.HandleMessage('CTHREADMGR_THREAD_OPEN', urmsg_THREAD_OPEN);
+    UDATA.HandleMessage('CTHREADMGR_THREAD_CLOSE', urmsg_THREAD_CLOSE);
+    UDATA.HandleMessage('CTHREADMGR_THREAD_CLOSE_ALL', urmsg_THREAD_CLOSE_ALL);
+
+    return () => {
+      STATE.AppStateChangeOff('COMMENTVOBJS', urstate_UpdateCommentVObjs);
+      UDATA.UnhandleMessage('CTHREADMGR_THREAD_OPEN', urmsg_THREAD_OPEN);
+      UDATA.UnhandleMessage('CTHREADMGR_THREAD_CLOSE', urmsg_THREAD_CLOSE);
+      UDATA.UnhandleMessage('CTHREADMGR_THREAD_CLOSE_ALL', urmsg_THREAD_CLOSE_ALL);
+    };
+  }, []);
+
+
+  /// COMPONENT HELPER METHODS ////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  /// UR HANDLERS /////////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function urstate_UpdateCommentVObjs(data) {
+    // This is necessary to force a re-render of the threads
+    // when the comment collection changes on the net
+    // especially when a new comment is added.
+    setDummy(dummy => dummy + 1); // Trigger re-render
+  }
+  /**
+   * Handle CTHREADMGR_THREAD_OPEN message
+   * 1. Register the button, and
+   * 2. Open the URCommentBtn
+   * @param {Object} data
+   * @param {string} data.cref - Collection reference
+   * @param {Object} data.position - Position of the button
+   */
+  function urmsg_THREAD_OPEN(data) {
+    if (DBG) console.log(PR, 'urmsg_THREAD_OPEN', data);
+    // Validate
+    if (
+      data.position === undefined ||
+      data.position.x === undefined ||
+      data.position.y === undefined
+    )
+      throw new Error(
+        `URCommentThreadMgr: urmsg_THREAD_OPEN: missing position data ${JSON.stringify(
+          data
+        )}`
+      );
+    // 1. Register the button
+    setCmtBtns(prevBtns => [...prevBtns, data]);
+    // 2. Open the URCommentThread
+    CMTMGR.UpdateCommentUIState(data.cref, { cref: data.cref, isOpen: true });
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function urmsg_THREAD_CLOSE(data) {
+    if (DBG) console.log('urmsg_THREAD_CLOSE', data);
+    setCmtBtns(prevBtns => prevBtns.filter(btn => btn.cref !== data.cref));
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function urmsg_THREAD_CLOSE_ALL(data) {
+    if (DBG) console.log('urmsg_THREAD_CLOSE_ALL', data);
+    setCmtBtns([]);
+  }
+
+  /// COMPONENT RENDER ////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  return (
+    <div className="URCommentThreadMgr">
+      URCommentThreadMgrs:
+      {cmtBtns.map(btn => (
+        <URCommentThread
+          key={btn.cref}
+          uiref={btn.cref}
+          cref={btn.cref}
+          uid={uid}
+          x={btn.position.x}
+          y={btn.position.y}
+        />
+      ))}
+    </div>
+  );
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+export default URCommentThreadMgr;

--- a/app/view/netcreate/components/URCommentThreadMgr.jsx
+++ b/app/view/netcreate/components/URCommentThreadMgr.jsx
@@ -70,7 +70,7 @@ const PR = 'URCommentThreadMgr';
 function URCommentThreadMgr() {
   const uid = CMTMGR.GetCurrentUserId();
   const [cmtBtns, setCmtBtns] = useState([]);
-  const [dummy, setDummy] = useState(0);
+  const [dummy, setDummy] = useState(100);
 
   /** Component Effect - register listeners on mount */
   useEffect(() => {
@@ -86,7 +86,6 @@ function URCommentThreadMgr() {
       UDATA.UnhandleMessage('CTHREADMGR_THREAD_CLOSE_ALL', urmsg_THREAD_CLOSE_ALL);
     };
   }, []);
-
 
   /// COMPONENT HELPER METHODS ////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -121,7 +120,12 @@ function URCommentThreadMgr() {
         )}`
       );
     // 1. Register the button
-    setCmtBtns(prevBtns => [...prevBtns, data]);
+    setCmtBtns(prevBtns => {
+      // skip if the comment is already open
+      if (prevBtns.find(btn => btn.cref === data.cref)) return prevBtns;
+      else return [...prevBtns, data];
+    });
+    setDummy(dummy => dummy + 15);
     // 2. Open the URCommentThread
     CMTMGR.UpdateCommentUIState(data.cref, { cref: data.cref, isOpen: true });
   }
@@ -141,7 +145,6 @@ function URCommentThreadMgr() {
 
   return (
     <div className="URCommentThreadMgr">
-      URCommentThreadMgrs:
       {cmtBtns.map(btn => (
         <URCommentThread
           key={btn.cref}

--- a/app/view/netcreate/components/URCommentThreadMgr.jsx
+++ b/app/view/netcreate/components/URCommentThreadMgr.jsx
@@ -5,11 +5,11 @@
   URCommentThreadMgr handles the opening and closing of URCommentThreads
   being requested from three sources:
   * Evidence Links -- via URCOmmentBtnAlias
-  * SVG props      -- in class-vbadge via UR.Publish(`CTHREADMGR_THREAD_OPEN`) calls
-  * SVG Mechanisms -- in class-vbadge via UR.Publish(`CTHREADMGR_THREAD_OPEN`) calls
+  * SVG props      -- in class-vbadge via UR.Publish(`CTHREADMGR_THREAD_OPENED`) calls
+  * SVG Mechanisms -- in class-vbadge via UR.Publish(`CTHREADMGR_THREAD_OPENED`) calls
 
   URCommentVBtn is a visual component that passes clicks
-  to URCommentThreadMgr via UR.Publish(`CTHREADMGR_THREAD_OPEN`) calls
+  to URCommentThreadMgr via UR.Publish(`CTHREADMGR_THREAD_OPENED`) calls
 
 
   HOW IT WORKS
@@ -19,10 +19,12 @@
     * Open the URCommentThread
     * When the URCommentThread is closed, it will be removed from the URCommentThreadMgr
 
+  See [Whimsical Comment Data Structures](https://whimsical.com/comment-data-structures-3zPhDYLVsEKt2gY7xyMMKS) for how the current system is implemented.
+
   UR MESSAGES
-    *  CTHREADMGR_THREAD_OPEN {cref, position}
-    *  CTHREADMGR_THREAD_CLOSE {cref}
-    *  CTHREADMGR_THREAD_CLOSE_ALL
+    *  CTHREADMGR_THREAD_OPENED {cref, position}
+    *  CTHREADMGR_THREAD_CLOSED {cref}            Just closed, update views
+    *  CTHREADMGR_THREAD_CLOSED_ALL
 
 
   NOTES
@@ -75,15 +77,14 @@ function URCommentThreadMgr() {
   /** Component Effect - register listeners on mount */
   useEffect(() => {
     UDATA.OnAppStateChange('COMMENTVOBJS', urstate_UpdateCommentVObjs);
-    UDATA.HandleMessage('CTHREADMGR_THREAD_OPEN', urmsg_THREAD_OPEN);
-    UDATA.HandleMessage('CTHREADMGR_THREAD_CLOSE', urmsg_THREAD_CLOSE);
-    UDATA.HandleMessage('CTHREADMGR_THREAD_CLOSE_ALL', urmsg_THREAD_CLOSE_ALL);
+    UDATA.HandleMessage('CTHREADMGR_THREAD_OPENED', urmsg_THREAD_OPEN);
+    UDATA.HandleMessage('CTHREADMGR_THREAD_CLOSED', urmsg_THREAD_CLOSE);
+    UDATA.HandleMessage('CTHREADMGR_THREAD_CLOSED_ALL', urmsg_THREAD_CLOSE_ALL);
 
     return () => {
-      STATE.AppStateChangeOff('COMMENTVOBJS', urstate_UpdateCommentVObjs);
-      UDATA.UnhandleMessage('CTHREADMGR_THREAD_OPEN', urmsg_THREAD_OPEN);
-      UDATA.UnhandleMessage('CTHREADMGR_THREAD_CLOSE', urmsg_THREAD_CLOSE);
-      UDATA.UnhandleMessage('CTHREADMGR_THREAD_CLOSE_ALL', urmsg_THREAD_CLOSE_ALL);
+      UDATA.UnhandleMessage('CTHREADMGR_THREAD_OPENED', urmsg_THREAD_OPEN);
+      UDATA.UnhandleMessage('CTHREADMGR_THREAD_CLOSED', urmsg_THREAD_CLOSE);
+      UDATA.UnhandleMessage('CTHREADMGR_THREAD_CLOSED_ALL', urmsg_THREAD_CLOSE_ALL);
     };
   }, []);
 

--- a/app/view/netcreate/components/URCommentVBtn.jsx
+++ b/app/view/netcreate/components/URCommentVBtn.jsx
@@ -1,0 +1,50 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  URCommentVBtn
+
+  A purely visual button.
+
+  It shows three visual states:
+  * read/unread status
+    * has unread comments (gold color)
+    * all comments are read (gray color)
+  * is open / selected (displaying comments)
+  * the number of comments.
+
+
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+import React, { useState, useEffect } from 'react';
+import CMTMGR from '../comment-mgr';
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/// REACT FUNCTIONAL COMPONENT ////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function URCommentVBtn({ id, count, hasUnreadComments, selected, cb }) {
+  let icon;
+  if (count === 0) {
+    icon = CMTMGR.ICN_COMMENT_UNREAD;
+  } else if (selected) {
+    if (hasUnreadComments) icon = CMTMGR.ICN_COMMENT_UNREAD_SELECTED;
+    else icon = CMTMGR.ICN_COMMENT_READ_SELECTED;
+  } else {
+    if (hasUnreadComments) icon = CMTMGR.ICN_COMMENT_UNREAD;
+    else icon = CMTMGR.ICN_COMMENT_READ;
+  }
+
+  return (
+    <button id={id} onClick={cb} className="URCommentVBtn">
+      {icon}
+      <div className={`count ${hasUnreadComments ? 'unread' : ''}`}>
+        {count === 0 ? '' : count}
+      </div>
+    </button>
+  );
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+export default URCommentVBtn;

--- a/app/view/netcreate/components/URCommentVBtn.jsx
+++ b/app/view/netcreate/components/URCommentVBtn.jsx
@@ -23,7 +23,7 @@ import CMTMGR from '../comment-mgr';
 
 /// REACT FUNCTIONAL COMPONENT ////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-function URCommentVBtn({ id, count, hasUnreadComments, selected, cb }) {
+function URCommentVBtn({ uiref, count, hasUnreadComments, selected, cb }) {
   let icon;
   if (count === 0) {
     icon = CMTMGR.ICN_COMMENT_UNREAD;
@@ -36,7 +36,7 @@ function URCommentVBtn({ id, count, hasUnreadComments, selected, cb }) {
   }
 
   return (
-    <button id={id} onClick={cb} className="URCommentVBtn">
+    <button id={uiref} onClick={cb} className="URCommentVBtn">
       {icon}
       <div className={`count ${hasUnreadComments ? 'unread' : ''}`}>
         {count === 0 ? '' : count}

--- a/app/view/netcreate/components/URCommentVBtn.jsx
+++ b/app/view/netcreate/components/URCommentVBtn.jsx
@@ -25,13 +25,14 @@ import CMTMGR from '../comment-mgr';
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function URCommentVBtn({ uiref, count, hasUnreadComments, selected, cb }) {
   let icon;
-  if (count === 0) {
-    icon = CMTMGR.ICN_COMMENT_UNREAD;
-  } else if (selected) {
+  if (selected) {
     if (hasUnreadComments) icon = CMTMGR.ICN_COMMENT_UNREAD_SELECTED;
+    else if (count === 0) icon = CMTMGR.ICN_COMMENT_UNREAD_SELECTED;
     else icon = CMTMGR.ICN_COMMENT_READ_SELECTED;
   } else {
+    // not selected
     if (hasUnreadComments) icon = CMTMGR.ICN_COMMENT_UNREAD;
+    else if (count === 0) icon = CMTMGR.ICN_COMMENT_UNREAD;
     else icon = CMTMGR.ICN_COMMENT_READ;
   }
 

--- a/app/view/netcreate/components/URTable.css
+++ b/app/view/netcreate/components/URTable.css
@@ -7,10 +7,11 @@
 .URTable th {
   padding: 0 5px;
   border-right: 1px solid #999;
-  position: -webkit-sticky;
-  position: sticky;
   top: 0;
   background-color: #daebef;
+  position: -webkit-sticky;
+  position: sticky;
+  z-index: 1; /* for some reason EdgeTable requires this or body cells will cover td */
 }
 .URTable th.selected {
   background-color: #c6d5d6;

--- a/app/view/netcreate/components/URTable.css
+++ b/app/view/netcreate/components/URTable.css
@@ -7,11 +7,13 @@
 .URTable th {
   padding: 0 5px;
   border-right: 1px solid #999;
-  position: relative;
-  background-color: #0001;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  background-color: #daebef;
 }
 .URTable th.selected {
-  background-color: #0003;
+  background-color: #c6d5d6;
 }
 .URTable thead,
 .URTable thead > tr,

--- a/app/view/netcreate/components/URTable.css
+++ b/app/view/netcreate/components/URTable.css
@@ -34,3 +34,6 @@
 .URTable .resize-handle:hover {
   background-color: #99f; /* Highlight handle on hover */
 }
+.URTable button {
+  padding: 0 2px;
+}

--- a/app/view/netcreate/components/URTable.css
+++ b/app/view/netcreate/components/URTable.css
@@ -1,0 +1,26 @@
+.URTable {
+}
+.URTable table {
+  border-collapse: collapse;
+  width: 100%;
+}
+.URTable th {
+  padding: 0 5px;
+  border-right: 1px solid #ccc;
+  position: relative;
+  user-select: none;
+  background-color: #0001;
+}
+.URTable .resize-handle {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 5px; /* 5px; */
+  cursor: col-resize;
+  background-color: transparent;
+  user-select: none;
+}
+.URTable .resize-handle:hover {
+  background-color: #ccf; /* Highlight handle on hover */
+}

--- a/app/view/netcreate/components/URTable.css
+++ b/app/view/netcreate/components/URTable.css
@@ -8,8 +8,12 @@
   padding: 0 5px;
   border-right: 1px solid #ccc;
   position: relative;
-  user-select: none;
   background-color: #0001;
+}
+.URTable thead,
+.URTable thead > tr,
+.URTable thead > tr > th {
+  user-select: none;
 }
 .URTable .resize-handle {
   position: absolute;

--- a/app/view/netcreate/components/URTable.css
+++ b/app/view/netcreate/components/URTable.css
@@ -6,7 +6,7 @@
 }
 .URTable th {
   padding: 0 5px;
-  border-right: 1px solid #ccc;
+  border-right: 1px solid #999;
   position: relative;
   background-color: #0001;
 }
@@ -17,6 +17,9 @@
 .URTable thead > tr,
 .URTable thead > tr > th {
   user-select: none;
+}
+.URTable tr:hover {
+  background-color: #0002;
 }
 .URTable .resize-handle {
   position: absolute;
@@ -29,5 +32,5 @@
   user-select: none;
 }
 .URTable .resize-handle:hover {
-  background-color: #ccf; /* Highlight handle on hover */
+  background-color: #99f; /* Highlight handle on hover */
 }

--- a/app/view/netcreate/components/URTable.css
+++ b/app/view/netcreate/components/URTable.css
@@ -10,6 +10,9 @@
   position: relative;
   background-color: #0001;
 }
+.URTable th.selected {
+  background-color: #0003;
+}
 .URTable thead,
 .URTable thead > tr,
 .URTable thead > tr > th {

--- a/app/view/netcreate/components/URTable.jsx
+++ b/app/view/netcreate/components/URTable.jsx
@@ -283,13 +283,7 @@ function URTable({ isOpen, data, columns }) {
         </thead>
         <tbody>
           {tabledata.map((tdata, idx) => (
-            <tr
-              key={idx}
-              style={{
-                color: tdata.meta.isFiltered ? 'red' : 'black',
-                opacity: tdata.meta.filteredTransparency
-              }}
-            >
+            <tr key={idx} style={{ opacity: tdata.meta.filteredTransparency }}>
               {columndefs.map((col, idx) => (
                 <td key={idx}>{m_ExecuteRenderer(tdata[col.data], col, idx)}</td>
               ))}

--- a/app/view/netcreate/components/URTable.jsx
+++ b/app/view/netcreate/components/URTable.jsx
@@ -90,6 +90,10 @@ function URTable({ data, columns }) {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   function m_SortByText(key, tdata, order) {
     const sortedData = [...tdata].sort((a, b) => {
+      console.log('sort by text', a[key], b[key]);
+      if (!a[key] && !b[key]) return 0;
+      if (!a[key]) return 1; // Move undefined or '' to the bottom regardless of sort order
+      if (!b[key]) return -1; // Move undefined or '' the bottom regardless of sort order
       if (a[key] < b[key]) return order;
       if (a[key] > b[key]) return order * -1;
       return 0;

--- a/app/view/netcreate/components/URTable.jsx
+++ b/app/view/netcreate/components/URTable.jsx
@@ -1,0 +1,209 @@
+/*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+UR Table
+
+Implements a table with resizable columns.
+Emulates the API of Handsontable.
+
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
+
+/// LIBRARIES /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import ReactDOM from 'react-dom'; // React 16
+// import { createRoot } from 'react-dom/client'; // requires React 18
+import UNISYS from 'unisys/client';
+
+const CMTMGR = require('../comment-mgr');
+import URCommentVBtn from './URCommentVBtn';
+const { ICON_PENCIL, ICON_VIEW } = require('system/util/constant');
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// Initialize UNISYS DATA LINK for functional react component
+const UDATAOwner = { name: 'URCommentThread' };
+const UDATA = UNISYS.NewDataLink(UDATAOwner);
+
+/// CLASS DECLARATION /////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function URTable({ data, attributeColumndefs }) {
+  const [columnWidths, setColumnWidths] = useState([]);
+
+  const tableRef = useRef(null);
+  const resizeRef = useRef(null);
+
+  /// USEEFFECT ///////////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  useEffect(() => {
+    const colWidths = [
+      50, // View/Edit
+      50, // Degrees
+      300 // Label
+    ];
+    let remainingWidth =
+      tableRef.current.clientWidth - colWidths.reduce((a, b) => a + b, 0) - 5;
+    for (let i = 0; i < attributeColumndefs.length; i++) {
+      colWidths.push(remainingWidth / attributeColumndefs.length);
+    }
+    colWidths.push(50); // Comments
+    setColumnWidths(colWidths);
+    console.log('columnWidths', colWidths);
+  }, []);
+
+  /// UTILITY METHODS /////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function u_GetButtonId(cref) {
+    return `comment-button-${cref}`;
+  }
+
+  /// RESIZE COLUMN HANDLERS //////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  const ui_mouseDown = (event, index) => {
+    resizeRef.current = {
+      index,
+      startX: event.clientX,
+      startWidth: columnWidths[index],
+      nextStartWidth: columnWidths[index + 1],
+      maxCombinedWidth: columnWidths[index] + columnWidths[index + 1] - 50
+    };
+  };
+  const ui_mouseMove = event => {
+    if (resizeRef.current !== null) {
+      const { index, startX, startWidth, nextStartWidth, maxCombinedWidth } =
+        resizeRef.current;
+      const delta = event.clientX - startX;
+      const newWidths = [...columnWidths];
+      newWidths[index] = Math.min(Math.max(50, startWidth + delta), maxCombinedWidth); // Minimum width set to 50px
+      newWidths[index + 1] = Math.min(
+        Math.max(50, nextStartWidth - delta),
+        maxCombinedWidth
+      );
+      setColumnWidths(newWidths);
+    }
+  };
+  const ui_mouseUp = () => {
+    resizeRef.current = null; // Reset on mouse up
+  };
+
+  /// CLICK HANDLERS //////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function evt_ClickViewComment(event, nodeId) {
+    event.preventDefault();
+    event.stopPropagation();
+    UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [parseInt(nodeId)] });
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function evt_ClickComment(cref) {
+    const position = CMTMGR.GetCommentThreadPosition(u_GetButtonId(cref));
+    CMTMGR.OpenCommentThread(cref, position);
+  }
+
+  /// TABLE DEFINITIONS ////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  const COLUMNDEFS = [
+    {
+      title: '-', // View/Edit
+      data: 'id',
+      type: 'text',
+      renderer: RenderViewOrEdit
+    },
+    {
+      title: 'Deg.',
+      type: 'text',
+      data: 'degrees'
+    },
+    {
+      title: 'Label',
+      type: 'text',
+      data: 'label'
+    },
+    ...attributeColumndefs,
+    {
+      title: 'Comments',
+      data: 'commentVBtnDef',
+      type: 'text',
+      renderer: RenderCommentBtn
+    }
+  ];
+
+  /// RENDERERS ////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function RenderViewOrEdit(value) {
+    return (
+      <button
+        className="outline"
+        onClick={event => evt_ClickViewComment(event, value)}
+      >
+        {ICON_VIEW}
+      </button>
+    );
+  }
+
+  function RenderCommentBtn(value) {
+    return (
+      <URCommentVBtn
+        id={u_GetButtonId(value.cref)}
+        count={value.count}
+        hasUnreadComments={value.hasUnreadComments}
+        selected={value.selected}
+        cb={e => evt_ClickComment(value.cref)}
+      />
+    );
+  }
+
+  /// BUILT-IN TABLE METHODS //////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function ExecuteRenderer(renderer, value) {
+    if (typeof renderer !== 'function') throw new Error('Invalid renderer');
+    return renderer(value);
+  }
+
+  const TABLEDATA = data;
+
+  /// RENDER //////////////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  return (
+    <div
+      className="URTable"
+      ref={tableRef}
+      onMouseMove={ui_mouseMove}
+      onMouseUp={ui_mouseUp}
+    >
+      <table>
+        <thead>
+          <tr>
+            {COLUMNDEFS.map((col, idx) => (
+              <th key={idx} width={`${columnWidths[idx]}`}>
+                {col.title}
+                <div
+                  className="resize-handle"
+                  onMouseDown={e => ui_mouseDown(e, idx)}
+                  hidden={idx === COLUMNDEFS.length - 1} // hide last resize handle
+                ></div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {TABLEDATA.map((tdata, idx) => (
+            <tr key={idx}>
+              {COLUMNDEFS.map((col, idx) => (
+                <td key={idx}>
+                  {col.renderer
+                    ? ExecuteRenderer(col.renderer, tdata[col.data])
+                    : tdata[col.data]}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+export default URTable;

--- a/app/view/netcreate/components/URTable.jsx
+++ b/app/view/netcreate/components/URTable.jsx
@@ -16,6 +16,7 @@ import ReactDOM from 'react-dom'; // React 16
 import UNISYS from 'unisys/client';
 
 const CMTMGR = require('../comment-mgr');
+import HDATE from 'system/util/hdate';
 import URCommentVBtn from './URCommentVBtn';
 const { ICON_PENCIL, ICON_VIEW } = require('system/util/constant');
 
@@ -28,13 +29,22 @@ const UDATA = UNISYS.NewDataLink(UDATAOwner);
 /// CLASS DECLARATION /////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function URTable({ data, attributeColumndefs }) {
+  const [tabledata, setTableData] = useState([]);
   const [columnWidths, setColumnWidths] = useState([]);
+  const [sortColumn, setSortColumn] = useState(0);
+  const [sortOrder, setSortOrder] = useState(1);
 
   const tableRef = useRef(null);
   const resizeRef = useRef(null);
 
   /// USEEFFECT ///////////////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// Init table data
+  useEffect(() => {
+    setTableData(data);
+  }, [data]);
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// Init column widths
   useEffect(() => {
     const colWidths = [
       50, // View/Edit
@@ -48,8 +58,12 @@ function URTable({ data, attributeColumndefs }) {
     }
     colWidths.push(50); // Comments
     setColumnWidths(colWidths);
-    console.log('columnWidths', colWidths);
   }, []);
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// Sort table data
+  useEffect(() => {
+    ExecuteSorter();
+  }, [sortColumn, sortOrder]);
 
   /// UTILITY METHODS /////////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -88,13 +102,17 @@ function URTable({ data, attributeColumndefs }) {
 
   /// CLICK HANDLERS //////////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  function evt_ClickViewComment(event, nodeId) {
+  function ui_ClickColumn(index) {
+    setSortColumn(index);
+    setSortOrder(sortOrder * -1);
+  }
+  function ui_ClickViewComment(event, nodeId) {
     event.preventDefault();
     event.stopPropagation();
     UDATA.LocalCall('SOURCE_SELECT', { nodeIDs: [parseInt(nodeId)] });
   }
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  function evt_ClickComment(cref) {
+  function ui_ClickComment(cref) {
     const position = CMTMGR.GetCommentThreadPosition(u_GetButtonId(cref));
     CMTMGR.OpenCommentThread(cref, position);
   }
@@ -106,12 +124,12 @@ function URTable({ data, attributeColumndefs }) {
     {
       title: '-', // View/Edit
       data: 'id',
-      type: 'text',
+      type: 'number',
       renderer: RenderViewOrEdit
     },
     {
       title: 'Deg.',
-      type: 'text',
+      type: 'number',
       data: 'degrees'
     },
     {
@@ -124,7 +142,8 @@ function URTable({ data, attributeColumndefs }) {
       title: 'Comments',
       data: 'commentVBtnDef',
       type: 'text',
-      renderer: RenderCommentBtn
+      renderer: RenderCommentBtn,
+      sorter: SortCommentsByCount
     }
   ];
 
@@ -134,7 +153,7 @@ function URTable({ data, attributeColumndefs }) {
     return (
       <button
         className="outline"
-        onClick={event => evt_ClickViewComment(event, value)}
+        onClick={event => ui_ClickViewComment(event, value)}
       >
         {ICON_VIEW}
       </button>
@@ -148,19 +167,139 @@ function URTable({ data, attributeColumndefs }) {
         count={value.count}
         hasUnreadComments={value.hasUnreadComments}
         selected={value.selected}
-        cb={e => evt_ClickComment(value.cref)}
+        cb={e => ui_ClickComment(value.cref)}
       />
     );
   }
 
-  /// BUILT-IN TABLE METHODS //////////////////////////////////////////////////
+  /// CUSTOM SORTERS //////////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  function ExecuteRenderer(renderer, value) {
-    if (typeof renderer !== 'function') throw new Error('Invalid renderer');
-    return renderer(value);
+  function SortCommentsByCount() {
+    const key = COLUMNDEFS[sortColumn].data;
+    const sortedData = [...tabledata].sort((a, b) => {
+      if (a[key].count < b[key].count) return sortOrder;
+      if (a[key].count > b[key].count) return sortOrder * -1;
+      return 0;
+    });
+    setTableData(sortedData);
   }
 
-  const TABLEDATA = data;
+  /// BUILT-IN SORTERS ////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function SortByText(key) {
+    const sortedData = [...tabledata].sort((a, b) => {
+      if (a[key] < b[key]) return sortOrder;
+      if (a[key] > b[key]) return sortOrder * -1;
+      return 0;
+    });
+    setTableData(sortedData);
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function SortByMarkdown(key) {
+    const sortedData = [...tabledata].sort((a, b) => {
+      // NC's markdown format from NCNodeTable will pass:
+      // { html, raw}
+      // We will sort by the raw text
+      if (a[key].raw < b[key].raw) return sortOrder;
+      if (a[key].raw > b[key].raw) return sortOrder * -1;
+      return 0;
+    });
+    setTableData(sortedData);
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function SortByNumber(key) {
+    const sortedData = [...tabledata].sort((a, b) => {
+      const akey = Number(a[key]);
+      const bkey = Number(b[key]);
+      if (isNaN(akey) && isNaN(bkey)) return 0;
+      if (isNaN(akey)) return 1; // Move NaN to the bottom regardless of sort order
+      if (isNaN(bkey)) return -1; // Move NaN to the bottom regardless of sort order
+      if (akey < bkey) return sortOrder;
+      if (akey > bkey) return sortOrder * -1;
+      return 0;
+    });
+    setTableData(sortedData);
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function SortByHDate(key) {
+    const sortedData = [...tabledata].sort((a, b) => {
+      const akey = HDATE.Parse(a[key]); // parseResult
+      const bkey = HDATE.Parse(b[key]);
+      // if ANY is defined, it's automatically greater than undefined
+      if (akey.length > 0 && bkey.length < 1) return sortOrder;
+      if (akey.length < 1 && bkey.length > 0) return sortOrder * -1;
+      if (akey.length < 1 && bkey.length < 1) return 0;
+      // two valid dates, compare them!
+      const da = akey[0].start.knownValues;
+      const db = bkey[0].start.knownValues;
+      let order;
+      if (da.year !== db.year) {
+        order = da.year - db.year;
+      } else if (da.month !== db.month) {
+        order = da.month - db.month;
+      } else if (da.day !== db.day) {
+        order = da.day - db.day;
+      } else if (da.hour !== db.hour) {
+        order = da.hour - db.hour;
+      } else if (da.minute !== db.minute) {
+        order = da.minute - db.minute;
+      } else if (da.second !== db.second) {
+        order = da.second - db.second;
+      }
+      return order * sortOrder;
+    });
+    setTableData(sortedData);
+  }
+  /// BUILT-IN TABLE METHODS //////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  // function ExecuteRenderer(renderer, value) {
+  //   if (typeof renderer !== 'function') throw new Error('Invalid renderer');
+  //   return renderer(value);
+  // }
+  function ExecuteRenderer(value, col, idx) {
+    const customRenderer = col.renderer;
+    if (customRenderer) {
+      if (typeof customRenderer !== 'function')
+        throw new Error('Invalid renderer for', col);
+      return customRenderer(value);
+    } else {
+      // Run built-in renderers
+      switch (col.type) {
+        case 'markdown':
+          return value.html;
+        case 'hdate':
+        case 'number':
+        case 'text':
+        default:
+          return value;
+      }
+    }
+  }
+  function ExecuteSorter() {
+    const customSorter = COLUMNDEFS[sortColumn].sorter;
+    const key = COLUMNDEFS[sortColumn].data;
+    if (customSorter) {
+      if (typeof customSorter !== 'function') throw new Error('Invalid sorter');
+      customSorter(key);
+    } else {
+      // Run built-in sorters
+      switch (COLUMNDEFS[sortColumn].type) {
+        case 'hdate':
+          SortByHDate(key);
+          break;
+        case 'markdown':
+          SortByMarkdown(key);
+          break;
+        case 'date':
+        case 'number':
+          SortByNumber(key);
+          break;
+        case 'text':
+        default:
+          SortByText(key);
+      }
+    }
+  }
 
   /// RENDER //////////////////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -175,7 +314,12 @@ function URTable({ data, attributeColumndefs }) {
         <thead>
           <tr>
             {COLUMNDEFS.map((col, idx) => (
-              <th key={idx} width={`${columnWidths[idx]}`}>
+              <th
+                key={idx}
+                className={sortColumn === idx ? 'selected' : ''}
+                width={`${columnWidths[idx]}`}
+                onClick={e => ui_ClickColumn(idx)}
+              >
                 {col.title}
                 <div
                   className="resize-handle"
@@ -187,13 +331,14 @@ function URTable({ data, attributeColumndefs }) {
           </tr>
         </thead>
         <tbody>
-          {TABLEDATA.map((tdata, idx) => (
+          {tabledata.map((tdata, idx) => (
             <tr key={idx}>
               {COLUMNDEFS.map((col, idx) => (
                 <td key={idx}>
-                  {col.renderer
+                  {ExecuteRenderer(tdata[col.data], col, idx)}
+                  {/* {col.renderer
                     ? ExecuteRenderer(col.renderer, tdata[col.data])
-                    : tdata[col.data]}
+                    : tdata[col.data]} */}
                 </td>
               ))}
             </tr>

--- a/app/view/netcreate/components/filter/FiltersPanel.jsx
+++ b/app/view/netcreate/components/filter/FiltersPanel.jsx
@@ -156,7 +156,7 @@ class FiltersPanel extends UNISYS.Component {
           padding: '5px',
           flexDirection: 'column',
           backgroundColor: '#EEE',
-          zIndex: '2000'
+          zIndex: '1500'
         }}
       >
         <ButtonGroup>

--- a/brunch-config.js
+++ b/brunch-config.js
@@ -195,7 +195,7 @@ module.exports = {
     // env 'package' is set by npm run package
     package: {
       optimize: false,
-      sourceMaps: false,
+      sourceMaps: true,
       plugins: {
         autoReload: { enabled: false }
       },


### PR DESCRIPTION
This adds the ability to resize the Node and Edge table column widths by direct manipulation of the UI.

## User Experience
Resizing columns:
* Fixed sizes for built-in fields, other fields split evenly -- The built in node and edge fields have fixed widths (e.g. degree, label, source, type, target, Comments).  The remaining custom arbitrary fields are then evenly distributed.
* Max resize -- Resizing is done essentially between two columns: the current column, and the column to the right.  (We assume the table width is fixed or 100%).  To give you simple, but finer control over resizing columns, you can expand or contract the current column and the next column up/down to a minimum size.  Once you hit the max size, you need to resize other columns to adjust.  (We don't allow you to resize neighboring columns once you've hit the max/min just to simplify the math).

## Technical Discussion

### History

We had successfully used [handsontable](https://handsontable.com/) for project tables in MEME, which handled sorting and resizing columns admirably.  But rendering handsontables in NC proved to be too inefficient: The redraw updates needed for custom rendering the view/edit and comment buttons as well as the Markdown text fields were slow enough to be unusable.  Also, handsontable paginated long table data which made for an awkward use experience.  The overhead introduced by all of the features of handsontable was not worth it.

It was more efficient for us to build custom tables that specifically addressed our sorting and resizing needs.  We emulated the API for handsontable, and isolated the table calls, so if we should change our mind or look for a different table library, it should be relatively easy to swap in a new table library.

### API

Table rendering is implemented via three layers of components:
* `URTable.jsx`
* `NCTable.jsx`
* `NCNodeTable.jsx` / `NCEdgeTable.jsx`

#### `URTable.jsx`

At the core is a generic `URTable.jsx` component that provides a simple table component with sorting and column resizing.  This can be used with ANY table.

#### `NCTable.jsx`

`NCTable.jsx` provides Net.Create-specific sorters and renderers.  Specifically, support for handling `markdown` and `hdate` (historical date) data formats.  `NCTable.jsx` provides the features common to both Node and Edge tables.

#### `NCNodeTable.jsx`/`NCEdgeTable.jsx`

`NCNodeTable.jsx` and `NCEdgeTable.jsx` defines the table data for nodes and edges, specifying:
* the table data format
* the column order
* any custom sorters
* any custom column renderers
* any custom click handlers (e.g. click to view/edit a node or edge, open a comment)


#### Table Data

Table data is defined as a simple JSON object table, e.g.: 
```
[
  { id: 1, label: 'Constantinople', founding: '100 ce' },
  { id: 2, label: 'Athens', founding: '1000 bce' },
  { id: 3, label: 'Cairo', founding: '3000 bce' },
]
```

The table itself is defined via "Column definitions" that specify:
* the columns to be included
* a title for the column
* the data key to use
* width of the column (in pixels)
* type of data (e.g. number, text)
* any custom sorter
* any custom renderer

URTable can handle a number of built-in generic data types:
* numbers
* dates
* text

...along with some Net.Create-specific data types:

* markdown
* hdate (historical date)


#### Column Sorters

Columns can be sorted ascending and descending using standard types: number, text.
Depending on the data format, dates can be handled and sorted as strings (e.g. "October 1, 2023") or numbers (e.g. if using unix timestamps).  

In addition, custom sorters can be defined for specific data types.

* markdown -- Sorts by raw markdown text, but displays rendered HTML (since sorting by html text is at best confusing).
* hdate -- Sorts by interpreted date, but displays raw hdate data (since we want to sort by the interpreted date while still showing what the user entered).


#### Column Renderers

Standard data types will display text as-is.

If the data requires special handling, you need to define a custom renderer.  For example, you can use a custom renderer to show a button or an image based on the table data.

For example, table data `{ id: 0, url: 'http://www.inquirium.net' }` you can use the `url` to render a clickable button. 



## To Do
- [x] Retain column widths when switching back to table view -- currently if you set column widths and then navigate away (e.g. close the table) then re-open the table, the columns revert to their default values.
- [ ] Add `NCTable.jsx` intermediate class between `URTable` and `NCNodeTable/NCEdgeTable`
- [ ] Show sort direction icons