### PR TITLE
Add Tol "Bright" Color Scheme

### DIFF
--- a/app-templates/_default.template.toml
+++ b/app-templates/_default.template.toml
@@ -341,7 +341,37 @@ includeInGraphTooltip = true
 isProvenance = false
 hidden = false
 
+  # 2.1 bright
+  # Paul Tol https://cran.r-project.org/web/packages/khroma/vignettes/tol.html
+
   [[nodeDefs.type.options]]
+  color = "#bbbbbb"
+  label = ""
+
+  [[nodeDefs.type.options]]
+  color = "#4477aa"
+  label = "Blue"
+
+  [[nodeDefs.type.options]]
+  color = "#66ccee"
+  label = "Cyan"
+
+  [[nodeDefs.type.options]]
+  color = "#228833"
+  label = "Green"
+
+  [[nodeDefs.type.options]]
+  color = "#ccbb44"
+  label = "Yellow"
+
+  [[nodeDefs.type.options]]
+  color = "#ee6677"
+  label = "Red"
+
+  [[nodeDefs.type.options]]
+  color = "#aa3377"
+  label = "Purple"
+
   color = "#eeeeee"
   label = ""
 
@@ -452,9 +482,36 @@ help = "Type of edge connection"
 isProvenance = false
 hidden = false
 
+  # 2.1 bright
+  # Paul Tol https://cran.r-project.org/web/packages/khroma/vignettes/tol.html
+
   [[edgeDefs.type.options]]
-  color = "#eeeeee"
+  color = "#bbbbbb"
   label = ""
+
+  [[edgeDefs.type.options]]
+  color = "#4477aa"
+  label = "Blue"
+
+  [[edgeDefs.type.options]]
+  color = "#66ccee"
+  label = "Cyan"
+
+  [[edgeDefs.type.options]]
+  color = "#228833"
+  label = "Green"
+
+  [[edgeDefs.type.options]]
+  color = "#ccbb44"
+  label = "Yellow"
+
+  [[edgeDefs.type.options]]
+  color = "#ee6677"
+  label = "Red"
+
+  [[edgeDefs.type.options]]
+  color = "#aa3377"
+  label = "Purple"
 
 [edgeDefs.notes]
 type = "string"

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -35,6 +35,7 @@ const LOCKMGR = require('../lock-mgr');
 const CMTMGR = require('../comment-mgr');
 const NCLOGIC = require('../nc-logic');
 const NCUI = require('../nc-ui');
+const UTILS = require('../nc-utils');
 const NCAutoSuggest = require('./NCAutoSuggest');
 const NCDialog = require('./NCDialog');
 const NCDialogCitation = require('./NCDialogCitation');
@@ -912,7 +913,7 @@ class NCEdge extends UNISYS.Component {
       type,
       isAdmin
     } = this.state;
-    const bgcolor = uBackgroundColor + '66'; // hack opacity
+    const bgcolor = UTILS.hex2rgba(uBackgroundColor, 0.5); // hack opacity
     const TEMPLATE = this.AppState('TEMPLATE');
     const defs = TEMPLATE.edgeDefs;
     const uShowCitationButton = TEMPLATE.citation && !TEMPLATE.citation.hidden;
@@ -1044,7 +1045,7 @@ class NCEdge extends UNISYS.Component {
       dSourceNode,
       dTargetNode
     } = this.state;
