### PR TITLE
hotfix-table-optimization: Skip table render if table is not open.  #396

### DIFF
--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -473,6 +473,18 @@ function NCEdgeTable({ isOpen }) {
   if (state.edges === undefined) return `loading...waiting for edges ${state.edges}`;
   if (state.edgeDefs === undefined)
     return `loading...waiting for nodeDefs ${state.edgeDefs}`;
+
+  // HACK Optimization: if the table is not open, don't render it
+  // REVIEW: Search input triggers a FILTEREDNCDATA update, which causes the table to
+  //         re-render. This is a hack to prevent that.  The proper fix is
+  //         probably only to update the `nodess` data if the data has changed.
+  if (!isOpen)
+    return (
+      <div id="NCEdgeTable">
+        <div className="URTable"></div>
+      </div>
+    );
+
   const COLUMNDEFS = DeriveColumnDefs();
   const TABLEDATA = DeriveTableData({ edgeDefs: state.edgeDefs, edges: state.edges });
   return (

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -417,6 +417,18 @@ function NCNodeTable({ isOpen }) {
   if (state.nodes === undefined) return `loading...waiting for nodes ${state.nodes}`;
   if (state.nodeDefs === undefined)
     return `loading...waiting for nodeDefs ${state.nodeDefs}`;
+
+  // HACK Optimization: if the table is not open, don't render it
+  // REVIEW: Search input triggers a FILTEREDNCDATA update, which causes the table to
+  //         re-render. This is a hack to prevent that.  The proper fix is
+  //         probably only to update the `nodess` data if the data has changed.
+  if (!isOpen)
+    return (
+      <div id="NCNodeTable">
+        <div className="URTable"></div>
+      </div>
+    );
+
   const COLUMNDEFS = DeriveColumnDefs();
   const TABLEDATA = DeriveTableData({ nodeDefs: state.nodeDefs, nodes: state.nodes });
   return (


### PR DESCRIPTION
DO NOT MERGE until after pilot!

To improve performance on older Chromebooks, skip rendering Node and Edge tables if they're closed.

Addresses #396.