### PR TITLE
Safer Template Import

### DIFF
--- a/app/view/netcreate/components/NCImportExport.jsx
+++ b/app/view/netcreate/components/NCImportExport.jsx
@@ -348,30 +348,11 @@ class NCImportExport extends UNISYS.Component {
           <fieldset>
             <label>
               <input
-                id="import-replace"
-                type="radio"
-                name="importtype"
-                value={IMPORTTYPE.REPLACE}
-                defaultChecked
-              />
-              Replace
-            </label>
-            <div>
-              <p>
-                {' '}
-                <b>Replace</b> existing nodes and edges. Use this to <b>load</b> a new
-                project
-              </p>
-              <ul>
-                <li>Existing objects will be removed</li>
-              </ul>
-            </div>
-            <label>
-              <input
                 id="import-merge"
                 type="radio"
                 name="importtype"
                 value={IMPORTTYPE.MERGE}
+                defaultChecked
               />
               Merge
             </label>
@@ -388,6 +369,25 @@ class NCImportExport extends UNISYS.Component {
                   Existing objects that do not match imported nodes/edges will not be
                   modified or removed
                 </li>
+              </ul>
+            </div>
+            <label>
+              <input
+                id="import-replace"
+                type="radio"
+                name="importtype"
+                value={IMPORTTYPE.REPLACE}
+              />
+              Replace
+            </label>
+            <div>
+              <p>
+                {' '}
+                <b>Replace</b> existing nodes and edges. Use this to <b>load</b> a new
+                project
+              </p>
+              <ul>
+                <li>Existing objects will be removed</li>
               </ul>
             </div>
           </fieldset>

--- a/app/view/netcreate/components/NCImportExport.jsx
+++ b/app/view/netcreate/components/NCImportExport.jsx
@@ -387,7 +387,11 @@ class NCImportExport extends UNISYS.Component {
                 project
               </p>
               <ul>
-                <li>Existing objects will be removed</li>
+                <li style={{ color: `var(--clr-warning)` }}>
+                  WARNING: All existing nodes and edges will be removed before new
+                  nodes and edges are imported. If you do not include an Edges file,
+                  all edges will be removed.
+                </li>
               </ul>
             </div>
           </fieldset>


### PR DESCRIPTION
This improves template importing by:
1. Default import template method to "Merge" rather than "Replace"
2. Add warnings and instructions to clarify that replacing only nodes and NOT including the edges file will result in the removal of all edges.

Fixes #425 