### PR TITLE
Misc Editor Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 # NetCreate ignored directories
 /app-data/*
 /runtime
-netcreate-config.js
 
 # _ur packages
 _dist
@@ -35,6 +34,8 @@ tmp-*
 # Ignore all generated files
 npm-debug.log
 *.tmproj
+git-info.js
+netcreate-config.js
 
 # Numerous always-ignore extensions
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Candidate version 2.0 "Commenting"
 * For Septemeber 2024 pilot testing.
 * Tagged Jan 15, 2025 for pilot testing.
 * Tagged Mar 1, 2025 for pilot testing.
+* Tagged Apr 19, 2025 for pilot testing: 2025-04-19_Pilot_vfoi-itest-2023-b
+* Tagged Apr 19, 2025 for pilot testing: 2025-04-19_Pilot_Part2_vfoi-itest -- with `hotfix-table-optimization` to deal with slow Chromebook rendering.
+* Tagged Jun 29, 2025 for pilot testing: 2025-06-29_SummerPD_vfoi-itest-2023-b
 
 v2.0.0 introduces "commenting" and a fresh user interface.  Database/file data format has changed significantly with 1.5.x so pre-1.4.x data (*.loki) and template (*.json) files are no longer compatible.
 
@@ -36,6 +39,9 @@ v2.0.0 introduces "commenting" and a fresh user interface.  Database/file data f
   - Conversion of JSON templates to TOML/YAML has been deprecated
 
 **Significant Features**
+- New "Bug Report" window for teachers
+- New branch `deploy-terraform` will be a branch purely for deploying and redeploying droplets to DigitalOcean. 
+- Add support for secure websockets (and SSL) if Net.Create is runing on `HTTPS`.
 - Generate "User Tokens" via the Advanced Panel #389
 - Nodes/Edges can be imported using "Replace" or "Merge" #386
 - All user interface widgets should be accessible #362

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ This is currently tagged v1.5.0, but in fact, this is the developer's "NetCreate
 Note: 
 
 * The default branch is **dev**, not master. 
+* There is a new branch `deploy-terraform` that is used for deploying and redeploying code to DigitalOcean droplets.  Droplets might be created at any point in time, so the `deploy-terraform` branch must always be working and error free.  Do NOT merge into `deploy-terraform` until the code has been throroughly tested or you may break an existing droplet.
 * When creating pull requests in GitHub, make sure that it's referring to _this repository_ and the the parent repository
 
 

--- a/app/unisys/server-logger.js
+++ b/app/unisys/server-logger.js
@@ -38,6 +38,7 @@ const LOG_CONFIG = {
 };
 const LOGGER = Tracer.colorConsole(LOG_CONFIG);
 let fs_log = null;
+let current_log_filename = null;
 // enums for outputing dates
 const e_weekday = [
   'Sunday',
@@ -56,6 +57,7 @@ var dir = PATH.resolve(PATH.join(__dirname, LOG_DIR));
 FSE.ensureDir(dir, function (err) {
   if (err) throw new Error('could not make ' + dir + ' directory');
   var logname = str_TimeDatedFilename('log') + '.txt';
+  current_log_filename = logname; // Store for client access
   var pathname = dir + '/' + logname;
   fs_log = FSE.createWriteStream(pathname);
 
@@ -187,6 +189,12 @@ LOG.Write = LogLine;
  */
 LOG.WriteRLog = function (info = { uaddr: '', group: '' }, ...args) {
   LogResearchLine(info, ...args);
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** API: Get current log filename
+ */
+LOG.GetCurrentLogFilename = function() {
+  return current_log_filename;
 }
 
 /// EXPORT MODULE DEFINITION //////////////////////////////////////////////////

--- a/app/unisys/server.js
+++ b/app/unisys/server.js
@@ -391,6 +391,13 @@ UNISYS.RegisterHandlers = () => {
     if (DBG) console.log(PR, sprint_message(pkt));
     return LOGGER.PKT_LogEvent(pkt);
   });
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  UNET.HandleMessage('SRV_GET_LOG_INFO', function (pkt) {
+    if (DBG) console.log(PR, sprint_message(pkt));
+    return {
+      logFilename: LOGGER.GetCurrentLogFilename()
+    };
+  });
 };
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/view/netcreate/NetCreate.css
+++ b/app/view/netcreate/NetCreate.css
@@ -33,6 +33,7 @@
   --clr-system-disabled: #526b78; /* dark navy for UI/system labels */
   --clr-system-faded: #35586999; /* transparent UI/system labels */
   --clr-system-fadedmore: #35586966; /* transparent UI/system labels */
