### PR TITLE
Hotfix Table Optimization Part 2

### DIFF
--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -21,7 +21,7 @@
 
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import UNISYS from 'unisys/client';
 import NCUI from '../nc-ui';
 import UTILS from '../nc-utils';
@@ -45,6 +45,7 @@ const DBG = false;
 /// REACT FUNCTIONAL COMPONENT ////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function NCEdgeTable({ isOpen }) {
+  const isOpenRef = useRef(isOpen);
   const [state, setState] = useState({});
 
   /// USEEFFECT ///////////////////////////////////////////////////////////////
@@ -52,9 +53,10 @@ function NCEdgeTable({ isOpen }) {
   useEffect(() => {
     const TEMPLATE = UDATA.AppState('TEMPLATE');
     const SESSION = UDATA.AppState('SESSION');
+    const NCDATA = UDATA.AppState('NCDATA');
     setState({
       edgeDefs: TEMPLATE.edgeDefs,
-      edges: [],
+      edges: NCDATA.edges,
       nodes: [], // needed for dereferencing source/target
       disableEdit: false,
       isLocked: !SESSION.isValid
@@ -70,10 +72,17 @@ function NCEdgeTable({ isOpen }) {
     };
   }, []);
 
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
   /// UR HANDLERS /////////////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// FILTEREDNCDATA is the reduced list of nodes, not ALL edges
   function urstate_FILTEREDNCDATA(data) {
+    // skip update if not open
+    if (!isOpenRef.current) return;
+
     if (data.edges) {
       // If we're transitioning from "COLLAPSE" or "FOCUS" to "HILIGHT/FADE", then we
       // also need to add back in edges that are not in filteredEdges
@@ -81,16 +90,11 @@ function NCEdgeTable({ isOpen }) {
       const FILTERDEFS = UDATA.AppState('FILTERDEFS');
       if (FILTERDEFS.filterAction === FILTER.ACTION.FADE) {
         const NCDATA = UDATA.AppState('NCDATA');
-        m_updateEdgeFilterState(NCDATA.edges);
+        setState(prevState => ({ ...prevState, edges: NCDATA.edges }));
       } else {
-        m_updateEdgeFilterState(data.edges);
+        setState(prevState => ({ ...prevState, edges: data.edges }));
       }
     }
-  }
-  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  function m_updateEdgeFilterState(edges) {
-    setState(prevState => ({ ...prevState, edges }));
-    return;
   }
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   function urstate_SESSION(decoded) {
@@ -474,22 +478,11 @@ function NCEdgeTable({ isOpen }) {
   if (state.edgeDefs === undefined)
     return `loading...waiting for nodeDefs ${state.edgeDefs}`;
 
-  // HACK Optimization: if the table is not open, don't render it
-  // REVIEW: Search input triggers a FILTEREDNCDATA update, which causes the table to
-  //         re-render. This is a hack to prevent that.  The proper fix is
-  //         probably only to update the `nodess` data if the data has changed.
-  if (!isOpen)
-    return (
-      <div id="NCEdgeTable">
-        <div className="URTable"></div>
-      </div>
-    );
-
   const COLUMNDEFS = DeriveColumnDefs();
   const TABLEDATA = DeriveTableData({ edgeDefs: state.edgeDefs, edges: state.edges });
   return (
     <div id="NCEdgeTable">
-      <URTable isOpen={isOpen} data={TABLEDATA} columns={COLUMNDEFS} />
+      <URTable isOpen={isOpenRef.current} data={TABLEDATA} columns={COLUMNDEFS} />
     </div>
   );
 }

--- a/app/view/netcreate/components/NCEdgeTable.jsx
+++ b/app/view/netcreate/components/NCEdgeTable.jsx
@@ -473,6 +473,18 @@ function NCEdgeTable({ isOpen }) {
   if (state.edges === undefined) return `loading...waiting for edges ${state.edges}`;
   if (state.edgeDefs === undefined)
     return `loading...waiting for nodeDefs ${state.edgeDefs}`;
+
+  // HACK Optimization: if the table is not open, don't render it
+  // REVIEW: Search input triggers a FILTEREDNCDATA update, which causes the table to
+  //         re-render. This is a hack to prevent that.  The proper fix is
+  //         probably only to update the `nodess` data if the data has changed.
+  if (!isOpen)
+    return (
+      <div id="NCEdgeTable">
+        <div className="URTable"></div>
+      </div>
+    );
+
   const COLUMNDEFS = DeriveColumnDefs();
   const TABLEDATA = DeriveTableData({ edgeDefs: state.edgeDefs, edges: state.edges });
   return (

--- a/app/view/netcreate/components/NCFiltersSummary.jsx
+++ b/app/view/netcreate/components/NCFiltersSummary.jsx
@@ -1,0 +1,85 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  ## OVERVIEW
+
+  NCFiltersSummary displays:
+  * If no filters are active, the count of nodes and edges in the graph
+  * If filters are active...
+    - the summary of filters applied and
+    - the count of nodes and edges active in the graph
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+import React, { useState, useEffect, useRef } from 'react';
+import UNISYS from 'unisys/client';
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// Initialize UNISYS DATA LINK for react component
+const UDATAOwner = { name: 'NCFiltersSummary' };
+const UDATA = UNISYS.NewDataLink(UDATAOwner);
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const DBG = false;
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/// REACT FUNCTIONAL COMPONENT ////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function NCFiltersSummary() {
+  const [state, setState] = useState({
+    filtersSummary: '',
+    graphStats: ''
+  });
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  useEffect(() => {
+    UDATA.OnAppStateChange('FILTEREDNCDATA', urmsg_UpdateFilterSummary);
+    return () => {
+      UDATA.AppStateChangeOff('FILTEREDNCDATA', urmsg_UpdateFilterSummary);
+    };
+  }, []);
+
+  function urmsg_UpdateFilterSummary(data) {
+    // If there is no change in filtersSummary or graphStats, skip the state update
+    // This prevents unnecessary re-renders and improves performance
+
+    const { filtersSummary, graphStats } = data.stats;
+
+    if (filtersSummary === state.filtersSummary && graphStats === state.graphStats) {
+      console.warn(
+        'FILTER_SUMMARY_UPDATE...urmsg_UpdateFilterSummary... no data skipping state update'
+      );
+      return;
+    }
+
+    if (
+      (filtersSummary && filtersSummary !== state.filtersSummary) ||
+      (graphStats && graphStats !== state.graphStats)
+    ) {
+      setState(prevState => ({
+        ...prevState,
+        filtersSummary: filtersSummary,
+        graphStats: graphStats
+      }));
+    }
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function evt_ClearFilters() {
+    UDATA.LocalCall('FILTER_CLEAR');
+  }
+
+  /// COMPONENT RENDER ////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  return (
+    <div id="filters-summary">
+      {!state.filtersSummary && state.graphStats}
+      {state.filtersSummary}
+      {state.filtersSummary && (
+        <button className="cat" onClick={evt_ClearFilters}>
+          Clear Filters
+        </button>
+      )}
+    </div>
+  );
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+export default NCFiltersSummary;

--- a/app/view/netcreate/components/NCInfoPanel.css
+++ b/app/view/netcreate/components/NCInfoPanel.css
@@ -1,8 +1,7 @@
 #InfoPanel {
   background-color: var(--clr-bg);
   display: grid;
-  grid-template-rows: 38px auto auto auto;
-  /* overflow: hidden; */
+  grid-template-rows: 38px min-content auto min-content;
 }
 #InfoPanel .graphtitle {
   color: var(--clr-system);

--- a/app/view/netcreate/components/NCInfoPanel.jsx
+++ b/app/view/netcreate/components/NCInfoPanel.jsx
@@ -16,6 +16,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import UNISYS from 'unisys/client';
+import NCFiltersSummary from './NCFiltersSummary';
 import NCNodeTable from './NCNodeTable';
 import NCEdgeTable from './NCEdgeTable';
 
@@ -44,8 +45,6 @@ function NCInfoPanel() {
     tabpanelHeight: defaultClosedTabPanelHeight,
     prevNodeTableHeight: 0,
     prevEdgeTableHeight: 0,
-    filtersSummary: '',
-    graphStats: '',
     draggerIsHidden: true
   });
   const ref_InfoPanel = useRef(null);
@@ -58,20 +57,8 @@ function NCInfoPanel() {
         infoPanelTop: ref_InfoPanel.current.offsetTop
       }));
     }
-    const urmsg_UpdateFilterSummary = data => {
-      if (
-        (data.filtersSummary && data.filtersSummary !== state.filtersSummary) ||
-        (data.graphStats && data.graphStats !== state.graphStats)
-      ) {
-        setState(prevState => ({
-          ...prevState,
-          filtersSummary: data.filtersSummary,
-          graphStats: data.graphStats
-        }));
-      }
-    };
-    UDATA.HandleMessage('FILTER_SUMMARY_UPDATE', urmsg_UpdateFilterSummary);
   }, []);
