### PR TITLE
Improve Template handling of tooltips

### DIFF
--- a/app/view/netcreate/render-mgr.js
+++ b/app/view/netcreate/render-mgr.js
@@ -167,29 +167,12 @@ function m_GetHelp(node) {
   const TEMPLATE = UDATA.AppState('TEMPLATE');
   const nodeDefs = TEMPLATE.nodeDefs;
   let titleText = '';
-  if (nodeDefs.label.includeInGraphTooltip !== undefined) {
-    // Add Label
-    if (nodeDefs.label.includeInGraphTooltip)
-      titleText += nodeDefs.label.displayLabel + ': ' + node.label + '\n';
-    // Add type
-    if (nodeDefs.type.includeInGraphTooltip)
-      titleText += nodeDefs.type.displayLabel + ': ' + node.type + '\n';
-    // Add degrees
-    if (nodeDefs.degrees.includeInGraphTooltip)
-      titleText += nodeDefs.degrees.displayLabel + ': ' + node.degrees + '\n';
-    // Add notes
-    if (nodeDefs.notes.includeInGraphTooltip)
-      titleText += nodeDefs.notes.displayLabel + ': ' + node.notes + '\n';
-    // Add info
-    if (nodeDefs.info.includeInGraphTooltip)
-      titleText += nodeDefs.info.displayLabel + ': ' + node.info + '\n';
-    // Add updated info
-    if (nodeDefs.updated.includeInGraphTooltip)
-      titleText += nodeDefs.updated.displayLabel + ': ' + m_GetUpdatedDateText(node);
-  } else {
-    // For backwards compatability
-    titleText += nodeDefs.displayLabel.label + ': ' + node.label + '\n';
-  }
+  Object.entries(nodeDefs).forEach(([key, def]) => {
+    if (def.includeInGraphTooltip && node[key] !== undefined) {
+      if (titleText) titleText += '\n';
+      titleText += def.displayLabel + ': ' + node[key];
+    }
+  });
   return titleText;
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Fixes/Features:
* Tooltips are now defined via the template node definitions (before they used a mix of predefined fields and falling back to the label field.
* Tooltips are now only shown if the node definition's `includeInGraphTooltip` parameter is true.  Fields that do not have the parameter or whose value is false will not show the tool tip.
* This fixes #255 where missing or would display `<fieldname>: undefined`
* This also fixes #256

NOTE: The `hidden` parameter is not affected by the `includeInGraphTooltip` parameter.  This means that a node field marked `hidden` but with `includeInGraphTooltip = true` will still show the tooltip value.