+  --clr-system-fadedmost: #35586933; /* transparent UI/system labels */
   --clr-base-font: #161616;
   --font-size-xs: 0.625rem; /* 10px */
   --font-size-sm: 0.75rem; /* 12px */
@@ -274,7 +275,7 @@ button svg {
   display: block;
   left: 1px;
   right: 10px;
-  background-color: #eafcff;
+  background-color: var(--clr-fg);
   font-size: 0.75em;
 }
 

--- a/app/view/netcreate/NetCreate.css
+++ b/app/view/netcreate/NetCreate.css
@@ -125,6 +125,12 @@ body {
   text-align: center;
 }
 
+.nc-bugreport-btn {
+  position: fixed;
+  bottom: 0px;
+  left: 0px;
+}
+
 /* NC Navbar -------------------------------------------------------------- */
 .nc-navbar {
   top: 0;
@@ -149,7 +155,7 @@ body {
   cursor: pointer;
 }
 
-/* SVG styles */
+/* SVG styles -------------------------------------------------------------- */
 svg#netgraph {
   flex-basis: 100%;
   min-width: 200px;

--- a/app/view/netcreate/NetCreate.jsx
+++ b/app/view/netcreate/NetCreate.jsx
@@ -60,6 +60,7 @@ import PANELMGR from './panel-mgr';
 import NCInfoPanel from './components/NCInfoPanel';
 import NCHelpPanel from './components/NCHelpPanel';
 import NCAdvancedPanel from './components/NCAdvancedPanel';
+import NCBugReport from './components/NCBugReport';
 import NCFiltersPanel from './components/filter/NCFiltersPanel';
 import URButtonToggle from './components/URButtonToggle';
 import URCommentStatus from './components/URCommentStatus';
@@ -230,7 +231,18 @@ class NetCreate extends UNISYS.Component {
       </div>
     );
     /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
+    const BUGREPORTBTN = (
+      <div className="nc-bugreport-btn">
+        <URButtonToggle
+          title="Show/Hide Bug Report"
+          selected={PANELMGR.BugreportIsOpen()}
+          onClick={PANELMGR.ToggleBugreport}
+        >
+          ⚠︎
+        </URButtonToggle>
+      </div>
+    );
+    /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     return (
       <main className="--NetCreate nc-base" role="main">
         {DISCONNECTED_MSG}
@@ -241,6 +253,7 @@ class NetCreate extends UNISYS.Component {
           <div className="--NetCreate_Columns nc-col-left" id="left">
             <NCSearch />
             <NCNode />
+            {BUGREPORTBTN}
           </div>
           {/*** CENTER NETVIEW COLUMN***************/}
           <div className="--NetCreate_Column_NetView nc-col-middle">
@@ -276,6 +289,7 @@ class NetCreate extends UNISYS.Component {
         <div id="dialog-container"></div>
         <NCHelpPanel />
         <NCAdvancedPanel />
+        <NCBugReport />
       </main>
     ); // end return
   } // end render()

--- a/app/view/netcreate/components/NCAutoSuggest.css
+++ b/app/view/netcreate/components/NCAutoSuggest.css
@@ -34,7 +34,6 @@
   color: #3334;
 }
 .helptop {
-  position: absolute;
   bottom: 120%;
   padding: 0 5px;
   margin-bottom: 3px;

--- a/app/view/netcreate/components/NCBugReport.css
+++ b/app/view/netcreate/components/NCBugReport.css
@@ -1,0 +1,23 @@
+#popover.NCBugReport {
+  width: 300px;
+  height: 200px;
+  top: inherit;
+  bottom: 0;
+  left: 0;
+  background-color: #fcc;
+}
+#popover.NCBugReport .popover-content {
+  flex-direction: column;
+  font-size: var(--font-size-xs);
+}
+#popover.NCBugReport .key-value-pair {
+  display: grid;
+  grid-template-columns: 100px auto;
+  column-gap: 0.5rem;
+}
+#popover.NCBugReport .key-value-pair label {
+  text-align: right;
+}
+#popover.NCBugReport .key-value-pair label::after {
+  content: ':';
+}

