### PR TITLE
ELA/History Default Template

### DIFF
--- a/app-templates/_default.template.toml
+++ b/app-templates/_default.template.toml
@@ -96,7 +96,7 @@ hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info
 includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
 options = { _control = "in_colorgroup",_controlDef = "NodeType", label = "Node Types", help = "Define custom Node Types" }
 
-[_ui.nodeDefs.notes]
+[_ui.nodeDefs.description]
 _control = "in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 exportLabel = { _control = "in_string", label = "Label for Export", help = "Label used when exporting data" }
@@ -104,7 +104,7 @@ help = { _control = "in_string", label = "Help Text", help = "Help text shown to
 hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
 includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
 
-[_ui.nodeDefs.info]
+[_ui.nodeDefs.othertext]
 _control = "in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 exportLabel = { _control = "in_string", label = "Label for Export", help = "Label used when exporting data" }
@@ -112,7 +112,24 @@ help = { _control = "in_string", label = "Help Text", help = "Help text shown to
 hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
 includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
 
-[_ui.nodeDefs.infoOrigin]
+[_ui.nodeDefs.sometype]
+_control = "in_composite"
+displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
+exportLabel = { _control = "in_string", label = "Label for Export", help = "Label used when exporting data" }
+help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
+hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
+includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
+options = { _control = "in_colorgroup",_controlDef = "NodeType", label = "Node Types", help = "Define custom Node Types" }
+
+[_ui.nodeDefs.somenumber]
+_control = "in_composite"
+displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
+exportLabel = { _control = "in_string", label = "Label for Export", help = "Label used when exporting data" }
+help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
+hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
+includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
+
+[_ui.nodeDefs.citation]
 _control = "in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 exportLabel = { _control = "in_string", label = "Label for Export", help = "Label used when exporting data" }
@@ -120,13 +137,6 @@ help = { _control = "in_string", label = "Help Text", help = "Help text shown to
 hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
 includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
 isProvenance = { _control = "in_boolean", label = "Is Provenance", help = "Whether this field tracks data provenance" }
-
-[_ui.nodeDefs.degrees]
-_control = "// in_composite"
-displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
-help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
-hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
-includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
 
 [_ui.nodeDefs.created]
 _control = "// in_composite"
@@ -150,6 +160,13 @@ hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info
 includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
 
 [_ui.nodeDefs.updatedBy]
+_control = "// in_composite"
+displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
+help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
+hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
+includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
+
+[_ui.nodeDefs.degrees]
 _control = "// in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
@@ -195,38 +212,22 @@ isProvenance = { _control = "in_boolean", label = "Is Provenance", help = "Wheth
 hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
 options = { _control = "in_colorgroup", label = "Edge Types", help = "Define custom Edge Types" }
 
-[_ui.edgeDefs.notes]
+[_ui.edgeDefs.description]
 _control = "in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
 isProvenance = { _control = "in_boolean", label = "Is Provenance", help = "Whether this field tracks data provenance" }
 hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
 
-[_ui.edgeDefs.weight]
-_control = "// in_composite"
-displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
-help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
-isRequired = { _control = "in_boolean", label = "Is Required", help = "Whether this field is required" }
-includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
-isProvenance = { _control = "in_boolean", label = "Is Provenance", help = "Whether this field tracks data provenance" }
-hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
-
-[_ui.edgeDefs.infoOrigin]
+[_ui.edgeDefs.sometype]
 _control = "in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
-includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
 isProvenance = { _control = "in_boolean", label = "Is Provenance", help = "Whether this field tracks data provenance" }
 hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
+options = { _control = "in_colorgroup", label = "Edge Types", help = "Define custom Edge Types" }
 
 [_ui.edgeDefs.citation]
-_control = "in_composite"
-displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
-help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
-isProvenance = { _control = "in_boolean", label = "Is Provenance", help = "Whether this field tracks data provenance" }
-hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
-
-[_ui.edgeDefs.category]
 _control = "in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
@@ -237,45 +238,35 @@ hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info
 _control = "// in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
-includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
 hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
 
 [_ui.edgeDefs.createdBy]
 _control = "// in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
-includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
 hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
 
 [_ui.edgeDefs.updated]
 _control = "// in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
-includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
 hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
 
 [_ui.edgeDefs.updatedBy]
 _control = "// in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
-includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
+hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
+
+[_ui.edgeDefs.weight]
+_control = "// in_composite"
+displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
+help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
+isRequired = { _control = "in_boolean", label = "Is Required", help = "Whether this field is required" }
+isProvenance = { _control = "in_boolean", label = "Is Provenance", help = "Whether this field tracks data provenance" }
 hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
 
 [_ui.edgeDefs.revision]
-_control = "// in_composite"
-displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
-help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
-includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
-hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
-
-[_ui.edgeDefs.sourceLabel]
-_control = "// in_composite"
-displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
-help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
-includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
-hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
-
-[_ui.edgeDefs.targetLabel]
 _control = "// in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
@@ -313,6 +304,8 @@ label = "Evidence Critique or Suggestion"
   prompt = "Tell me more"
   help = "Can you tell me more about ... "
   feedback = ""
+
+# NODES
 
 [nodeDefs.id]
 type = "number"
@@ -372,43 +365,53 @@ hidden = false
   color = "#aa3377"
   label = "Purple"
 
-  color = "#eeeeee"
-  label = ""
-
-[nodeDefs.notes]
-type = "string"
-displayLabel = "Notes"
-exportLabel = "Notes"
+[nodeDefs.description]
+type = "markdown"
+displayLabel = "Description"
+exportLabel = "Description"
 help = "General purpose notes text field"
 includeInGraphTooltip = true
 isProvenance = false
 hidden = false
 
-[nodeDefs.info]
+[nodeDefs.othertext]
+type = "markdown"
+displayLabel = "OtherText"
+exportLabel = "OtherText"
+help = "General purpose notes text field"
+includeInGraphTooltip = true
+isProvenance = false
+hidden = false
+
+[nodeDefs.sometype]
+type = "select"
+displayLabel = "SomeType"
+exportLabel = "SomeType"
+help = "Select a category"
+includeInGraphTooltip = true
+isProvenance = false
+hidden = false
+
+  [[nodeDefs.sometype.options]]
+  color = "#bbbbbb"
+  label = ""
+
+[nodeDefs.somenumber]
 type = "number"
-displayLabel = "Number"
-exportLabel = "Info"
+displayLabel = "SomeNumber"
+exportLabel = "SomeNumber"
 help = "Some number comparison"
 includeInGraphTooltip = true
 isProvenance = false
 hidden = false
 
-[nodeDefs.infoOrigin]
-type = "infoOrigin"
-displayLabel = "Info Origin"
-exportLabel = "infoOrigin"
-help = "Who created this?  (aka Source)"
+[nodeDefs.citation]
+type = "string"
+displayLabel = "Citation"
+exportLabel = "Citation"
+help = 'Source Book.Chapter (e.g. "Part 2 06.03")'
 includeInGraphTooltip = true
 isProvenance = true
-hidden = false
-
-[nodeDefs.degrees]
-type = "number"
-displayLabel = "Degrees"
-exportLabel = "Degrees"
-help = "Number of edges connected to this node"
-includeInGraphTooltip = true
-isProvenance = false
 hidden = false
 
 [nodeDefs.created]
@@ -443,6 +446,15 @@ help = "Author who updated the node"
 includeInGraphTooltip = true
 hidden = false
 
+[nodeDefs.degrees]
+type = "number"
+displayLabel = "Degrees"
+exportLabel = "Degrees"
+help = "Number of edges connected to this node"
+includeInGraphTooltip = true
+isProvenance = false
+hidden = false
+
 [nodeDefs.revision]
 type = "string"
 displayLabel = "Revision"
@@ -450,6 +462,8 @@ exportLabel = "Revision"
 help = "Number of times this node has been revised"
 includeInGraphTooltip = true
 hidden = true
+
+# EDGES
 
 [edgeDefs.id]
 type = "number"
@@ -513,12 +527,60 @@ hidden = false
   color = "#aa3377"
   label = "Purple"
 
-[edgeDefs.notes]
+[edgeDefs.description]
 type = "string"
-displayLabel = "Notes"
-exportLabel = "Notes"
-help = "Significance of the connection"
+displayLabel = "Description"
+exportLabel = "Description"
+help = "Description of the connection"
 isProvenance = false
+hidden = false
+
+[edgeDefs.sometype]
+type = "select"
+displayLabel = "SomeType"
+exportLabel = "SomeType"
+help = "Type of edge connection"
+isProvenance = false
+hidden = false
+
+  [[edgeDefs.sometype.options]]
+  color = "#bbbbbb"
+  label = ""
+
+[edgeDefs.citation]
+type = "string"
+displayLabel = "Citation"
+exportLabel = "Citation"
+help = 'Source Book.Chapter (e.g. "Part 2 06.03")'
+isProvenance = true
+hidden = false
+
+[edgeDefs.created]
+type = "timestamp"
+displayLabel = "Created"
+exportLabel = "Created"
+help = "Date and time edge was created"
+hidden = false
+
+[edgeDefs.createdBy]
+type = "string"
+displayLabel = "Created By"
+exportLabel = "Created By"
+help = "Author who created the edge"
+hidden = false
+
+[edgeDefs.updated]
+type = "timestamp"
+displayLabel = "Updated"
+exportLabel = "Updated"
+help = "Date and time edge was last modified"
+hidden = false
+
+[edgeDefs.updatedBy]
+type = "string"
+displayLabel = "Updated By"
+exportLabel = "Updated By"
+help = "Author who updated the edge"
 hidden = false
 
 [edgeDefs.weight]
@@ -527,71 +589,12 @@ defaultValue = 1
 displayLabel = "Weight"
 exportLabel = "Weight"
 help = "Weight of edge"
-includeInGraphTooltip = true
 isRequired = true
 isProvenance = false
-hidden = false
-
-[edgeDefs.infoOrigin]
-type = "string"
-displayLabel = "Info Origin"
-exportLabel = "InfoOrigin"
-help = "Who created this?  (aka Source)"
-includeInGraphTooltip = true
-isProvenance = true
-hidden = false
-
-[edgeDefs.citation]
-type = "string"
-displayLabel = "Citation"
-exportLabel = "Citation"
-help = 'Source Book.Chapter (e.g. "Part 2 06.03")'
-isProvenance = false
-hidden = false
-
-[edgeDefs.category]
-type = "string"
-displayLabel = "Category"
-exportLabel = "Category"
-help = "Category (deprecated)"
-isProvenance = false
-hidden = true
-
-[edgeDefs.created]
-type = "timestamp"
-displayLabel = "Created"
-exportLabel = "Created"
-includeInGraphTooltip = true
-help = "Date and time edge was created"
-hidden = false
-
-[edgeDefs.createdBy]
-type = "string"
-displayLabel = "Created By"
-exportLabel = "Created By"
-includeInGraphTooltip = true
-help = "Author who created the edge"
-hidden = false
-
-[edgeDefs.updated]
-type = "timestamp"
-displayLabel = "Updated"
-exportLabel = "Updated"
-includeInGraphTooltip = true
-help = "Date and time edge was last modified"
-hidden = false
-
-[edgeDefs.updatedBy]
-type = "string"
-displayLabel = "Updated By"
-exportLabel = "Updated By"
-includeInGraphTooltip = true
-help = "Author who updated the nodedgee"
 hidden = false
 
 [edgeDefs.revision]
 displayLabel = "Revision"
 exportLabel = "Revision"
-includeInGraphTooltip = true
 help = "Number of times this edge has been revised"
 hidden = true

--- a/app-templates/_default.template.toml
+++ b/app-templates/_default.template.toml
@@ -134,9 +134,18 @@ _control = "in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 exportLabel = { _control = "in_string", label = "Label for Export", help = "Label used when exporting data" }
 help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
+isProvenance = { _control = "in_boolean", label = "Is Provenance", help = "Whether this field tracks data provenance" }
 hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
 includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
+
+[_ui.nodeDefs.infoOrigin]
+_control = "in_composite"
+displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
+exportLabel = { _control = "in_string", label = "Label for Export", help = "Label used when exporting data" }
+help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
 isProvenance = { _control = "in_boolean", label = "Is Provenance", help = "Whether this field tracks data provenance" }
+hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
+includeInGraphTooltip = { _control = "in_boolean", label = "Include In Graph Tooltip?", help = "display additional info" }
 
 [_ui.nodeDefs.created]
 _control = "// in_composite"
@@ -228,6 +237,13 @@ hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info
 options = { _control = "in_colorgroup", label = "Edge Types", help = "Define custom Edge Types" }
 
 [_ui.edgeDefs.citation]
+_control = "in_composite"
+displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
+help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
+isProvenance = { _control = "in_boolean", label = "Is Provenance", help = "Whether this field tracks data provenance" }
+hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
+
+[_ui.edgeDefs.infoOrigin]
 _control = "in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
 help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
@@ -421,6 +437,15 @@ includeInGraphTooltip = true
 isProvenance = true
 hidden = false
 
+[nodeDefs.infoOrigin]
+type = "infoOrigin"
+displayLabel = "Info Source"
+exportLabel = "InfoSource"
+help = "Who created this?  (aka Source)"
+includeInGraphTooltip = true
+isProvenance = true
+hidden = false
+
 [nodeDefs.created]
 type = "timestamp"
 displayLabel = "Created"
@@ -559,6 +584,14 @@ type = "string"
 displayLabel = "Citation"
 exportLabel = "Citation"
 help = 'Source Book.Chapter (e.g. "Part 2 06.03")'
+isProvenance = true
+hidden = false
+
+[edgeDefs.infoOrigin]
+type = "infoOrigin"
+displayLabel = "Info Source"
+exportLabel = "InfoSource"
+help = "Who created this?  (aka Source)"
 isProvenance = true
 hidden = false
 

--- a/app-templates/_default.template.toml
+++ b/app-templates/_default.template.toml
@@ -234,6 +234,13 @@ help = { _control = "in_string", label = "Help Text", help = "Help text shown to
 isProvenance = { _control = "in_boolean", label = "Is Provenance", help = "Whether this field tracks data provenance" }
 hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
 
+[_ui.edgeDefs.othertext]
+_control = "in_composite"
+displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
+help = { _control = "in_string", label = "Help Text", help = "Help text shown to users" }
+isProvenance = { _control = "in_boolean", label = "Is Provenance", help = "Whether this field tracks data provenance" }
+hidden = { _control = "in_boolean", label = "Hide Field", help = "hide this info" }
+
 [_ui.edgeDefs.created]
 _control = "// in_composite"
 displayLabel = { _control = "in_string", label = "Label for Display", help = "Used as the label shown in the interface" }
@@ -553,6 +560,14 @@ displayLabel = "Citation"
 exportLabel = "Citation"
 help = 'Source Book.Chapter (e.g. "Part 2 06.03")'
 isProvenance = true
+hidden = false
+
+[edgeDefs.othertext]
+type = "string"
+displayLabel = "Other Text"
+exportLabel = "Other Text"
+help = "Additional information about the connection"
+isProvenance = false
 hidden = false
 
 [edgeDefs.created]

--- a/app-templates/_default.template.toml
+++ b/app-templates/_default.template.toml
@@ -366,7 +366,7 @@ hidden = false
   label = "Purple"
 
 [nodeDefs.description]
-type = "markdown"
+type = "string"
 displayLabel = "Description"
 exportLabel = "Description"
 help = "General purpose notes text field"
@@ -375,7 +375,7 @@ isProvenance = false
 hidden = false
 
 [nodeDefs.othertext]
-type = "markdown"
+type = "string"
 displayLabel = "OtherText"
 exportLabel = "OtherText"
 help = "General purpose notes text field"

--- a/app/unisys/server-template-schema.js
+++ b/app/unisys/server-template-schema.js
@@ -135,7 +135,7 @@ const NODES_SCHEMA20 = {
     hidden: 'boolean',
     options: 'nodeType[]'
   },
-  notes: {
+  description: {
     type: 'string',
     displayLabel: 'string',
     exportLabel: 'string',
@@ -144,7 +144,7 @@ const NODES_SCHEMA20 = {
     isProvenance: 'boolean',
     hidden: 'boolean'
   },
-  info: {
+  othertext: {
     type: 'string',
     displayLabel: 'string',
     exportLabel: 'string',
@@ -153,7 +153,17 @@ const NODES_SCHEMA20 = {
     isProvenance: 'boolean',
     hidden: 'boolean'
   },
-  infoOrigin: {
+  sometype: {
+    type: 'string',
+    displayLabel: 'string',
+    exportLabel: 'string',
+    help: 'string',
+    includeInGraphTooltip: 'boolean',
+    isProvenance: 'boolean',
+    hidden: 'boolean',
+    options: 'nodeType[]'
+  },
+  somenumber: {
     type: 'string',
     displayLabel: 'string',
     exportLabel: 'string',
@@ -162,7 +172,7 @@ const NODES_SCHEMA20 = {
     isProvenance: 'boolean',
     hidden: 'boolean'
   },
-  degrees: {
+  citation: {
     type: 'string',
     displayLabel: 'string',
     exportLabel: 'string',
@@ -201,6 +211,15 @@ const NODES_SCHEMA20 = {
     exportLabel: 'string',
     help: 'string',
     includeInGraphTooltip: 'boolean',
+    hidden: 'boolean'
+  },
+  degrees: {
+    type: 'string',
+    displayLabel: 'string',
+    exportLabel: 'string',
+    help: 'string',
+    includeInGraphTooltip: 'boolean',
+    isProvenance: 'boolean',
     hidden: 'boolean'
   },
   revision: {
@@ -248,7 +267,7 @@ const EDGES_SCHEMA20 = {
     hidden: 'boolean',
     options: 'edgeType[]'
   },
-  notes: {
+  description: {
     type: 'string',
     displayLabel: 'string',
     exportLabel: 'string',
@@ -256,35 +275,16 @@ const EDGES_SCHEMA20 = {
     isProvenance: 'boolean',
     hidden: 'boolean'
   },
-  weight: {
-    type: 'string',
-    defaultValue: 'number',
-    displayLabel: 'string',
-    exportLabel: 'string',
-    help: 'string',
-    includeInGraphTooltip: 'boolean',
-    isRequired: 'boolean',
-    isProvenance: 'boolean',
-    hidden: 'boolean'
-  },
-  infoOrigin: {
+  sometype: {
     type: 'string',
     displayLabel: 'string',
     exportLabel: 'string',
     help: 'string',
-    includeInGraphTooltip: 'boolean',
     isProvenance: 'boolean',
-    hidden: 'boolean'
+    hidden: 'boolean',
+    options: 'edgeType[]'
   },
   citation: {
-    type: 'string',
-    displayLabel: 'string',
-    exportLabel: 'string',
-    help: 'string',
-    isProvenance: 'boolean',
-    hidden: 'boolean'
-  },
-  category: {
     type: 'string',
     displayLabel: 'string',
     exportLabel: 'string',
@@ -296,7 +296,6 @@ const EDGES_SCHEMA20 = {
     type: 'string',
     displayLabel: 'string',
     exportLabel: 'string',
-    includeInGraphTooltip: 'boolean',
     help: 'string',
     hidden: 'boolean'
   },
@@ -304,7 +303,6 @@ const EDGES_SCHEMA20 = {
     type: 'string',
     displayLabel: 'string',
     exportLabel: 'string',
-    includeInGraphTooltip: 'boolean',
     help: 'string',
     hidden: 'boolean'
   },
@@ -312,7 +310,6 @@ const EDGES_SCHEMA20 = {
     type: 'string',
     displayLabel: 'string',
     exportLabel: 'string',
-    includeInGraphTooltip: 'boolean',
     help: 'string',
     hidden: 'boolean'
   },
@@ -320,14 +317,22 @@ const EDGES_SCHEMA20 = {
     type: 'string',
     displayLabel: 'string',
     exportLabel: 'string',
-    includeInGraphTooltip: 'boolean',
     help: 'string',
+    hidden: 'boolean'
+  },
+  weight: {
+    type: 'string',
+    defaultValue: 'number',
+    displayLabel: 'string',
+    exportLabel: 'string',
+    help: 'string',
+    isRequired: 'boolean',
+    isProvenance: 'boolean',
     hidden: 'boolean'
   },
   revision: {
     displayLabel: 'string',
     exportLabel: 'string',
-    includeInGraphTooltip: 'boolean',
     help: 'string',
     hidden: 'boolean'
   }

--- a/app/unisys/server-template-schema.js
+++ b/app/unisys/server-template-schema.js
@@ -181,6 +181,15 @@ const NODES_SCHEMA20 = {
     isProvenance: 'boolean',
     hidden: 'boolean'
   },
+  infoOrigin: {
+    type: 'string',
+    displayLabel: 'string',
+    exportLabel: 'string',
+    help: 'string',
+    includeInGraphTooltip: 'boolean',
+    isProvenance: 'boolean',
+    hidden: 'boolean'
+  },
   created: {
     type: 'string',
     displayLabel: 'string',
@@ -285,6 +294,14 @@ const EDGES_SCHEMA20 = {
     options: 'edgeType[]'
   },
   citation: {
+    type: 'string',
+    displayLabel: 'string',
+    exportLabel: 'string',
+    help: 'string',
+    isProvenance: 'boolean',
+    hidden: 'boolean'
+  },
+  infoOrigin: {
     type: 'string',
     displayLabel: 'string',
     exportLabel: 'string',

--- a/app/unisys/server-template-schema.js
+++ b/app/unisys/server-template-schema.js
@@ -292,6 +292,14 @@ const EDGES_SCHEMA20 = {
     isProvenance: 'boolean',
     hidden: 'boolean'
   },
+  othertext: {
+    type: 'string',
+    displayLabel: 'string',
+    exportLabel: 'string',
+    help: 'string',
+    isProvenance: 'boolean',
+    hidden: 'boolean'
+  },
   created: {
     type: 'string',
     displayLabel: 'string',

--- a/app/view/netcreate/components/MURColorGroup.jsx
+++ b/app/view/netcreate/components/MURColorGroup.jsx
@@ -52,7 +52,7 @@ function m_ExtractColorArrayProps(controlData) {
 function ColorGroup(props) {
   const { propDef } = props;
   const { draft, hasLock, dispatch } = React.useContext(RSB.SettingsContext);
-  const [sortType, setSortType] = React.useState('a-z');
+  const [sortType, setSortType] = React.useState('none');
 
   const controlData = RSB.GetDataForProp(draft.pending || draft.template, propDef);
   const colorProps = m_ExtractColorArrayProps(controlData);
@@ -81,13 +81,23 @@ function ColorGroup(props) {
   const handleSortChange = e => {
     const newSortType = e.target.value;
     setSortType(newSortType);
-    const sortedArray = [...sourceData].sort((a, b) => {
-      const labelA = (a.label || '').toLowerCase();
-      const labelB = (b.label || '').toLowerCase();
-      return newSortType === 'a-z'
-        ? labelA.localeCompare(labelB)
-        : labelB.localeCompare(labelA);
-    });
+    let sortedArray;
+
+    if (newSortType === 'none') {
+      // Revert to original template order by accessing the original template data
+      const originalControlData = RSB.GetDataForProp(draft.template, propDef);
+      const originalProps = m_ExtractColorArrayProps(originalControlData);
+      sortedArray = [...(originalProps.sourceData || [])];
+    } else {
+      // Sort current data
+      sortedArray = [...sourceData].sort((a, b) => {
+        const labelA = (a.label || '').toLowerCase();
+        const labelB = (b.label || '').toLowerCase();
+        return newSortType === 'a-z'
+          ? labelA.localeCompare(labelB) //  'a-z'
+          : labelB.localeCompare(labelA); // 'z-a'
+      });
+    }
     dispatch({
       op: 'update',
       propDef,
@@ -172,6 +182,7 @@ function ColorGroup(props) {
           value={sortType}
           onChange={handleSortChange}
         >
+          <option value="none">No</option>
           <option value="a-z">A-Z</option>
           <option value="z-a">Z-A</option>
         </select>

--- a/app/view/netcreate/components/NCImportExport.jsx
+++ b/app/view/netcreate/components/NCImportExport.jsx
@@ -348,30 +348,11 @@ class NCImportExport extends UNISYS.Component {
           <fieldset>
             <label>
               <input
-                id="import-replace"
-                type="radio"
-                name="importtype"
-                value={IMPORTTYPE.REPLACE}
-                defaultChecked
-              />
-              Replace
-            </label>
-            <div>
-              <p>
-                {' '}
-                <b>Replace</b> existing nodes and edges. Use this to <b>load</b> a new
-                project
-              </p>
-              <ul>
-                <li>Existing objects will be removed</li>
-              </ul>
-            </div>
-            <label>
-              <input
                 id="import-merge"
                 type="radio"
                 name="importtype"
                 value={IMPORTTYPE.MERGE}
+                defaultChecked
               />
               Merge
             </label>
@@ -388,6 +369,25 @@ class NCImportExport extends UNISYS.Component {
                   Existing objects that do not match imported nodes/edges will not be
                   modified or removed
                 </li>
+              </ul>
+            </div>
+            <label>
+              <input
+                id="import-replace"
+                type="radio"
+                name="importtype"
+                value={IMPORTTYPE.REPLACE}
+              />
+              Replace
+            </label>
+            <div>
+              <p>
+                {' '}
+                <b>Replace</b> existing nodes and edges. Use this to <b>load</b> a new
+                project
+              </p>
+              <ul>
+                <li>Existing objects will be removed</li>
               </ul>
             </div>
           </fieldset>

--- a/app/view/netcreate/components/NCImportExport.jsx
+++ b/app/view/netcreate/components/NCImportExport.jsx
@@ -387,7 +387,11 @@ class NCImportExport extends UNISYS.Component {
                 project
               </p>
               <ul>
-                <li>Existing objects will be removed</li>
+                <li style={{ color: `var(--clr-warning)` }}>
+                  WARNING: All existing nodes and edges will be removed before new
+                  nodes and edges are imported. If you do not include an Edges file,
+                  all edges will be removed.
+                </li>
               </ul>
             </div>
           </fieldset>


### PR DESCRIPTION
This updates the default template for the ELA/History pilot.

The goal is to provide a starting comprehensive set of fields that can be customized for individual projects (by renaming or hiding uneeded fields).

See [VFOI Expansion Template Thinking](https://docs.google.com/spreadsheets/d/1muuzZtvw1yptz9AhF4Lao8eK8VDff_mQdBTF4ZHOFHo/edit?gid=0#gid=0) for a the spec/design.

## To Test

You should test this with a new project template, built from scratch.

1. Check out `dev-bl/new-default`
2. `/.nc.js --dataset=<newproject>`
3. Make sure the necessary fields are there


## Additional Notes
* This includes the necessary changes in `server-template-schema` so that the default template will validate.
* "Force Sort" now has a "No" option to revert to the unsorted types list from the original template file.
* Default nodeDef and edgeDef provenance fields updated.