### PR TITLE
Hotifx new node disable #466

### DIFF
--- a/app/unisys/common-netmessage-class.js
+++ b/app/unisys/common-netmessage-class.js
@@ -347,6 +347,14 @@ class NetMessage {
     this.SocketSend(socket);
   }
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** Utility to check whether a transaction packet has a valid resolver
+   *  function */
+  HasTransactionHash() {
+    const hash = m_GetHashKey(this);
+    var resolverFunc = m_transactions[hash];
+    return typeof resolverFunc === 'function';
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /** If this is a transaction packet that is returned, then execute the stored
       resolver function from the promise stored in m_transactions, which will
       then trigger .then() following any calls
@@ -357,9 +365,10 @@ class NetMessage {
     var resolverFunc = m_transactions[hash];
     if (dbg) console.log(PR, 'CompleteTransaction', hash);
     if (typeof resolverFunc !== 'function') {
-      throw Error(
-        `transaction [${hash}] resolverFunction is type ${typeof resolverFunc}`
-      );
+      const trf = typeof resolverFunc;
+      console.warn(`critical error:`);
+      console.warn(`bad resolverFunction for hash [${hash}] (type ${trf})`);
+      console.log(JSON.stringify(this));
     } else {
       resolverFunc(this.data);
       Reflect.deleteProperty(m_transactions[hash]);

--- a/app/unisys/common-netmessage-class.js
+++ b/app/unisys/common-netmessage-class.js
@@ -207,7 +207,7 @@ class NetMessage {
     // is this packet originating from server to a remote?
     if (
       this.s_uaddr === NetMessage.DefaultServerUADDR() &&
-      !this.msg.startsWith('SVR_')
+      !this.msg.startsWith('SRV_')
     ) {
       return this.s_uaddr;
     }
@@ -439,7 +439,7 @@ NetMessage.SocketUADDR = function () {
 /** Return a default server UADDR
  */
 NetMessage.DefaultServerUADDR = function () {
-  return 'SVR_01';
+  return 'SRV_01';
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** Return current SessionID string

--- a/app/unisys/server-network.js
+++ b/app/unisys/server-network.js
@@ -297,9 +297,14 @@ async function m_HandleMessage(socket, pkt) {
   // is this a returning packet that was forwarded?
   if (pkt.IsOwnResponse()) {
     // console.log(PR,`-- ${pkt.Message()} completing transaction ${pkt.seqlog.join(':')}`);
-    pkt.CompleteTransaction();
+    if (pkt.HasTransactionHash()) pkt.CompleteTransaction();
+    else {
+      LOGGER.WriteRLog(`ERROR: Packet ${pkt.id} '${pkt.msg}' transaction error`);
+      LOGGER.WriteRLog(pkt.JSON());
+    }
     return;
   }
+
   // console.log(PR,`packet source incoming ${pkt.SourceAddress()}-${pkt.Message()}`);
   // (1) first check if this is a server handler
   let promises = m_PromiseServerHandlers(pkt);

--- a/app/unisys/server-network.js
+++ b/app/unisys/server-network.js
@@ -48,7 +48,7 @@ let FIRST_CONNECTION = false; // first connection flag
 /// API MEHTHODS //////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 var UNET = {};
-const SERVER_UADDR = NetMessage.DefaultServerUADDR(); // is 'SVR_01'
+const SERVER_UADDR = NetMessage.DefaultServerUADDR(); // is 'SRV_01'
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** Initialize() is called by brunch-server.js to define the default UNISYS
  *  network values, so it can embed them in the index.ejs file for webapps */

--- a/app/view/netcreate/components/NCSearch.jsx
+++ b/app/view/netcreate/components/NCSearch.jsx
@@ -36,13 +36,11 @@ class NCSearch extends UNISYS.Component {
 
     this.state = {
       isLoggedIn: false,
-      uNodeOrEdgeBeingEdited: false,
       uIsLockedByComment: false,
       value: ''
     }; // initialized on componentDidMount and clearSelection
 
     this.UpdateSession = this.UpdateSession.bind(this);
-    this.urstate_LOCKSTATE = this.urstate_LOCKSTATE.bind(this);
     this.UIOnChange = this.UIOnChange.bind(this);
     this.UIOnSelect = this.UIOnSelect.bind(this);
     this.UINewNode = this.UINewNode.bind(this);
@@ -50,12 +48,10 @@ class NCSearch extends UNISYS.Component {
     /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     /// REGISTER LISTENERS
     this.OnAppStateChange('SESSION', this.UpdateSession);
-    this.OnAppStateChange('LOCKSTATE', this.urstate_LOCKSTATE);
   }
 
   componentWillUnmount() {
     this.AppStateChangeOff('SESSION', this.UpdateSession);
-    this.AppStateChangeOff('LOCKSTATE', this.urstate_LOCKSTATE);
   }
 
   /**
@@ -71,15 +67,6 @@ class NCSearch extends UNISYS.Component {
     this.setState({ isLoggedIn: decoded.isValid });
   }
 
-  urstate_LOCKSTATE(LOCKSTATE) {
-    this.setState({
-      uNodeOrEdgeBeingEdited: LOCKSTATE.nodeOrEdgeBeingEdited
-    });
-    // DEPRECATED -- comment editing lock state is only relevant if you are editing your own comment
-    //   this.setState({
-    //   // uIsLockedByComment: LOCKSTATE.commentBeingEditedByMe  // NOT IMPLEMENTED
-    // });
-  }
 
   /**
    * The callback function (cb) is used to restore the selection point
@@ -126,10 +113,9 @@ class NCSearch extends UNISYS.Component {
   /// MAIN RENDER
   ///
   render() {
-    const { value, isLoggedIn, uNodeOrEdgeBeingEdited, uIsLockedByComment } =
-      this.state;
+    const { value, isLoggedIn, uIsLockedByComment } = this.state;
     const newNodeBtnHidden = !isLoggedIn || uIsLockedByComment;
-    const newNodeBtnDisabled = value === '' || uNodeOrEdgeBeingEdited;
+    const newNodeBtnDisabled = value === '';
     const key = 'search'; // used for search/source/target, placeholder for search
     return (
       <div className="--NCSearch ncsearch">


### PR DESCRIPTION
The "New Node" button was overly aggressive, getting disabled whenever someone else was:
* editing a node
* editing a template
During classroom activity, this meant the "New Node" button was mysteriously being disabled whenever another student was adding a node.

This functionality used to be needed because without disabling, you could be editing a node, enter a search term, and inadvertently create a new node on top of your node edit.

This is no longer necessary with the new UI where a screen covers the rest of the app (and the "New Node" button) when editing a node.

The "New Node" is now only disabled during template edits.

See #466 


## TO DO

Today
- [x] Deploy `hotifx-newNode-disable-#466` to `al2025`
- [x] Update backup.nc.app with 9/9's app data.

After Pilot
- [x] This PR will be ready to merge after confirmation that the pilot droplets are stable -- deployed droplets currently on the hotifx-resolverFunction-#457 branch.
- [x] Merge #458 first
- [ ] Merge into dev-bl/template-cleanup
- [ ] Merge into dev-dhi-next also before deleting the branch