--- a/app/view/netcreate/components/NCBugReport.jsx
+++ b/app/view/netcreate/components/NCBugReport.jsx
@@ -22,7 +22,7 @@ const DBG = false;
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// export a class object for consumption by brunch/require
 function NCBugReport() {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
   const [logInfo, setLogInfo] = useState({ logFilename: 'loading...' });
 
   useEffect(() => {

--- a/app/view/netcreate/components/NCBugReport.jsx
+++ b/app/view/netcreate/components/NCBugReport.jsx
@@ -8,7 +8,7 @@ import React, { useState, useEffect } from 'react';
 import UNISYS from 'unisys/client';
 import URPopover from './URPopover';
 const SETTINGS = require('settings');
-const GIT_INFO = require('system/git-info');
+const GIT_INFO = require('../../../../app-config/git-info');
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/app/view/netcreate/components/NCBugReport.jsx
+++ b/app/view/netcreate/components/NCBugReport.jsx
@@ -1,0 +1,83 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  # NCBugReport
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+import React, { useState, useEffect } from 'react';
+import UNISYS from 'unisys/client';
+import URPopover from './URPopover';
+const SETTINGS = require('settings');
+const GIT_INFO = require('system/git-info');
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// Initialize UNISYS DATA LINK for react component
+const UDATAOwner = { name: 'NCBugReport' };
+const UDATA = UNISYS.NewDataLink(UDATAOwner);
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const DBG = false;
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// export a class object for consumption by brunch/require
+function NCBugReport() {
+  const [isOpen, setIsOpen] = useState(true);
+
+  useEffect(() => {
+    UDATA.OnAppStateChange('PANELSTATE', evt_ToggleBugReport);
+    return () => {
+      UDATA.AppStateChangeOff('PANELSTATE', evt_ToggleBugReport);
+    };
+  }, []);
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function evt_ToggleBugReport(PANELSTATE) {
+    setIsOpen(PANELSTATE.bugreportIsOpen);
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  function ui_CloseBugReport() {
+    const PANELSTATE = UDATA.AppState('PANELSTATE');
+    UDATA.SetAppState('PANELSTATE', { ...PANELSTATE, bugreportIsOpen: false });
+  }
+
+  // COMPONENT RENDER ////////////////////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  if (!isOpen) return null;
+
+  return (
+    <URPopover
+      title={`Bug Report ${new Date().toLocaleString()}`}
+      onClose={ui_CloseBugReport}
+      classOverride="NCBugReport"
+    >
+      <i>Take a screenshot and send it to Net.Create staff.</i>
+      <div className="key-value-pair">
+        <label>Loki file</label>
+        <div>{window.NC_CONFIG.dataset}.loki</div>
+        <label>Template file</label>
+        <div>{window.NC_CONFIG.dataset}.template.toml</div>
+        <label>Git Branch</label>
+        <div>
+          {GIT_INFO.branch} {GIT_INFO.isDirty ? '(modified)' : ''}
+        </div>
+        <label>Git Commit</label>
+        <div>
+          {GIT_INFO.shortCommit} - {GIT_INFO.commitMessage}
+        </div>
+        <label>Build Time</label>
+        <div>{GIT_INFO.buildTime}</div>
+        <label>Log file</label>
+        <div>{window.NC_CONFIG.dataset}.log</div>
+        <label>Server IP</label>
+        <div>{SETTINGS.ServerHostIP()}</div>
+        <label>UADDR</label>
+        <div>{UNISYS.SocketUADDR()}</div>
+      </div>
+    </URPopover>
+  );
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+export default NCBugReport;

--- a/app/view/netcreate/components/NCBugReport.jsx
+++ b/app/view/netcreate/components/NCBugReport.jsx
@@ -23,9 +23,23 @@ const DBG = false;
 /// export a class object for consumption by brunch/require
 function NCBugReport() {
   const [isOpen, setIsOpen] = useState(true);
+  const [logInfo, setLogInfo] = useState({ logFilename: 'loading...' });
 
   useEffect(() => {
     UDATA.OnAppStateChange('PANELSTATE', evt_ToggleBugReport);
+
+    // Get log info from server
+    UDATA.Call('SRV_GET_LOG_INFO', {})
+      .then(data => {
+        setLogInfo(data);
+      })
+      .catch(err => {
+        console.error('Failed to get log info:', err);
+        setLogInfo({
+          logFilename: 'error getting log info'
+        });
+      });
+
     return () => {
       UDATA.AppStateChangeOff('PANELSTATE', evt_ToggleBugReport);
     };
@@ -68,7 +82,7 @@ function NCBugReport() {
         <label>Build Time</label>
         <div>{GIT_INFO.buildTime}</div>
         <label>Log file</label>
-        <div>{window.NC_CONFIG.dataset}.log</div>
+        <div>{logInfo.logFilename}</div>
         <label>Server IP</label>
         <div>{SETTINGS.ServerHostIP()}</div>
         <label>UADDR</label>

--- a/app/view/netcreate/components/NCDialog.jsx
+++ b/app/view/netcreate/components/NCDialog.jsx
@@ -51,7 +51,7 @@ class NCDialog extends React.Component {
     return (
       <div className="dialog">
         <div className="screen"></div>
-        <Draggable>
+        <Draggable cancel="input, textarea, select, button, .no-drag">
           <div className="dialogwindow">
             <div className="dialogmessage">{message}</div>
             <div className="dialogcontrolbar">

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -667,7 +667,10 @@ class NCEdge extends UNISYS.Component {
    */
   LookupBackgroundColor(type) {
     const COLORMAP = this.AppState('COLORMAP');
-    const uBackgroundColor = COLORMAP.edgeColorMap[type] || '#555555';
+    // Use empty string as fallback for undefined type if an empty type has been defined
+    const normalizedType =
+      type === undefined && COLORMAP.edgeColorMap[''] ? '' : type;
+    const uBackgroundColor = COLORMAP.edgeColorMap[normalizedType] || '#555555';
     return uBackgroundColor;
   }
   LookupSourceTargetNodeColor({ dSourceNode, dTargetNode } = this.state) {

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -211,10 +211,10 @@
 }
 .nccomponent .formview label {
   font-size: var(--font-size-xs);
-  line-height: var(--font-size-normal);
+  line-height: var(--font-size-sm);
   opacity: 0.7;
   text-align: right;
-  margin-bottom: 0; /* override bootstrap */
+  margin-bottom: 0.25rem; /* override bootstrap */
 }
 .nccomponent .formview.typeview {
   /* match .formview with column gap*/

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -209,12 +209,21 @@
 .nccomponent .edit .formview {
   row-gap: 10px;
 }
-.nccomponent .formview label {
+.nccomponent .formview > label {
   font-size: var(--font-size-xs);
   line-height: var(--font-size-sm);
   opacity: 0.7;
   text-align: right;
   margin-bottom: 0.25rem; /* override bootstrap */
+}
+
+/* Type View */
+.nccomponent.ncedge .formview.typeview,
+.nccomponent.ncedge .typeview label,
+.nccomponent.ncedge .typeview div {
+  display: inline;
+  padding-right: 0.25rem;
+  line-height: 1.25rem;
 }
 .nccomponent .formview.typeview {
   /* match .formview with column gap*/
@@ -226,7 +235,8 @@
 }
 .nccomponent .formview .edgetypeRow {
   display: grid;
-  grid-template-columns: 18px 1fr;
+  grid-template-columns: 22px 1fr;
+  align-items: center;
   column-gap: 10px;
   margin-bottom: 0;
 }
@@ -245,7 +255,6 @@
   max-width: 225px;
 }
 .nccomponent .formview div.targetarrow {
-  margin-top: -5px;
   text-align: center;
   font-size: 18px;
   font-weight: bold;

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -538,7 +538,10 @@ class NCNode extends UNISYS.Component {
    */
   LookupBackgroundColor(type) {
     const COLORMAP = this.AppState('COLORMAP');
-    const uBackgroundColor = COLORMAP.nodeColorMap[type] || '#555555';
+    // Use empty string as fallback for undefined type if an empty type has been defined
+    const normalizedType =
+      type === undefined && COLORMAP.nodeColorMap[''] ? '' : type;
+    const uBackgroundColor = COLORMAP.nodeColorMap[normalizedType] || '#555555';
     return uBackgroundColor;
   }
 

--- a/app/view/netcreate/components/URCommentThread.jsx
+++ b/app/view/netcreate/components/URCommentThread.jsx
@@ -144,7 +144,7 @@ function URCommentThread({ uiref, cref, uid, x, y }) {
   const showAddCommentClickTarget = !CMTMGR.GetCommentsAreBeingEdited();
 
   return (
-    <Draggable>
+    <Draggable cancel="input, textarea, select, button, .no-drag">
       <div
         className="commentThread"
         style={{ left: `${x}px`, top: `${y}px`, maxHeight: commentMaxHeight }}

--- a/app/view/netcreate/components/URDialog.jsx
+++ b/app/view/netcreate/components/URDialog.jsx
@@ -53,7 +53,7 @@ function URDialog({ info }) {
     isOpen && (
       <div id="urdialog">
         <div className="screen"></div>
-        <Draggable>
+        <Draggable cancel="input, textarea, select, button, .no-drag">
           <div className="dialogwindow">
             <div className="dialogmessage">{message}</div>
             <div className="dialogcontrolbar">

--- a/app/view/netcreate/components/URPopover.jsx
+++ b/app/view/netcreate/components/URPopover.jsx
@@ -35,7 +35,7 @@ function URPopover({ title, onClose, children }) {
     </button>
   );
   return (
-    <Draggable cancel=".no-drag">
+    <Draggable cancel="input, textarea, select, button, .no-drag">
       <div id="popover">
         <div className="popover-toolbar">
           {title}

--- a/app/view/netcreate/components/URPopover.jsx
+++ b/app/view/netcreate/components/URPopover.jsx
@@ -20,7 +20,7 @@ const PR = 'URPopover';
 
 /// REACT FUNCTIONAL COMPONENT ////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-function URPopover({ title, onClose, children }) {
+function URPopover({ title, onClose, children, classOverride }) {
   /// COMPONENT RENDER ////////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   const BTN_CLOSE = (
@@ -36,7 +36,7 @@ function URPopover({ title, onClose, children }) {
   );
   return (
     <Draggable cancel="input, textarea, select, button, .no-drag">
-      <div id="popover">
+      <div id="popover" className={classOverride}>
         <div className="popover-toolbar">
           {title}
           {BTN_CLOSE}

--- a/app/view/netcreate/components/URTable.css
+++ b/app/view/netcreate/components/URTable.css
@@ -3,7 +3,7 @@
   --bg-thead-clr: #fdfdff;
   --bg-selected-clr: #eef;
   --bg-hover-clr: #ddf;
-  --tabletip-hover-clr: #ccf;
+  --tabletip-hover-clr: var(--clr-bg);
   /* layout */
   --padding-horizontal: 5px;
   --row-height: 1em;
@@ -18,17 +18,24 @@
   /* top: 0; */
   /* z-index: 1; for some reason EdgeTable can't set z to 1 or thead will cover tabletip */
 }
+.URTable th,
+.URTable td {
+  border-bottom: 1px solid var(--clr-system-fadedmost);
+}
 .URTable th {
-  padding: 0 var(--padding-horizontal);
-  border-right: 1px solid #999;
+  padding: 2px var(--padding-horizontal);
+  /* border-right: 1px solid #999; */
   background-color: var(--bg-thead-clr);
   top: 0;
   position: -webkit-sticky;
   position: sticky; /* needed for resizing columns */
+  text-align: left;
   z-index: 1; /* for some reason EdgeTable requires this or body cells will cover td */
 }
-.URTable th.selected {
-  background-color: var(--bg-selected-clr);
+.URTable th.selected,
+.URTable th.selected:hover {
+  color: var(--clr-cat-fg);
+  background-color: var(--clr-cat-bg);
 }
 .URTable thead,
 .URTable thead > tr,
@@ -42,7 +49,8 @@
   display: none;
 }
 .URTable th:hover {
-  background-color: var(--bg-hover-clr);
+  color: inherit;
+  background-color: var(--clr-bg);
   cursor: default;
 }
 .URTable th:hover span {
@@ -60,7 +68,7 @@
 }
 
 .URTable tr:hover {
-  background-color: var(--bg-hover-clr);
+  background-color: var(--clr-bg);
 }
 .URTable td {
   padding: 0 var(--padding-horizontal);
@@ -121,13 +129,13 @@
 .URTable .tabletip p {
   margin: 0; /* override markdown text spacing */
 }
-.URTable td:hover {
+.URTable tr td:hover {
   overflow: visible;
   background-color: var(--tabletip-hover-clr);
   position: relative;
   z-index: 200;
 }
-.URTable td:hover .tabletip .tabletip-text {
+.URTable tr td:hover .tabletip .tabletip-text {
   visibility: visible;
   opacity: 1;
   z-index: 200;
@@ -135,17 +143,17 @@
 .URTable td:hover .tabletip .tabletip-text a {
   color: #ccf;
 }
-.URTable td:hover .tabletip .tabletip-text img {
+.URTable tr td:hover .tabletip .tabletip-text img {
   max-width: 300px;
   max-height: 300px;
 }
-.URTable td:hover .tabletip-source {
+.URTable tr td:hover .tabletip-source {
   position: relative;
   padding-top: var(--padding-horizontal);
   padding-right: var(--padding-horizontal); /* gap next column */
   padding-bottom: var(--padding-horizontal);
   background-color: var(--tabletip-hover-clr);
 }
-.URTable td:hover .tabletip-source p {
+.URTable tr td:hover .tabletip-source p {
   background-color: var(--tabletip-hover-clr); /* override markdown p */
 }

--- a/app/view/netcreate/nc-ui.js
+++ b/app/view/netcreate/nc-ui.js
@@ -82,6 +82,7 @@ function Markdownify(str = '') {
   const htmlString = MD.render(str);
   // HACK!!! MDPARSE does not give us direct access to the dom elements, so just
   // hack it by adding to the parsed html string
+  // Add target="_blank" to all links
   const hackedHtmlString = htmlString.replace(/<a href/g, `<a target="_blank" href`);
   return MDPARSE(hackedHtmlString);
 }
@@ -651,6 +652,11 @@ function m_RenderNumberInput(key, value, cb, helpText) {
 /** There are two levels of callbacks necessary here.
  *  1. The `onChange` handler (in this module) processes the input's onChange event, and...
  *  2. ...then passes the resulting value to the `cb` function in the parent module.
+ *
+ *  If there isn't a default "" option, add one so that the user can clear the selection.
+ *  Otherwise, the default "" option will appear to be selected, but in fact is not selected.
+ *  Try to show the help text in the select dropdown.
+ *  If the help text is not defined, it will use the `displayLabel`
  *  @param {string} key
  *  @param {string} value
  *  @param {function} cb
@@ -659,6 +665,8 @@ function m_RenderNumberInput(key, value, cb, helpText) {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function RenderOptionsInput(key, value, defs, cb, helpText) {
   const options = defs[key].options;
+  // If there isn't a default "" option, add one
+  if (!options.some(o => o.label === '')) options.unshift({ label: '', value: '' });
   return (
     <div key={`${key}div`}>
       <div className="help">{helpText}</div>

--- a/app/view/netcreate/panel-mgr.js
+++ b/app/view/netcreate/panel-mgr.js
@@ -6,6 +6,8 @@
   status of panel components, including:
   - NCVocabulary
   - NCHelp
+  - NCAdvancedPanel
+  - NCBugReport
 
 
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
@@ -38,7 +40,8 @@ function m_Init() {
   const PANELSTATE = {
     advancedIsOpen: false,
     helpIsOpen: false,
-    vocabIsOpen: false
+    vocabIsOpen: false,
+    bugreportIsOpen: false
   };
   UDATA.SetAppState('PANELSTATE', PANELSTATE);
 }
@@ -53,6 +56,9 @@ function HelpIsOpen() {
 }
 function VocabIsOpen() {
   return UDATA.AppState('PANELSTATE').vocabIsOpen;
+}
+function BugreportIsOpen() {
+  return UDATA.AppState('PANELSTATE').bugreportIsOpen;
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function ToggleAdvanced() {
@@ -76,6 +82,13 @@ function ToggleVocabulary() {
     vocabIsOpen: !PANELSTATE.vocabIsOpen
   });
 }
+function ToggleBugreport() {
+  const PANELSTATE = UDATA.AppState('PANELSTATE');
+  UDATA.SetAppState('PANELSTATE', {
+    ...PANELSTATE,
+    bugreportIsOpen: !PANELSTATE.bugreportIsOpen
+  });
+}
 
 /// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -83,7 +96,9 @@ module.exports = {
   AdvancedIsOpen,
   HelpIsOpen,
   VocabIsOpen,
+  BugreportIsOpen,
   ToggleAdvanced,
   ToggleHelp,
-  ToggleVocabulary
+  ToggleVocabulary,
+  ToggleBugreport
 };

--- a/app/view/netcreate/render-mgr.js
+++ b/app/view/netcreate/render-mgr.js
@@ -93,7 +93,10 @@ function m_UpdateNodes(nodes) {
     const isSecondarySelected = SELECTION.selectedSecondary === n.id;
     const isFound = foundNodes.includes(n.id);
     // FIXME: Just copy over relevant attributes, don't copy the whole object!!!!
-    n.color = COLORMAP.nodeColorMap[n.type];
+    // Use default blank color if it's available
+    const normalizedType =
+      n.type === undefined && COLORMAP.nodeColorMap[''] ? '' : n.type;
+    n.color = COLORMAP.nodeColorMap[normalizedType];
     n.opacity = n.filteredTransparency;
     n.size = Math.min(TEMPLATE.nodeSizeDefault + n.degrees, TEMPLATE.nodeSizeMax);
     n.selected = false;

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
     "_mur/"
   ],
   "scripts": {
-    "dev": ". ./@build-ursys-min.sh && brunch w -s",
+    "dev": "node scripts/generate-git-info.js && . ./@build-ursys-min.sh && brunch w -s",
     "lint": "npm exec --workspaces -- npm run lint && eslint app/",
     "dev:inspect": "node --inspect brunch-server.js",
-    "classroom": "brunch build -e classroom",
-    "package": ". ./@build-ursys-min.sh && brunch build -e package",
+    "package": "node scripts/generate-git-info.js && ./@build-ursys-min.sh && brunch build -e package",
+    "classroom": "node scripts/generate-git-info.js && brunch build -e classroom",
     "package:debug": "brunch watch -e package_debug -s",
     "clean": "rm -rf ./public ./node_modules && npm exec --workspaces -- npm run clean",
     "debug": "LOGGY_STACKS=true BRUNCH_DEVTOOLS=true ./brunch-debug watch --server",

--- a/scripts/generate-git-info.js
+++ b/scripts/generate-git-info.js
@@ -5,13 +5,24 @@ const path = require('path');
 
 function getGitInfo() {
   try {
-    const branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+      encoding: 'utf8'
+    }).trim();
     const commit = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
-    const shortCommit = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
-    const commitDate = execSync('git log -1 --format=%cd --date=iso', { encoding: 'utf8' }).trim();
-    const commitMessage = execSync('git log -1 --pretty=%B', { encoding: 'utf8' }).trim();
-    const isDirty = execSync('git diff --quiet && git diff --cached --quiet || echo "dirty"', { encoding: 'utf8' }).trim() === 'dirty';
-    
+    const shortCommit = execSync('git rev-parse --short HEAD', {
+      encoding: 'utf8'
+    }).trim();
+    const commitDate = execSync('git log -1 --format=%cd --date=iso', {
+      encoding: 'utf8'
+    }).trim();
+    const commitMessage = execSync('git log -1 --pretty=%B', {
+      encoding: 'utf8'
+    }).trim();
+    const isDirty =
+      execSync('git diff --quiet && git diff --cached --quiet || echo "dirty"', {
+        encoding: 'utf8'
+      }).trim() === 'dirty';
+
     return {
       branch,
       commit,
@@ -39,7 +50,7 @@ function getGitInfo() {
 const gitInfo = getGitInfo();
 
 // Write to a file that can be imported
-const outputPath = path.join(__dirname, '../app/system/git-info.js');
+const outputPath = path.join(__dirname, '../app-config/git-info.js');
 const content = `// Auto-generated git information
 module.exports = ${JSON.stringify(gitInfo, null, 2)};
 `;

--- a/scripts/generate-git-info.js
+++ b/scripts/generate-git-info.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function getGitInfo() {
+  try {
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
+    const commit = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+    const shortCommit = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+    const commitDate = execSync('git log -1 --format=%cd --date=iso', { encoding: 'utf8' }).trim();
+    const commitMessage = execSync('git log -1 --pretty=%B', { encoding: 'utf8' }).trim();
+    const isDirty = execSync('git diff --quiet && git diff --cached --quiet || echo "dirty"', { encoding: 'utf8' }).trim() === 'dirty';
+    
+    return {
+      branch,
+      commit,
+      shortCommit,
+      commitDate,
+      commitMessage,
+      isDirty,
+      buildTime: new Date().toISOString()
+    };
+  } catch (error) {
+    console.warn('Could not get git info:', error.message);
+    return {
+      branch: 'unknown',
+      commit: 'unknown',
+      shortCommit: 'unknown',
+      commitDate: 'unknown',
+      commitMessage: 'unknown',
+      isDirty: false,
+      buildTime: new Date().toISOString()
+    };
+  }
+}
+
+// Generate the git info
+const gitInfo = getGitInfo();
+
+// Write to a file that can be imported
+const outputPath = path.join(__dirname, '../app/system/git-info.js');
+const content = `// Auto-generated git information
+module.exports = ${JSON.stringify(gitInfo, null, 2)};
+`;
+
+fs.writeFileSync(outputPath, content);
+console.log('Git info written to:', outputPath);


### PR DESCRIPTION
A number of minor fixes and a few new minor features.

# New Feature

## Bug Report

See #405, #419.

A new Bug Report window is now displayed for teachers to report bugs.
- A small "Bug Report" button is displayed in the lower left (a caution icon for now...I had tried a bug but that was too attention-grabbing).
- Clicking it will open the Bug Report window, showing:
   - Loki file name
   - Template file name
   - Git branch
   - Git commit
   - Build time
   - Log file name
   - Server IP
   - UADDR
- The intended use is for the teacher to simply screen capture the error and send it to Joshua.
- The Bug Report is draggable.
- 
<img width="869" height="598" alt="screenshot_331" src="https://github.com/user-attachments/assets/96b0ba91-17d3-46a4-99a0-873e14eb7b94" />

<img width="869" height="598" alt="screenshot_330" src="https://github.com/user-attachments/assets/e7174bd6-6684-49d8-81e3-f6702675514a" />

# Fixes

- NCNode labels line heights now show better grouping so a multi-line label reads as a single group
- NCEdge "Type" label is now displayed more compactly on a single line
- NCEdge Source/Target selection Help window is now properly displayed above the source/target (was mistakenly displayed at the top of the Edge component.
- Dragging of input elements, buttons, etc. is now disabled on Draggable and URPopOver components.