### PR TITLE
Fix Advanced Panel Bugs

### DIFF
--- a/app/view/netcreate/components/NCAdvancedPanel.jsx
+++ b/app/view/netcreate/components/NCAdvancedPanel.jsx
@@ -53,11 +53,32 @@ const UDATAOwner = { name: 'NCAdvancedPanel' };
 const UDATA = UNISYS.NewDataLink(UDATAOwner);
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const DBG = false;
-const VIEWS = {
-  template: 'Template',
-  importexport: 'Import/Export',
-  usertokens: 'User Tokens',
-  settings: 'Settings'
+const TABS = {
+  EXPORT: {
+    id: 'export',
+    label: 'Export',
+    adminRequired: false
+  },
+  IMPORT_EXPORT: {
+    id: 'importexport',
+    label: 'Import/Export',
+    adminRequired: true
+  },
+  TEMPLATE: {
+    id: 'template',
+    label: 'Template',
+    adminRequired: true
+  },
+  SETTINGS: {
+    id: 'settings',
+    label: 'Settings',
+    adminRequired: true
+  },
+  USER_TOKENS: {
+    id: 'usertokens',
+    label: 'User Tokens',
+    adminRequired: true
+  }
 };
 
 /// REACT COMPONENT ///////////////////////////////////////////////////////////
@@ -140,6 +161,7 @@ function NCAdvancedPanel() {
   }
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   function ui_PasswordClear() {
+    setOpenTab('export'); // Revert to default export tab
     setPassword('');
   }
 
@@ -148,23 +170,25 @@ function NCAdvancedPanel() {
   const TABS = hasAdminPermissions
     ? VIEWS // show all tabs to admin
     : { export: 'Export' }; // show "Export" only
+  const activeTabs = Object.values(TABS).filter(tab =>
+    hasAdminPermissions ? tab.adminRequired : !tab.adminRequired
+  );
 
   let jsx;
   switch (openTab) {
-    case 'template':
+    case TABS.TEMPLATE.id:
       jsx = <NCTemplate />;
       break;
-    case 'importexport':
-    case 'export':
-      jsx = <NCImportExport isAdmin={hasAdminPermissions} />;
-      break;
-    case 'usertokens':
+    case TABS.USER_TOKENS.id:
       jsx = <NCUserTokens />;
       break;
-    case 'settings':
+    case TABS.SETTINGS.id:
       jsx = <MURSettingEditor />;
       break;
+    case TABS.IMPORT_EXPORT.id:
+    case TABS.EXPORT.id:
     default:
+      jsx = <NCImportExport isAdmin={hasAdminPermissions} />;
       break;
   }
 
@@ -172,15 +196,18 @@ function NCAdvancedPanel() {
 
   let adminStatus;
   if (hasAdminPermissions === undefined) {
+    // Admin Mode is disabled because the adminPassword has not been defined
     adminStatus = <span>Admin Mode Disabled</span>;
     console.log(`NOTE: "adminPassword" is not set (premature mount?)`);
   } else if (hasAdminPermissions === false)
+    // Admin Mode is disabled, show password
     adminStatus = (
       <label>
         admin: <input type="password" id="password" onChange={ui_PasswordChange} />
       </label>
     );
   else if (hasAdminPermissions === true)
+    // Admin Mode is enabled, show "Reset Password" button
     adminStatus = (
       <button type="button" onClick={ui_PasswordClear}>
         Admin Logout
@@ -191,17 +218,17 @@ function NCAdvancedPanel() {
     <URPopover title="Advanced" onClose={ui_CloseAdvanced}>
       <div id="NCTabPanel" className="NCAdvancedPanel">
         <div className="tabs" role="tablist">
-          {Object.keys(TABS).map(k => (
+          {activeTabs.map(tab => (
             <button
-              key={k}
+              key={tab.id}
               role="tab"
-              className={openTab === k ? 'selected' : ''}
-              aria-selected={openTab === k}
-              aria-controls={k}
-              tabIndex={openTab === k ? '0' : '-1'}
-              onClick={() => ui_SelectTab(k)}
+              className={openTab === tab.id ? 'selected' : ''}
+              aria-selected={openTab === tab.id}
+              aria-controls={tab.id}
+              tabIndex={openTab === tab.id ? '0' : '-1'}
+              onClick={() => ui_SelectTab(tab.id)}
             >
-              {TABS[k]}
+              {tab.label}
             </button>
           ))}
         </div>

--- a/app/view/netcreate/components/NCAdvancedPanel.jsx
+++ b/app/view/netcreate/components/NCAdvancedPanel.jsx
@@ -85,18 +85,8 @@ const TABS = {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// export a class object for consumption by brunch/require
 function NCAdvancedPanel() {
-  // HACK MAKE SURE TO CHANGE BACK BEFORE PR SUBMISSION -
-  // this completely bypasses the adminPassword checks //
-  let isOpen, setIsOpen;
-  let openTab, setOpenTab;
-  if (!DBG) {
-    [isOpen, setIsOpen] = useState(false);
-    [openTab, setOpenTab] = useState('importexport');
-  } else {
-    [isOpen, setIsOpen] = useState(true);
-    [openTab, setOpenTab] = useState('settings');
-  }
-  // HACK MAKE SURE TO CHANGE BACK BEFORE PR SUBMISSION -
+  const [isOpen, setIsOpen] = useState(false);
+  const [openTab, setOpenTab] = useState('importexport');
   const [password, setPassword] = useState('');
   const [hasAdminPermissions, setHasAdminPermissions] = useState(undefined);
 
@@ -131,16 +121,8 @@ function NCAdvancedPanel() {
       );
     const isAdmin =
       TEMPLATE && TEMPLATE.adminPassword && TEMPLATE.adminPassword === password;
-    if (!DBG) setHasAdminPermissions(isAdmin);
-    // HACK: disable admin password for prop-settings-2
-    else {
-      console.log(
-        '%c*** DBG Mode: AdminPassword Bypassed ***',
-        'color: red; font-weight: bold;'
-      );
-      setHasAdminPermissions(true);
-    }
-    // HACK END
+
+    setHasAdminPermissions(isAdmin);
 
     const PERMISSIONS = UDATA.AppState('PERMISSIONS');
     UDATA.SetAppState('PERMISSIONS', { ...PERMISSIONS, isAdmin });
@@ -167,9 +149,6 @@ function NCAdvancedPanel() {
 
   // COMPONENT RENDER ////////////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  const TABS = hasAdminPermissions
-    ? VIEWS // show all tabs to admin
-    : { export: 'Export' }; // show "Export" only
   const activeTabs = Object.values(TABS).filter(tab =>
     hasAdminPermissions ? tab.adminRequired : !tab.adminRequired
   );

--- a/app/view/netcreate/components/NCUserTokens.jsx
+++ b/app/view/netcreate/components/NCUserTokens.jsx
@@ -185,6 +185,9 @@ function NCUserTokens() {
           Generate Tokens
         </button>
         <div></div>
+        {/* Hide the "Shareable" functionality.  Joshua requested #427.
+            `secretKey` now requires validation so shareable tokens are
+            possible with a valid secretKey -- no need for extra shareable
         <fieldset>
           <legend>Advanced Options</legend>
           {!state.templateSalt && (
@@ -204,7 +207,7 @@ function NCUserTokens() {
             Shareable -- Make tokens usable for ANY graph without a template
             secretKey.
           </label>
-        </fieldset>
+        </fieldset> */}
       </div>
       <br />
       <label htmlFor="tokenDisplay">Copy and share these tokens.</label>


### PR DESCRIPTION
In Advanced Panel after admin logout, two problems:
- The currently selected panel will remain displayed. It should be cleared.
- The Export panel should be selected. (and the "Export" tab is grayed out/disabled -- but that would be fixed once we reselect the Export panel)

Fixes #407 

## Minor Fixes
- Removed "Shareable" checkbox #427 

## Lint/Cleanup
- Removed hack to skip adminPassword during dev