### PR TITLE
Hotfix: m_locked_nodes should use `add` not `set`

### DIFF
--- a/app/unisys/server-database.js
+++ b/app/unisys/server-database.js
@@ -756,7 +756,7 @@ DB.PKT_RequestLockNode = function (pkt) {
     return m_MakeLockError(`nodeID ${nodeID} is already locked`);
   // SUCCESS
   // single matching node exists and is not yet locked, so lock it
-  m_locked_nodes.add(uaddr);
+  m_locked_nodes.set(uaddr);
   return { nodeID, locked: true };
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Error in `server-database`

```
root/nc-multiplex/netcreate-itest/app/unisys/server-database.js:759
  m_locked_nodes.add(uaddr);
                 ^

TypeError: m_locked_nodes.add is not a function
    at DB.PKT_RequestLockNode (/root/nc-multiplex/netcreate-itest/app/unisys/server-database.js:759:18)
    at /root/nc-multiplex/netcreate-itest/app/unisys/server.js:236:28
    at /root/nc-multiplex/netcreate-itest/app/unisys/server-network.js:369:20
    at new Promise (<anonymous>)
    at f_make_resolver_func (/root/nc-multiplex/netcreate-itest/app/unisys/server-network.js:368:12)
    at m_PromiseServerHandlers (/root/nc-multiplex/netcreate-itest/app/unisys/server-network.js:360:15)
    at m_HandleMessage (/root/nc-multiplex/netcreate-itest/app/unisys/server-network.js:299:18)
    at m_SocketMessage (/root/nc-multiplex/netcreate-itest/app/unisys/server-network.js:279:9)
    at WebSocket.<anonymous> (/root/nc-multiplex/netcreate-itest/app/unisys/server-network.js:180:5)
    at WebSocket.emit (node:events:517:28)
```

`m_locked_nodes` is a `Map` not a `Set`.
So the method should be `set` not `add`