### PR TITLE
Add utility function to remove diacritic marks when comparing text (but leave them in original)

### DIFF
--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -542,6 +542,12 @@ function m_MatchString(needle, haystack, contains = true) {
   return contains ? ResultsAND : !ResultsAND;
 }
 function m_MatchStringSnippet(needle, haystack, contains = true) {
+  // Normalize and strip diacritics
+  const normalize = str => str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
+  needle = normalize(needle);
+  haystack = normalize(haystack);
+
   const regex = new RegExp(/*'^'+*/ needle, 'i');
   let matches;
   if (needle === '') {

--- a/app/view/netcreate/filter-mgr.js
+++ b/app/view/netcreate/filter-mgr.js
@@ -543,10 +543,9 @@ function m_MatchString(needle, haystack, contains = true) {
 }
 function m_MatchStringSnippet(needle, haystack, contains = true) {
   // Normalize and strip diacritics
-  const normalize = str => str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 
-  needle = normalize(needle);
-  haystack = normalize(haystack);
+  needle = UTILS.RemoveDiacriticMarks(needle);
+  haystack = UTILS.RemoveDiacriticMarks(haystack);
 
   const regex = new RegExp(/*'^'+*/ needle, 'i');
   let matches;

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -1032,7 +1032,7 @@ function m_SetMatchingNodesByLabel(str = '', yes = {}, no = {}) {
   let returnMatches = [];
 
   // Escape special regex characters in the search string and remove diacritics
-  str = RemoveDiacriticMarks(str.trim());
+  str = UTILS.RemoveDiacriticMarks(str.trim());
   str = u_EscapeRegexChars(str); // Escape special regex characters
 
   if (str === '') return undefined;

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -1013,16 +1013,13 @@ MOD.FindMatchingNodesByLabel = label => {
 function m_FindMatchingNodesByLabel(str = '') {
   if (!str) return [];
   // Normalize and remove diacritics from input
-  str = str
-    .trim()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '');
+  str = UTILS.RemoveDiacriticMarks(str);
   str = u_EscapeRegexChars(str.trim());
   if (str === '') return [];
   const regex = new RegExp(/*'^'+*/ str, 'i');
   return NCDATA.nodes.filter(node => {
     // Normalize and remove diacritics from node label
-    const label = node.label.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    const label = UTILS.RemoveDiacriticMarks(node.label);
     return regex.test(label);
   });
 }
@@ -1033,7 +1030,11 @@ function m_FindMatchingNodesByLabel(str = '') {
  */
 function m_SetMatchingNodesByLabel(str = '', yes = {}, no = {}) {
   let returnMatches = [];
-  str = u_EscapeRegexChars(str.trim());
+
+  // Escape special regex characters in the search string and remove diacritics
+  str = RemoveDiacriticMarks(str.trim());
+  str = u_EscapeRegexChars(str); // Escape special regex characters
+
   if (str === '') return undefined;
   const regex = new RegExp(/*'^'+*/ str, 'i');
   NCDATA.nodes.forEach(node => {

--- a/app/view/netcreate/nc-logic.js
+++ b/app/view/netcreate/nc-logic.js
@@ -1012,10 +1012,19 @@ MOD.FindMatchingNodesByLabel = label => {
 };
 function m_FindMatchingNodesByLabel(str = '') {
   if (!str) return [];
+  // Normalize and remove diacritics from input
+  str = str
+    .trim()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
   str = u_EscapeRegexChars(str.trim());
   if (str === '') return [];
   const regex = new RegExp(/*'^'+*/ str, 'i');
-  return NCDATA.nodes.filter(node => regex.test(node.label));
+  return NCDATA.nodes.filter(node => {
+    // Normalize and remove diacritics from node label
+    const label = node.label.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    return regex.test(label);
+  });
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** Set nodes that PARTIALLY match 'str' to 'yes' props.

--- a/app/view/netcreate/nc-utils.js
+++ b/app/view/netcreate/nc-utils.js
@@ -90,11 +90,21 @@ function DeriveInfoOriginString(author, ms) {
   return `Created by ${author} on ${new Date(ms).toLocaleString()}`;
 }
 
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** API METHOD
+ *  Removes diacritic marks for comparison purposes
+ *  @param {string} stringToProcess
+ */
+function RemoveDiacriticMarks(stringToProcess) {
+  return stringToProcess.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
 /// MODULE EXPORTS ///////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 module.exports = {
   GenerateUUID,
   RecalculateAllNodeDegrees,
   RecalculateAllEdgeSizes,
-  DeriveInfoOriginString
+  DeriveInfoOriginString,
+  RemoveDiacriticMarks
 };


### PR DESCRIPTION
In cases where diacritic marks exist, it may confuse users to have to type them out to find a match. For example, they may expect that an n will match with ñ etc. This adds a function to normalize the strings for comparison when searching or filtering. I opted not to include it in the duplicate warning in case they are different, as the search will show the duplicates anyhow.