+
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   function evt_SelectTab(tabkey) {
     let tabpanelHeight = defaultClosedTabPanelHeight;
@@ -94,10 +81,7 @@ function NCInfoPanel() {
       draggerIsHidden
     }));
   }
-  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  function evt_ClearFilters() {
-    UDATA.LocalCall('FILTER_CLEAR');
-  }
+
   /// DRAGGER HANDLERS ////////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// Update max table height whenever the active tab changes
@@ -212,15 +196,7 @@ function NCInfoPanel() {
         ))}
       </div>
 
-      <div id="filters-summary">
-        {!state.filtersSummary && state.graphStats}
-        {state.filtersSummary}
-        {state.filtersSummary && (
-          <button className="cat" onClick={evt_ClearFilters}>
-            Clear Filters
-          </button>
-        )}
-      </div>
+      <NCFiltersSummary />
 
       <div className="tabpanels">
         <section id={TABS.GRAPH.label} className="hidden" role="tabpanel" />

--- a/app/view/netcreate/components/NCInfoPanel.jsx
+++ b/app/view/netcreate/components/NCInfoPanel.jsx
@@ -166,8 +166,8 @@ function NCInfoPanel() {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   function ui_MouseUp() {
     ref_Dragger.current = null;
-    document.mouseup = null;
-    document.mousemove = null;
+    document.onmouseup = null;
+    document.onmousemove = null;
   }
 
   /// COMPONENT RENDER ////////////////////////////////////////////////////////

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -22,7 +22,7 @@
 
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import UNISYS from 'unisys/client';
 import NCUI from '../nc-ui';
 import UTILS from '../nc-utils';
@@ -46,6 +46,7 @@ const DBG = false;
 /// REACT FUNCTIONAL COMPONENT ////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function NCNodeTable({ isOpen }) {
+  const isOpenRef = useRef(isOpen);
   const [state, setState] = useState({});
 
   /// USEEFFECT ///////////////////////////////////////////////////////////////
@@ -53,9 +54,10 @@ function NCNodeTable({ isOpen }) {
   useEffect(() => {
     const TEMPLATE = UDATA.AppState('TEMPLATE');
     const SESSION = UDATA.AppState('SESSION');
+    const NCDATA = UDATA.AppState('NCDATA');
     setState({
       nodeDefs: TEMPLATE.nodeDefs,
-      nodes: [],
+      nodes: NCDATA.nodes,
       disableEdit: false,
       isLocked: !SESSION.isValid
     });
@@ -70,10 +72,17 @@ function NCNodeTable({ isOpen }) {
     };
   }, []);
 
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
   /// UR HANDLERS /////////////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// FILTEREDNCDATA is the reduced list of nodes, not ALL nodes
   function urstate_FILTEREDNCDATA(data) {
+    // skip update if not open
+    if (!isOpenRef.current) return;
+
     if (data.nodes) {
       // If we're transitioning from "COLLAPSE" or "FOCUS" to "HILIGHT/FADE", then we
       // also need to add back in nodes that are not in filteredNodes
@@ -82,17 +91,11 @@ function NCNodeTable({ isOpen }) {
       if (FILTERDEFS.filterAction === FILTER.ACTION.FADE) {
         // show ALL nodes
         const NCDATA = UDATA.AppState('NCDATA');
-        m_updateNodeFilterState(NCDATA.nodes);
+        setState(prevState => ({ ...prevState, nodes: NCDATA.nodes }));
       } else {
-        // show only filtered nodes from the filter update
-        m_updateNodeFilterState(data.nodes);
+        setState(prevState => ({ ...prevState, nodes: data.nodes }));
       }
     }
-  }
-  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  function m_updateNodeFilterState(nodes) {
-    setState(prevState => ({ ...prevState, nodes }));
-    return;
   }
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   function urstate_SESSION(decoded) {
@@ -314,6 +317,7 @@ function NCNodeTable({ isOpen }) {
     // Only include built in fields
     // Only include non-hidden fields
     // Only include non-provenance fields
+
     const attributeDefs = Object.keys(nodeDefs).filter(
       k =>
         !BUILTIN_FIELDS_NODE.includes(k) &&
@@ -418,22 +422,11 @@ function NCNodeTable({ isOpen }) {
   if (state.nodeDefs === undefined)
     return `loading...waiting for nodeDefs ${state.nodeDefs}`;
 
-  // HACK Optimization: if the table is not open, don't render it
-  // REVIEW: Search input triggers a FILTEREDNCDATA update, which causes the table to
-  //         re-render. This is a hack to prevent that.  The proper fix is
-  //         probably only to update the `nodess` data if the data has changed.
-  if (!isOpen)
-    return (
-      <div id="NCNodeTable">
-        <div className="URTable"></div>
-      </div>
-    );
-
   const COLUMNDEFS = DeriveColumnDefs();
   const TABLEDATA = DeriveTableData({ nodeDefs: state.nodeDefs, nodes: state.nodes });
   return (
     <div id="NCNodeTable">
-      <URTable isOpen={isOpen} data={TABLEDATA} columns={COLUMNDEFS} />
+      <URTable isOpen={isOpenRef.current} data={TABLEDATA} columns={COLUMNDEFS} />
     </div>
   );
 }

--- a/app/view/netcreate/components/NCNodeTable.jsx
+++ b/app/view/netcreate/components/NCNodeTable.jsx
@@ -417,6 +417,18 @@ function NCNodeTable({ isOpen }) {
   if (state.nodes === undefined) return `loading...waiting for nodes ${state.nodes}`;
   if (state.nodeDefs === undefined)
     return `loading...waiting for nodeDefs ${state.nodeDefs}`;
+
+  // HACK Optimization: if the table is not open, don't render it
+  // REVIEW: Search input triggers a FILTEREDNCDATA update, which causes the table to
+  //         re-render. This is a hack to prevent that.  The proper fix is
+  //         probably only to update the `nodess` data if the data has changed.
+  if (!isOpen)
+    return (
+      <div id="NCNodeTable">
+        <div className="URTable"></div>
+      </div>
+    );
+
   const COLUMNDEFS = DeriveColumnDefs();
   const TABLEDATA = DeriveTableData({ nodeDefs: state.nodeDefs, nodes: state.nodes });
   return (

--- a/app/view/netcreate/components/URTable.jsx
+++ b/app/view/netcreate/components/URTable.jsx
@@ -135,6 +135,9 @@ SORTORDER.set(0, '▲▼');
 SORTORDER.set(1, '▲');
 SORTORDER.set(-1, '▼');
 
+const HumanDateCache = new Map();
+const HumanDateShortCache = new Map();
+
 /// FUNCTIONAL COMPONENT DECLARATION //////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function URTable({ isOpen, data, columns }) {
@@ -191,6 +194,10 @@ function URTable({ isOpen, data, columns }) {
   /// e.g. Jan 7 10:05:29 AM
   function u_HumanDate(timestamp) {
     if (timestamp === undefined || timestamp === '') return '<no date>';
+
+    // Check cache first
+    if (HumanDateCache.has(timestamp)) return HumanDateCache.get(timestamp);
+
     const date = new Date(timestamp);
     const timestring = date.toLocaleTimeString('en-Us', {
       hour: '2-digit',
@@ -202,12 +209,22 @@ function URTable({ isOpen, data, columns }) {
       day: 'numeric',
       year: 'numeric'
     });
+
+    // Cache the result
+    // - Clear cache if it gets too large
+    if (HumanDateCache.size > 2048) HumanDateCache.clear();
+    HumanDateCache.set(timestamp, `${datestring} ${timestring}`);
+
     return `${datestring} ${timestring}`;
   }
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /// e.g. 1/7/25 10:05a
   function u_HumanDateShort(timestamp) {
     if (timestamp === undefined || timestamp === '') return '<no date>';
+
+    // Check cache first
+    if (HumanDateShortCache.has(timestamp)) return HumanDateShortCache.get(timestamp);
+
     const date = new Date(timestamp);
     const timestring = date.toLocaleTimeString('en-Us', {
       hour: '2-digit',
@@ -218,6 +235,12 @@ function URTable({ isOpen, data, columns }) {
       day: '2-digit',
       year: '2-digit'
     });
+
+    // Cache the result
+    // - Clear cache if it gets too large
+    if (HumanDateShortCache.size > 2048) HumanDateShortCache.clear();
+    HumanDateShortCache.set(timestamp, `${datestring} ${timestring}`);
+
     return `${datestring} ${timestring}`;
   }
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -40,6 +40,23 @@
         }
     }
 
+
+    FILTEREDNCDATA = {
+        nodes: [ ... ],
+        edges: [ ... ],
+        stats: {
+            nodeCount: 0,
+            edgeCount: 0,
+            filteredNodeCount: 0,
+            filteredEdgeCount: 0,
+            statsSummary: '',     // NCFiltersPanel count of nodes/edges if filters are applied
+                                  // (displayed at bottom of NCFiltersPanel)
+
+            graphStats: ''        // NCInfoPanel count of nodes/edges if no filters
+            filtersSummary: '',   // NCInfoPanel summary of active filters
+        }
+    }
+
   FEATURES
 
   * See Whimiscal [diagram](https://whimsical.com/d3-data-flow-B2tTGnQYPSNviUhsPL64Dz)
@@ -111,7 +128,7 @@ MOD.Hook('INITIALIZE', () => {
   UDATA.OnAppStateChange('FILTERDEFS', data => {
     if (DBG) console.log(PR + 'OnAppStateChange: FILTERDEFS', data);
     // The filter defs have been updated, so apply the filters.
-    m_UpdateFilters();
+    m_FiltersApply();
   });
 
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -160,7 +177,7 @@ MOD.Hook('INITIALIZE', () => {
    */
   UDATA.OnAppStateChange('NCDATA', data => {
     if (DBG) console.log(PR + 'OnAppStateChange: NCDATA', data);
-    m_UpdateFilters();
+    m_FiltersApply();
   });
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /** Listen for TEMPLATE updates so we know to trigger change?
@@ -405,11 +422,13 @@ function m_FiltersApply() {
     FILTERDEFS.filterAction
   );
 
+  // Update Filter Summary
+  const filterSummary = m_UpdateFilterSummary(FILTEREDNCDATA.stats.statsSummary);
+  FILTEREDNCDATA.stats = { ...FILTEREDNCDATA.stats, ...filterSummary };
+
   // Update FILTEREDNCDATA
   UDATA.SetAppState('FILTEREDNCDATA', FILTEREDNCDATA);
   // edge-mgr handles this call and updates VDATA, which is rendered by d3-simplenetgraph
-
-  return FILTEREDNCDATA.stats.statsSummary;
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function m_ClearFilters() {
@@ -448,12 +467,6 @@ function m_UpdateFilterSummary(statsSummary) {
   const FILTERDEFS = UDATA.AppState('FILTERDEFS');
   const FILTEREDNCDATA = UDATA.AppState('FILTEREDNCDATA');
 
-  // skip if FILTERDEFS has not been defined yet
-  if (Object.keys(FILTERDEFS).length < 1) {
-    UDATA.LocalCall('FILTER_SUMMARY_UPDATE', { graphStats });
-    return;
-  }
-
   const graphStats = `${FILTEREDNCDATA.nodes && FILTEREDNCDATA.nodes.length} nodes, ${
     FILTEREDNCDATA.edges && FILTEREDNCDATA.edges.length
   } edges`;
@@ -461,19 +474,14 @@ function m_UpdateFilterSummary(statsSummary) {
   const typeSummary = FILTERDEFS.filterAction; // text for filter action is the label, e.g. 'HIGHLIGHT'
   const nodeSummary = m_FiltersToString(FILTERDEFS.nodes.filters);
   const edgeSummary = m_FiltersToString(FILTERDEFS.edges.filters);
-  let summary = '';
+  let filtersSummary = '';
   if (nodeSummary || edgeSummary)
-    summary = `${typeSummary} ${nodeSummary ? 'NODES: ' : ''}${nodeSummary} ${
+    filtersSummary = `${typeSummary} ${nodeSummary ? 'NODES: ' : ''}${nodeSummary} ${
       edgeSummary ? 'EDGES: ' : ''
     }${edgeSummary}`;
-  if (summary) summary += ' ' + statsSummary;
+  if (filtersSummary) filtersSummary += ' ' + statsSummary;
 
-  UDATA.LocalCall('FILTER_SUMMARY_UPDATE', { filtersSummary: summary, graphStats });
-}
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-function m_UpdateFilters() {
-  const statsSummary = m_FiltersApply();
-  m_UpdateFilterSummary(statsSummary);
+  return { filtersSummary, graphStats };
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function m_FiltersToString(filters) {


### PR DESCRIPTION
DO NOT MERGE until after pilot is over!!!
Merge #398 before this!!!

To continue to improve performance on older Chromebooks...

`FILTER_SUMMARY_UPDATE` and `FILTEREDNCDATA` UDATA updates were resulting in NCNodeTable and NCEdgeTable rendering twice.  This is most visible when typing in search terms with either table open.

This fix reduces search input changes to a single state update.

* `FILTER_SUMMARY_UPDATE` calls were combined with `FILTEREDNCDATA` so there is a single UDATA message/state update.
* The filtered summary was moved out of NCInfoPanel into a new NCFilteredSummary component so that any updates to `FILTEREDNCDATA` would not trigger a second render with the child NCNodeTable and NCEdgeTable components.
* Go beyond #398 to not only skip the render, but also skip the state update if the NCNodeTable or NCEdgeTable components are closed.
* `HumanDate` and `HumanDateShort` rendering on `URTable` is very sluggish on a slow Chromebook.  e.g. it was taking 1356ms eating 18.5% of the rendering time with 82 nodes.  Cache the rendered date so it doesn't have to be constructed with each render. 424299c

Further optimizations might be hard to come by.  Search input changes render quite quickly in the graph.  The culprit is table rendering itself rather than repeated state updates.

Addresses #396.