-    const bgcolor = uBackgroundColor + '99'; // hack opacity
+    const bgcolor = UTILS.hex2rgba(uBackgroundColor, 0.6); // hack opacity
     const defs = this.AppState('TEMPLATE').edgeDefs;
     const AskNodeDialog = uNewNodeLabel ? (
       <NCDialog

--- a/app/view/netcreate/components/NCEdge.jsx
+++ b/app/view/netcreate/components/NCEdge.jsx
@@ -937,8 +937,9 @@ class NCEdge extends UNISYS.Component {
         >
           {/* BUILT-IN - - - - - - - - - - - - - - - - - */}
           <div className="titlebar" style={{ marginBottom: '3px' }}>
-            <div className="nodenumber">EDGE {id} </div>
-            <div></div>
+            <div className="nodelabel">
+              <div className="nodenumber">EDGE #{id} </div>
+            </div>
             <URCommentVBtn cref={collection_ref} key={collection_ref} />
           </div>
           <div className="formview">

--- a/app/view/netcreate/components/NCNode.css
+++ b/app/view/netcreate/components/NCNode.css
@@ -218,21 +218,29 @@
 }
 
 /* Type View */
-.nccomponent.ncedge .formview.typeview,
-.nccomponent.ncedge .typeview label,
-.nccomponent.ncedge .typeview div {
-  display: inline;
-  padding-right: 0.25rem;
-  line-height: 1.25rem;
-}
 .nccomponent .formview.typeview {
   /* match .formview with column gap*/
-  grid-template-columns: 50px auto;
+  display: flex;
+  column-gap: 0.5rem;
 }
 .nccomponent .formview.typeview label {
+  text-align: left; /* override regular formview */
+  padding-left: 0.5rem; /* match .titlebar */
   color: #666;
   opacity: 1;
 }
+
+.nccomponent.ncedge .formview.typeview,
+.nccomponent.ncedge .formview.typeview div {
+  display: inline;
+  line-height: 1.25rem;
+}
+.nccomponent.ncedge .formview.typeview label {
+  display: inline;
+  padding-left: 0; /* override ncnode typeview */
+  padding-right: 0.25rem;
+}
+
 .nccomponent .formview .edgetypeRow {
   display: grid;
   grid-template-columns: 22px 1fr;
@@ -324,17 +332,16 @@
 
 .nccomponent .titlebar {
   display: grid;
-  grid-template-columns: 60px auto 34px;
+  grid-template-columns: auto 34px;
   align-items: center;
-  /* display: flex;
-  justify-content: space-between;
-  align-items: baseline; */
+  padding-left: 0.5rem;
 }
 .nccomponent .titlebar .nodenumber {
   font-size: 10px;
+  font-weight: var(--font-weight-normal);
   line-height: 26px; /* match CommmentBtn */
   color: #666;
-  padding-right: 0.4em;
+  padding-left: 1rem;
 }
 .nccomponent .titlebar .nodelabel label {
   margin-bottom: 0; /* override bootstrap */

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -46,6 +46,7 @@ const { BUILTIN_FIELDS_NODE } = require('system/util/enum');
 const { EDGE_NOT_SET_LABEL, ARROW_RIGHT } = require('system/util/constant');
 const NCLOGIC = require('../nc-logic');
 const NCUI = require('../nc-ui');
+const UTILS = require('../nc-utils');
 const NCEdge = require('./NCEdge');
 const NCDialogCitation = require('./NCDialogCitation');
 const SETTINGS = require('settings');
@@ -749,7 +750,7 @@ class NCNode extends UNISYS.Component {
     const TEMPLATE = this.AppState('TEMPLATE');
     const defs = TEMPLATE.nodeDefs;
     const uShowCitationButton = TEMPLATE.citation && !TEMPLATE.citation.hidden;
-    const bgcolor = uBackgroundColor + '44'; // hack opacity
+    const bgcolor = UTILS.hex2rgba(uBackgroundColor, 0.5); // hack opacity
     const citation =
       `NetCreate ${TEMPLATE.name} network, ` +
       `Node: "${label}" (ID ${id}). ` +
@@ -869,7 +870,7 @@ class NCNode extends UNISYS.Component {
       type
     } = this.state;
     const defs = this.AppState('TEMPLATE').nodeDefs;
-    const bgcolor = uBackgroundColor + '66'; // hack opacity
+    const bgcolor = UTILS.hex2rgba(uBackgroundColor, 0.6); // hack opacity
     const matchList = matchingNodes
       ? matchingNodes.map(n => (
           <div key={`${n.label}${n.id}`} value={n.id}>
@@ -1005,7 +1006,7 @@ class NCNode extends UNISYS.Component {
             label: EDGE_NOT_SET_LABEL
           };
           const color = EDGEMGR.LookupEdgeColor(e, TEMPLATE);
-          const bgcolor = color + '33'; // opacity hack
+          const bgcolor = UTILS.hex2rgba(color, 0.33); // opacity hack
           if (e.id === selectedEdgeId) {
             return <NCEdge edgeId={e.id} parentNodeId={id} key={e.id} />;
           } else {

--- a/app/view/netcreate/components/NCNode.jsx
+++ b/app/view/netcreate/components/NCNode.jsx
@@ -764,8 +764,10 @@ class NCNode extends UNISYS.Component {
         <div className="view" style={{ background: bgcolor }}>
           {/* BUILT-IN - - - - - - - - - - - - - - - - - */}
           <div className="titlebar">
-            <div className="nodenumber">NODE {id}</div>
-            <div className="nodelabel">{NCUI.RenderLabel('label', label)}</div>
+            <div className="nodelabel">
+              {NCUI.RenderLabel('label', label)}
+              <span className="nodenumber">#{id}</span>
+            </div>
             <URCommentVBtn cref={collection_ref} key={collection_ref} />
             {/* use key to make sure URCommentVBtn refreshes */}
           </div>

--- a/app/view/netcreate/nc-utils.js
+++ b/app/view/netcreate/nc-utils.js
@@ -89,6 +89,36 @@ function RecalculateAllEdgeSizes(data) {
 function DeriveInfoOriginString(author, ms) {
   return `Created by ${author} on ${new Date(ms).toLocaleString()}`;
 }
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** API METHOD
+ * Converts a hex color to an rgba string.
+ * @param {string} hex - The hex color string (e.g., "#ff0000").
+ * @param {number} [alpha=1] - The alpha value for the rgba color (default is 1).
+ * @returns {string} The rgba color string (e.g., "rgba(255, 0, 0, 1)").
+ * @example
+ * const rgbaColor = hex2rgba("#ff0000", 0.5); // "rgba(255, 0, 0, 0.5)"
+ * const rgbaColor = hex2rgba("#00ff00"); // "rgba(0, 255, 0, 1)"
+ * const rgbaColor = hex2rgba("#0000ff", 0.8); // "rgba(0, 0, 255, 0.8)"
+ */
+function hex2rgba(hex, alpha = 1) {
+  // Remove the hash if present
+  hex = hex.replace('#', '');
+
+  // Handle 3-digit hex colors by expanding them to 6-digit
+  if (hex.length === 3) {
+    hex = hex
+      .split('')
+      .map(char => char + char)
+      .join('');
+  }
+
+  // Parse RGB values
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
 
 /// MODULE EXPORTS ///////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -96,5 +126,6 @@ module.exports = {
   GenerateUUID,
   RecalculateAllNodeDegrees,
   RecalculateAllEdgeSizes,
-  DeriveInfoOriginString
+  DeriveInfoOriginString,
+  hex2rgba
 };


### PR DESCRIPTION
Added "2.1 bright" color scheme from Paul Tol https://cran.r-project.org/web/packages/khroma/vignettes/tol.html
for Node and Edge types.

## Minor UI Fixes
- Added a hext2rgba utility to add an alpha for properly setting the Node and Edge background colors.  (Removed original placeholder string hack that would break if a rgba value was used).
- The "Node" label is now left justified with the node number displayed to the right of the label ala Evan's design.
- The Node and Edge "Type" menu layout is now adjusted to it is more compact.