### PR TITLE
Feature: Add `type` as a built-in field

### DIFF
--- a/app/system/util/enum.js
+++ b/app/system/util/enum.js
@@ -19,6 +19,7 @@ ENUM.EDITORTYPE = {
 ENUM.BUILTIN_FIELDS_NODE = [
   'id',
   'label',
+  'type',
   'degrees',
   'created',
   'createdBy',
@@ -29,6 +30,7 @@ ENUM.BUILTIN_FIELDS_NODE = [
 ENUM.BUILTIN_FIELDS_EDGE = [
   'id',
   'source',
+  'type',
   'target',
   'weight',
   'degrees',

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -535,7 +535,7 @@ class NCEdgeTable extends UNISYS.Component {
     });
     const COLUMNDEFS = [
       {
-        title: '-', // View/Edit
+        title: '', // View/Edit
         data: 'id',
         type: 'number',
         width: 50, // in px

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -525,9 +525,8 @@ class NCEdgeTable extends UNISYS.Component {
     // column definitions for custom attributes
     // (built in columns are: view, degrees, label)
     const ATTRIBUTE_COLUMNDEFS = attributeDefs.map(key => {
-      let title = String(key);
-      title = title.charAt(0).toUpperCase() + title.slice(1).toLowerCase();
-      let type = edgeDefs[key].type;
+      const title = edgeDefs[key].displayLabel;
+      const type = edgeDefs[key].type;
       return {
         title,
         type,

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -551,7 +551,7 @@ class NCEdgeTable extends UNISYS.Component {
     ];
     if (edgeDefs['type'] && !edgeDefs['type'].hidden) {
       COLUMNDEFS.push({
-        title: 'Type',
+        title: edgeDefs['type'].displayLabel,
         type: 'text',
         width: 130, // in px
         data: 'type'

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -542,7 +542,7 @@ class NCEdgeTable extends UNISYS.Component {
         renderer: RenderViewOrEdit
       },
       {
-        title: 'Source',
+        title: edgeDefs['source'].displayLabel,
         width: 130, // in px
         data: 'sourceDef',
         renderer: RenderNode,
@@ -559,7 +559,7 @@ class NCEdgeTable extends UNISYS.Component {
     }
     COLUMNDEFS.push(
       {
-        title: 'Target',
+        title: edgeDefs['target'].displayLabel,
         width: 130, // in px
         data: 'targetDef',
         renderer: RenderNode,
@@ -575,7 +575,6 @@ class NCEdgeTable extends UNISYS.Component {
         sorter: SortCommentsByCount
       }
     );
-
     this.setState({ COLUMNDEFS });
   }
 

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -548,13 +548,17 @@ class NCEdgeTable extends UNISYS.Component {
         data: 'sourceDef',
         renderer: RenderNode,
         sorter: SortNodes
-      },
-      {
+      }
+    ];
+    if (edgeDefs['type'] && !edgeDefs['type'].hidden) {
+      COLUMNDEFS.push({
         title: 'Type',
         type: 'text',
         width: 130, // in px
         data: 'type'
-      },
+      });
+    }
+    COLUMNDEFS.push(
       {
         title: 'Target',
         width: 130, // in px
@@ -571,8 +575,7 @@ class NCEdgeTable extends UNISYS.Component {
         renderer: RenderCommentBtn,
         sorter: SortCommentsByCount
       }
-    ];
-    23;
+    );
 
     this.setState({ COLUMNDEFS });
   }

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -181,25 +181,49 @@
 }
 
 .nccomponent .nodelabel {
-  padding: 3px 10px 5px 0px;
+  padding: 3px 10px 0 0px;
   font-weight: bold;
   text-align: left;
   overflow: hidden;
+}
+.nccomponent .edit .nodelabel {
+  padding-right: 0px;
 }
 
 .nccomponent .formview {
   display: grid;
   grid-template-columns: 70px auto;
+  align-items: center;
   column-gap: 10px;
   margin-bottom: 10px;
+}
+.nccomponent .edit .formview {
+  row-gap: 10px;
 }
 .nccomponent .formview label {
   font-size: 10px;
   line-height: 12px;
   opacity: 0.7;
   text-align: right;
+  margin-bottom: 0; /* override bootstrap */
 }
-
+.nccomponent .formview.typeview {
+  /* match .formview with column gap*/
+  grid-template-columns: 40px auto;
+}
+.nccomponent .formview.typeview label {
+  color: #0004;
+  opacity: 1;
+}
+.nccomponent .formview .edgetypeRow {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  column-gap: 10px;
+  margin-bottom: 0;
+}
+.nccomponent .formview .edgetypeRow .typeview {
+  margin-bottom: 0;
+}
 .nccomponent .formview .viewvalue {
   padding-left: 10px;
   text-align: left;
@@ -279,8 +303,8 @@
 
 .nccomponent .titlebar {
   display: grid;
-  grid-template-columns: 4em auto 30px;
-  align-items: top;
+  grid-template-columns: 60px auto 30px;
+  align-items: center;
   /* display: flex;
   justify-content: space-between;
   align-items: baseline; */
@@ -291,7 +315,9 @@
   color: #0004;
   padding-right: 0.4em;
 }
-
+.nccomponent .titlebar .nodelabel label {
+  margin-bottom: 0; /* override bootstrap */
+}
 .nccomponent .controlbar {
   display: flex;
   justify-content: flex-end;

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -168,6 +168,7 @@ class NCNode extends UNISYS.Component {
       // NODE DEFS
       id: null,
       label: '',
+      type: '',
       degrees: null,
       attributes: [],
       provenance: [],
@@ -355,6 +356,7 @@ class NCNode extends UNISYS.Component {
       {
         id: node.id,
         label: node.label,
+        type: node.type,
         degrees: node.degrees,
         attributes: attributes,
         provenance: provenance,
@@ -502,12 +504,13 @@ class NCNode extends UNISYS.Component {
   /// DATA SAVING
   ///
   SaveNode() {
-    const { id, label, attributes, provenance, created, updated, revision } =
+    const { id, label, type, attributes, provenance, created, updated, revision } =
       this.state;
     const uid = NCLOGIC.GetCurrentUserId();
     const node = {
       id,
       label,
+      type,
       updatedBy: uid
     };
     Object.keys(attributes).forEach(k => (node[k] = attributes[k]));
@@ -557,8 +560,7 @@ class NCNode extends UNISYS.Component {
    * color mapping.  This will eventually be replaced with a color manager.
    */
   SetBackgroundColor() {
-    const { attributes } = this.state;
-    const type = (attributes && attributes.type) || ''; // COLORMAP uses "" for undefined
+    const { type } = this.state;
     const COLORMAP = UDATA.AppState('COLORMAP');
     const uBackgroundColor = COLORMAP.nodeColorMap[type] || '#555555';
     this.setState({ uBackgroundColor });
@@ -624,12 +626,13 @@ class NCNode extends UNISYS.Component {
   }
 
   UIEnableEditMode() {
-    const { uSelectedTab, id, label, attributes, provenance } = this.state;
+    const { uSelectedTab, id, label, type, attributes, provenance } = this.state;
     // If user was on Edges tab while requesting edit (e.g. from Node Table), then
     // switch to Attributes tab first.
     const editableTab = uSelectedTab === TABS.EDGES ? TABS.ATTRIBUTES : uSelectedTab;
     const previousState = {
       label,
+      type,
       attributes: Object.assign({}, attributes)
       // provenance: Object.assign({}, provenance) // uncomment after provenence is implemented
     };
@@ -642,6 +645,7 @@ class NCNode extends UNISYS.Component {
     const node = {
       id,
       label,
+      type,
       provenance
     };
     Object.keys(attributes).forEach(k => (node[k] = attributes[k]));
@@ -664,6 +668,7 @@ class NCNode extends UNISYS.Component {
     this.setState(
       {
         label: previousState.label,
+        type: previousState.type,
         attributes: previousState.attributes
         // provenance: previousState.provenance // uncomment after provenence is implemented
       },
@@ -747,7 +752,8 @@ class NCNode extends UNISYS.Component {
       uIsValidReplacementNodeID,
       uShowCitationDialog,
       id,
-      label
+      label,
+      type
     } = this.state;
     const TEMPLATE = UDATA.AppState('TEMPLATE');
     const defs = TEMPLATE.nodeDefs;
@@ -769,7 +775,15 @@ class NCNode extends UNISYS.Component {
             <div className="nodenumber">NODE {id}</div>
             <div className="nodelabel">{NCUI.RenderLabel('label', label)}</div>
             <URCommentBtn cref={collection_ref} />
+            {/* using key resets with a new URComment <URCommentBtn cref={collection_ref} key={collection_ref} /> */}
           </div>
+          {/* Special handling for `type` field */}
+          {defs['type'] && !defs['type'].hidden && (
+            <div className="formview typeview">
+              {NCUI.RenderLabel('type', defs['type'].displayLabel, defs['type'].help)}
+              {NCUI.RenderStringValue('type', type)}
+            </div>
+          )}
           {/* TABS - - - - - - - - - - - - - - - - - - - */}
           <div className="--NCNode_View_Tabs tabcontainer">
             {NCUI.RenderTabSelectors(TABS, this.state, this.UISelectTab)}
@@ -851,8 +865,9 @@ class NCNode extends UNISYS.Component {
       uBackgroundColor,
       uShowMatchlist,
       matchingNodes,
+      id,
       label,
-      id
+      type
     } = this.state;
     const defs = UDATA.AppState('TEMPLATE').nodeDefs;
     const bgcolor = uBackgroundColor + '66'; // hack opacity
@@ -894,6 +909,23 @@ class NCNode extends UNISYS.Component {
               )}
               {isDuplicate && <div className="message">{duplicateWarning}</div>}
             </div>
+            {/* Special handling for `type` field */}
+            {defs['type'] && !defs['type'].hidden && (
+              <div className="formview typeview">
+                {NCUI.RenderLabel(
+                  'type',
+                  defs['type'].displayLabel,
+                  defs['type'].help
+                )}
+                {NCUI.RenderOptionsInput(
+                  'type',
+                  type,
+                  defs,
+                  this.UIInputUpdate,
+                  defs['type'].help
+                )}
+              </div>
+            )}
             {/* TABS - - - - - - - - - - - - - - - - - - - */}
             <div className="tabcontainer">
               {NCUI.RenderTabSelectors(TABS, this.state, this.UISelectTab)}

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -514,6 +514,12 @@ class NCNodeTable extends UNISYS.Component {
         renderer: RenderNode,
         sorter: SortNodes
       },
+      {
+        title: 'Type',
+        type: 'text',
+        width: 130, // in px
+        data: 'type'
+      },
       ...ATTRIBUTE_COLUMNDEFS,
       {
         title: 'Comments',
@@ -557,7 +563,7 @@ class NCNodeTable extends UNISYS.Component {
     /// TABLE DATA GENERATION
     /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     const TABLEDATA = nodes.map((node, i) => {
-      const { id, label, degrees } = node;
+      const { id, label, type, degrees } = node;
 
       const sourceDef = { id, label };
 
@@ -593,6 +599,7 @@ class NCNodeTable extends UNISYS.Component {
       return {
         id,
         label: sourceDef, // { id, label } so that we can render a button
+        type,
         degrees,
         ...attributes,
         commentVBtnDef,

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -500,13 +500,13 @@ class NCNodeTable extends UNISYS.Component {
         renderer: RenderViewOrEdit
       },
       {
-        title: 'Deg.',
+        title: nodeDefs['degrees'].displayLabel,
         type: 'number',
         width: 50, // in px
         data: 'degrees'
       },
       {
-        title: 'Label',
+        title: nodeDefs['label'].displayLabel,
         data: 'label',
         width: 300, // in px
         renderer: RenderNode,

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -130,8 +130,7 @@ class NCNodeTable extends UNISYS.Component {
   /**
    */
   componentDidMount() {
-    if (DBG) console.error('NodeTable.componentDidMount!');
-
+    if (DBG) console.log('NodeTable.componentDidMount!');
     this.onStateChange_SESSION(this.AppState('SESSION'));
 
     // Explicitly retrieve data because we may not have gotten a NCDATA
@@ -513,23 +512,23 @@ class NCNodeTable extends UNISYS.Component {
         width: 300, // in px
         renderer: RenderNode,
         sorter: SortNodes
-      },
-      {
+      }
+    ];
+    if (nodeDefs['type'] && !nodeDefs['type'].hidden) {
+      COLUMNDEFS.push({
         title: 'Type',
         type: 'text',
         width: 130, // in px
         data: 'type'
-      },
-      ...ATTRIBUTE_COLUMNDEFS,
-      {
-        title: 'Comments',
-        data: 'commentVBtnDef',
-        width: 50, // in px
-        renderer: RenderCommentBtn,
-        sorter: SortCommentsByCount
-      }
-    ];
-
+      });
+    }
+    COLUMNDEFS.push(...ATTRIBUTE_COLUMNDEFS, {
+      title: 'Comments',
+      data: 'commentVBtnDef',
+      width: 50, // in px
+      renderer: RenderCommentBtn,
+      sorter: SortCommentsByCount
+    });
     this.setState({ COLUMNDEFS });
   }
 

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -515,7 +515,7 @@ class NCNodeTable extends UNISYS.Component {
     ];
     if (nodeDefs['type'] && !nodeDefs['type'].hidden) {
       COLUMNDEFS.push({
-        title: 'Type',
+        title: nodeDefs['type'].displayLabel,
         type: 'text',
         width: 130, // in px
         data: 'type'

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -483,9 +483,8 @@ class NCNodeTable extends UNISYS.Component {
     // column definitions for custom attributes
     // (built in columns are: view, degrees, label)
     const ATTRIBUTE_COLUMNDEFS = attributeDefs.map(key => {
-      let title = String(key);
-      title = title.charAt(0).toUpperCase() + title.slice(1).toLowerCase();
-      let type = nodeDefs[key].type;
+      const title = nodeDefs[key].displayLabel;
+      const type = nodeDefs[key].type;
       return {
         title,
         type,

--- a/app/view/netcreate/components/URTable.css
+++ b/app/view/netcreate/components/URTable.css
@@ -39,4 +39,5 @@
 }
 .URTable button {
   padding: 0 2px;
+  text-align: left;
 }

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -707,6 +707,7 @@ function m_IsNodeMatchedByFilter(node, filter) {
     case FILTER.OPERATORS.IS_NOT_EMPTY.key:
       return nodeValue !== undefined && nodeValue !== '';
     default:
+      if (nodeValue === undefined) return false; // no value to match
       if (filter.type === FILTER.TYPES.HDATE)
         return m_MatchHDate(filter.operator, filter.value, nodeValue);
       // else assume it's a number
@@ -848,6 +849,7 @@ function m_IsEdgeMatchedByFilter(edge, filter) {
     case FILTER.OPERATORS.IS_NOT_EMPTY.key:
       return edgeValue !== undefined && edgeValue !== '';
     default:
+      if (edgeValue === undefined) return false; // no value to match
       if (filter.type === FILTER.TYPES.HDATE)
         return m_MatchHDate(filter.operator, filter.value, edgeValue);
       // else assume it's a number

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -230,7 +230,7 @@ function RenderAttributesTabEdit(state, defs, onchange) {
         items.push(m_RenderNumberInput(k, value, onchange, helpText));
         break;
       case 'select':
-        items.push(m_RenderOptionsInput(k, value, defs, onchange, helpText));
+        items.push(RenderOptionsInput(k, value, defs, onchange, helpText));
         break;
       default:
         items.push(RenderStringValue(k, value, onchange)); // display unsupported type
@@ -292,7 +292,7 @@ function RenderProvenanceItemsEdit(state, defs, onchange) {
         items.push(m_RenderNumberInput(k, value, onchange, helpText));
         break;
       case 'select':
-        items.push(m_RenderOptionsInput(k, value, defs, onchange, helpText));
+        items.push(RenderOptionsInput(k, value, defs, onchange, helpText));
         break;
       default:
         items.push(RenderStringValue(k, value, onchange)); // display unsupported type
@@ -486,7 +486,7 @@ function m_RenderNumberInput(key, value, cb, helpText) {
  *  @returns
  */
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-function m_RenderOptionsInput(key, value, defs, cb, helpText) {
+function RenderOptionsInput(key, value, defs, cb, helpText) {
   const options = defs[key].options;
   return (
     <div key={`${key}div`}>
@@ -545,5 +545,6 @@ module.exports = {
   RenderMarkdownValue,
   RenderStringValue,
   RenderMarkdownInput,
-  RenderStringInput
+  RenderStringInput,
+  RenderOptionsInput
 };


### PR DESCRIPTION
## `type` field

This makes `type` a built-in and required field.
* "Type" is moved out of the "Attributes" tab to the top of the node/edge, right below the node labels.
* For edge editing, `Type` is now next to the direction arrow.
* The order and position of the "Type" field within NodeTables and EdgeTables is now fixed in place.
* If you don't want the `type` field, you can set `hidden: true`.  HOWEVER, do not remove it outright.  `type` is implicitly a required field.  See #270 for future hardening.

One additional fix:
* Node and Edge table column headers now use the template's `displayLabel` value.  (This is how tables used to work).

### To Test
* Open a node, set the type, save.  Does the type work?  (If node type color is set, does the color change)?
* Do the same thing for edges.
* Review NodeTable and EdgeTable to see if type is properly displayed in the correct order.
* Edit the template and set both Node and Edge "Type" fields to hidden.  Does the app still load?  Is `type` gone from:
  * Node View
  * Node Edit
  * Edge View
  * Edge Edit
  * Node Table
  * Edge Table
* Edit the template and set both Node and Edge "Type" fields to hidden = `false`.  Does the app still load?  Are all the fields restored?
  * Node View
  * Node Edit
  * Edge View
  * Edge Edit
  * Node Table
  * Edge Table

## History

In the first versions of Net.Create, `type` was an attribute field, implicitly "built-in".

As we transitioned to customizable fields, there was more of a distinction between "built-in" fields and "customizable" fields, but the type selection widget remained set within the "attributes" tab and rendered automatically with the other attributes fields.

At the same time, we were doing things like hacking the order of edge tables so that "Type" could show between "Source" and "Target.

But as we move towards customizable fields, we needed to handle both the display of "Type" outside of the attributes tab, and set a custom order the columns in the Node and Edge tables.  This PR does that.

NOTE though that the template itself is in a somewhat transitory period -- deleting the `type` field altogether from the template will cause errors.  Old built-in fields (like `type`, `notes`, `info`, and `citation`) are still being validated, so we'll have to do a more thorough cleaning in the future.  See #270.

Addresses #269 
See also #270 for outstanding isses